### PR TITLE
fix(#3297): Allow variant skip

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1298,9 +1298,21 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
             _ => bail_span!(self, "only public enums are allowed with #[wasm_bindgen]"),
         }
 
+        fn skip(attrs: &mut Vec<syn::Attribute>) -> bool {
+            let Ok(attrs) = BindgenAttrs::find(attrs) else {
+                return false;
+            };
+
+            let result = attrs.skip().is_some();
+            attrs.check_used();
+
+            result
+        }
+
         let variants = self
             .variants
             .iter()
+            .filter(|v| !skip(&mut (v.attrs).clone()))
             .enumerate()
             .map(|(i, v)| {
                 match v.fields {


### PR DESCRIPTION
Provides a way to avoid having `only C-Style enums allowed with #[wasm_bindgen]` by allowing user to omit an enum Variant, it's then at the user discretion to use #[cfg] directives to reflect this

Can be seen in the example:

```rust
#[wasm_bindgen]
pub enum Operation {
    INCREMENT,

    #[cfg(not(target_arch = "wasm32"))]
    #[wasm_bindgen(skip)]
    CUSTOM(fn(i32) -> i32),
}
```