### PR TITLE
webidl: webgpu: make the `size` argument to `copyBufferToBuffer` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 * Deprecate async constructors.
   [#4402](https://github.com/rustwasm/wasm-bindgen/pull/4402)
+* The `size` argument to `GPUCommandEncoder.copyBufferToBuffer` is now
+  optional. [#4508](https://github.com/wasm-bindgen/wasm-bindgen/pull/4508)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 
 * Deprecate async constructors.
   [#4402](https://github.com/rustwasm/wasm-bindgen/pull/4402)
-* The `size` argument to `GPUCommandEncoder.copyBufferToBuffer` is now
-  optional. [#4508](https://github.com/wasm-bindgen/wasm-bindgen/pull/4508)
+
+* The `size` argument to `GPUCommandEncoder.copyBufferToBuffer` is now optional.
+  [#4508](https://github.com/wasm-bindgen/wasm-bindgen/pull/4508)
 
 ### Fixed
 

--- a/crates/web-sys/src/features/gen_GpuCommandEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuCommandEncoder.rs
@@ -198,6 +198,78 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn copy_buffer_to_buffer_with_u32_and_u32(
+        this: &GpuCommandEncoder,
+        source: &GpuBuffer,
+        source_offset: u32,
+        destination: &GpuBuffer,
+        destination_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "GpuBuffer")]
+    # [wasm_bindgen (catch , method , structural , js_class = "GPUCommandEncoder" , js_name = copyBufferToBuffer)]
+    #[doc = "The `copyBufferToBuffer()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuBuffer`, `GpuCommandEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn copy_buffer_to_buffer_with_f64_and_u32(
+        this: &GpuCommandEncoder,
+        source: &GpuBuffer,
+        source_offset: f64,
+        destination: &GpuBuffer,
+        destination_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "GpuBuffer")]
+    # [wasm_bindgen (catch , method , structural , js_class = "GPUCommandEncoder" , js_name = copyBufferToBuffer)]
+    #[doc = "The `copyBufferToBuffer()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuBuffer`, `GpuCommandEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn copy_buffer_to_buffer_with_u32_and_f64(
+        this: &GpuCommandEncoder,
+        source: &GpuBuffer,
+        source_offset: u32,
+        destination: &GpuBuffer,
+        destination_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "GpuBuffer")]
+    # [wasm_bindgen (catch , method , structural , js_class = "GPUCommandEncoder" , js_name = copyBufferToBuffer)]
+    #[doc = "The `copyBufferToBuffer()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuBuffer`, `GpuCommandEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn copy_buffer_to_buffer_with_f64_and_f64(
+        this: &GpuCommandEncoder,
+        source: &GpuBuffer,
+        source_offset: f64,
+        destination: &GpuBuffer,
+        destination_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "GpuBuffer")]
+    # [wasm_bindgen (catch , method , structural , js_class = "GPUCommandEncoder" , js_name = copyBufferToBuffer)]
+    #[doc = "The `copyBufferToBuffer()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuBuffer`, `GpuCommandEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn copy_buffer_to_buffer_with_u32_and_u32_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,

--- a/crates/web-sys/webidls/unstable/WebGPU.webidl
+++ b/crates/web-sys/webidls/unstable/WebGPU.webidl
@@ -946,7 +946,7 @@ interface GPUCommandEncoder {
         GPUSize64 sourceOffset,
         GPUBuffer destination,
         GPUSize64 destinationOffset,
-        GPUSize64 size);
+        optional GPUSize64 size);
 
     [Throws]
     undefined copyBufferToTexture(


### PR DESCRIPTION
This matches the latest spec.

There is also a 3-argument overload of `copyBufferToBuffer`, which I have not added, as it poses some additional challenges, and I do not immediately need it.

See https://www.w3.org/TR/webgpu/#commands-buffer-copies for context for the following explanation.

The logic in wasm-bindgen that generates unique names for the different overloads does not understand that the 3-argument overload is omitting the 2nd and 4th arguments to the 5-argument overload. So it generates names based on every argument starting with the 2nd, which (1) changes existing names for variants of the 5-argument overload, (2) includes `with_gpu_buffer` for the 3rd argument in the names even though that has no actual disambiguation purpose. 