### PR TITLE
Add `WASM_BINDGEN_TEST_WEBDRIVER_JSON` var to override `webdriver.json` path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 * Added `DocumentOrShadowRoot.adoptedStyleSheets`.
   [#4625](https://github.com/wasm-bindgen/wasm-bindgen/pull/4625)
 
+* Added ability to determine `webdriver.json` config location via
+  `WASM_BINDGEN_TEST_WEBDRIVER_JSON` environment variable to
+  `wasm-bindgen-test`.
+  [#4434](https://github.com/wasm-bindgen/wasm-bindgen/pull/4434)
+
 ### Changed
 
 * Fixed wrong method names for `GestureEvent` bindings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added `DocumentOrShadowRoot.adoptedStyleSheets`.
   [#4625](https://github.com/wasm-bindgen/wasm-bindgen/pull/4625)
 
-* Added ability to determine `webdriver.json` config location via
+* Added ability to determine WebDriver JSON config location via
   `WASM_BINDGEN_TEST_WEBDRIVER_JSON` environment variable to
   `wasm-bindgen-test`.
   [#4434](https://github.com/wasm-bindgen/wasm-bindgen/pull/4434)

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -127,7 +127,7 @@ pub fn run(
     };
     println!("Try find `webdriver.json` for configure browser's capabilities:");
     let capabilities: Capabilities = match File::open(
-        std::env::var("WASM_BINDGEN_WEBDRIVER_JSON").unwrap_or("webdriver.json".to_string()),
+        std::env::var("WASM_BINDGEN_TEST_WEBDRIVER_JSON").unwrap_or("webdriver.json".to_string()),
     ) {
         Ok(file) => {
             println!("Ok");

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -126,7 +126,9 @@ pub fn run(
         session: None,
     };
     println!("Try find `webdriver.json` for configure browser's capabilities:");
-    let capabilities: Capabilities = match File::open("webdriver.json") {
+    let capabilities: Capabilities = match File::open(
+        std::env::var("WASM_BINDGEN_WEBDRIVER_JSON").unwrap_or("webdriver.json".to_string()),
+    ) {
         Ok(file) => {
             println!("Ok");
             serde_json::from_reader(file)

--- a/guide/src/wasm-bindgen-test/browsers.md
+++ b/guide/src/wasm-bindgen-test/browsers.md
@@ -64,8 +64,8 @@ wasm-pack test --headless --chrome --firefox --safari
 
 ## Configuring Headless Browser capabilities
 
-Either add the file `webdriver.json` to the root of your crate or ensure an environment
-variable `WASM_BINDGEN_TEST_WEBDRIVER_JSON` is set and points to a `webdriver.json` file.
+Either add the file `webdriver.json` to the root of your crate or ensure the environment
+variable `WASM_BINDGEN_TEST_WEBDRIVER_JSON` points to one.
 Each browser has own section for capabilities. For example:
 
 ```json

--- a/guide/src/wasm-bindgen-test/browsers.md
+++ b/guide/src/wasm-bindgen-test/browsers.md
@@ -64,8 +64,9 @@ wasm-pack test --headless --chrome --firefox --safari
 
 ## Configuring Headless Browser capabilities
 
-Add the file `webdriver.json` to the root of your crate. Each browser has own 
-section for capabilities. For example:
+Either add the file `webdriver.json` to the root of your crate or ensure an environment
+variable `WASM_BINDGEN_TEST_WEBDRIVER_JSON` is set and points to a `webdriver.json` file.
+Each browser has own section for capabilities. For example:
 
 ```json
 {
@@ -139,7 +140,7 @@ installation by default.
 
 ### Running the Tests in the Remote Headless Browser
 
-Tests can be run on a remote webdriver. To do this, the above environment 
+Tests can be run on a remote webdriver. To do this, the above environment
 variables must be set as URL to the remote webdriver. For example:
 
 ```


### PR DESCRIPTION
This is handy supporting various machines with different browsers and configurations installed. I'm able to update my CI to point to specific configs per machine that's matched that all contain unique settings.