### PR TITLE
feat(Blob): add `Blob.bytes()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,25 @@
 
 * Added format and colorSpace support to VideoFrameCopyToOptions
   [#4543](https://github.com/wasm-bindgen/wasm-bindgen/pull/4543)
+
 * Added support for the [`onbeforeinput`](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforeinput_event) attribute.
   [#4544](https://github.com/wasm-bindgen/wasm-bindgen/pull/4544)
+
 * `TypedArray::new_from_slice(&[T])` constructor that allows to create a
   JS-owned `TypedArray` from a Rust slice.
   [#4555](https://github.com/wasm-bindgen/wasm-bindgen/pull/4555)
+
 * Added `Function::call4` and `Function::bind4` through `Function::call9` `Function::bind9` methods for calling  and binding JavaScript functions with 4-9 arguments.
   [#4572](https://github.com/wasm-bindgen/wasm-bindgen/pull/4572)
+
 * Added isPointInFill and isPointInStroke methods for the SVGGeometryElement idl.
   [#4509](https://github.com/wasm-bindgen/wasm-bindgen/pull/4509)
+
 * Add bindings for `PictureInPicture`.
   [#4593](https://github.com/rustwasm/wasm-bindgen/pull/4593)
+
+* Added `bytes` method for the `Blob` idl
+  [#4506](https://github.com/wasm-bindgen/wasm-bindgen/pull/4506)
 
 ### Changed
 

--- a/crates/web-sys/src/features/gen_Blob.rs
+++ b/crates/web-sys/src/features/gen_Blob.rs
@@ -136,6 +136,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Blob`*"]
     pub fn array_buffer(this: &Blob) -> ::js_sys::Promise;
+    # [wasm_bindgen (method , structural , js_class = "Blob" , js_name = bytes)]
+    #[doc = "The `bytes()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blob/bytes)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`*"]
+    pub fn bytes(this: &Blob) -> ::js_sys::Promise;
     # [wasm_bindgen (catch , method , structural , js_class = "Blob" , js_name = slice)]
     #[doc = "The `slice()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/Blob.webidl
+++ b/crates/web-sys/webidls/enabled/Blob.webidl
@@ -33,6 +33,7 @@ interface Blob {
   [NewObject] ReadableStream stream();
   [NewObject] Promise<DOMString> text();
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
+  [NewObject] Promise<Uint8Array> bytes();
 };
 
 enum EndingTypes { "transparent", "native" };


### PR DESCRIPTION
WebIDL source: <https://w3c.github.io/FileAPI/#blob-section>
Docs: <https://developer.mozilla.org/en-US/docs/Web/API/Blob/bytes>

Fixes rustwasm/wasm-bindgen#4475