### PR TITLE
Error on invalid import attr position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * Added isPointInFill and isPointInStroke methods for the SVGGeometryElement idl.
   [#4509](https://github.com/wasm-bindgen/wasm-bindgen/pull/4509)
+
 * Stricter checks for `module`, `raw_module` and `inline_js` attributes applied to inapplicable items.
   [#4522](https://github.com/wasm-bindgen/wasm-bindgen/pull/4522)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 * Added isPointInFill and isPointInStroke methods for the SVGGeometryElement idl.
   [#4509](https://github.com/wasm-bindgen/wasm-bindgen/pull/4509)
+* Stricter checks for `module`, `raw_module` and `inline_js` attributes applied to inapplicable items.
+  [#4522](https://github.com/wasm-bindgen/wasm-bindgen/pull/4522)
 
 * Add bindings for `PictureInPicture`.
   [#4593](https://github.com/rustwasm/wasm-bindgen/pull/4593)

--- a/crates/cli/tests/reference/import.d.ts
+++ b/crates/cli/tests/reference/import.d.ts
@@ -1,3 +1,36 @@
 /* tslint:disable */
 /* eslint-disable */
 export function exported(): void;
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InitOutput {
+  readonly memory: WebAssembly.Memory;
+  readonly exported: () => [number, number];
+  readonly __wbindgen_exn_store: (a: number) => void;
+  readonly __externref_table_alloc: () => number;
+  readonly __wbindgen_export_2: WebAssembly.Table;
+  readonly __externref_table_dealloc: (a: number) => void;
+  readonly __wbindgen_start: () => void;
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+/**
+* Instantiates the given `module`, which can either be bytes or
+* a precompiled `WebAssembly.Module`.
+*
+* @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+*
+* @returns {InitOutput}
+*/
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
+/**
+* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+* for everything else, calls `WebAssembly.instantiate` directly.
+*
+* @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+*
+* @returns {Promise<InitOutput>}
+*/
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/crates/cli/tests/reference/import.js
+++ b/crates/cli/tests/reference/import.js
@@ -1,10 +1,10 @@
 import { default as default1 } from 'tests/wasm/import_class.js';
+import * as __wbg_star0 from './snippets/reference-test-ddc0ab9a51c9d25f/inline0.js';
+import * as __wbg_star1 from 'foo-raw';
+import * as __wbg_star2 from 'pure-extern';
+import * as __wbg_star3 from 'tests/wasm/imports.js';
 
 let wasm;
-export function __wbg_set_wasm(val) {
-    wasm = val;
-}
-
 
 function addToExternrefTable0(obj) {
     const idx = wasm.__externref_table_alloc();
@@ -30,18 +30,16 @@ function getUint8ArrayMemory0() {
     return cachedUint8ArrayMemory0;
 }
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+let cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
 
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
+if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
 
 const MAX_SAFARI_DECODE_BYTES = 2146435072;
 let numBytesDecoded = 0;
 function decodeText(ptr, len) {
     numBytesDecoded += len;
     if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
-        cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
         cachedTextDecoder.decode();
         numBytesDecoded = len;
     }
@@ -66,62 +64,158 @@ export function exported() {
     }
 }
 
-export function __wbg_add_7fbfb2c172506d12(arg0, arg1) {
-    const ret = add(arg0, arg1);
-    return ret;
-};
+const EXPECTED_RESPONSE_TYPES = new Set(['basic', 'cors', 'default']);
 
-export function __wbg_barfromfoo_29614885590bfb6f() {
-    bar_from_foo();
-};
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
 
-export function __wbg_catchme_f7d87ea824a61e87() { return handleError(function () {
-    catch_me();
-}, arguments) };
+            } catch (e) {
+                const validResponse = module.ok && EXPECTED_RESPONSE_TYPES.has(module.type);
 
-export function __wbg_get_56ba567010fb9959(arg0) {
-    const ret = arg0.get();
-    return ret;
-};
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
 
-export function __wbg_myfunction_8c7b624429f78550() {
-    b.my_function();
-};
+                } else {
+                    throw e;
+                }
+            }
+        }
 
-export function __wbg_new_d21827b66c7fd25d(arg0) {
-    const ret = new default1(arg0);
-    return ret;
-};
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
 
-export function __wbg_nocatch_be850a8dddd9599d() {
-    no_catch();
-};
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
 
-export function __wbg_reload_84c12f152ad689f0() {
-    window.location.reload();
-};
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
 
-export function __wbg_static_accessor_CONST_9e9d5ae758197645() {
-    const ret = a.CONST;
-    return ret;
-};
+        } else {
+            return instance;
+        }
+    }
+}
 
-export function __wbg_write_c2ce0ce33a6087d5(arg0, arg1) {
-    window.document.write(getStringFromWasm0(arg0, arg1));
-};
+function __wbg_get_imports() {
+    const imports = {};
+    imports.wbg = {};
+    imports.wbg.__wbg_catchme_f7d87ea824a61e87 = function() { return handleError(function () {
+        catch_me();
+    }, arguments) };
+    imports.wbg.__wbg_get_56ba567010fb9959 = function(arg0) {
+        const ret = arg0.get();
+        return ret;
+    };
+    imports.wbg.__wbg_myfunction_8c7b624429f78550 = function() {
+        b.my_function();
+    };
+    imports.wbg.__wbg_new_d21827b66c7fd25d = function(arg0) {
+        const ret = new default1(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_nocatch_be850a8dddd9599d = function() {
+        no_catch();
+    };
+    imports.wbg.__wbg_reload_84c12f152ad689f0 = function() {
+        window.location.reload();
+    };
+    imports.wbg.__wbg_static_accessor_CONST_9e9d5ae758197645 = function() {
+        const ret = a.CONST;
+        return ret;
+    };
+    imports.wbg.__wbg_write_c2ce0ce33a6087d5 = function(arg0, arg1) {
+        window.document.write(getStringFromWasm0(arg0, arg1));
+    };
+    imports.wbg.__wbindgen_init_externref_table = function() {
+        const table = wasm.__wbindgen_export_2;
+        const offset = table.grow(4);
+        table.set(0, undefined);
+        table.set(offset + 0, undefined);
+        table.set(offset + 1, null);
+        table.set(offset + 2, true);
+        table.set(offset + 3, false);
+        ;
+    };
+    imports.wbg.__wbindgen_throw = function(arg0, arg1) {
+        throw new Error(getStringFromWasm0(arg0, arg1));
+    };
+    imports['./snippets/reference-test-ddc0ab9a51c9d25f/inline0.js'] = __wbg_star0;
+    imports['foo-raw'] = __wbg_star1;
+    imports['pure-extern'] = __wbg_star2;
+    imports['tests/wasm/imports.js'] = __wbg_star3;
 
-export function __wbindgen_init_externref_table() {
-    const table = wasm.__wbindgen_export_2;
-    const offset = table.grow(4);
-    table.set(0, undefined);
-    table.set(offset + 0, undefined);
-    table.set(offset + 1, null);
-    table.set(offset + 2, true);
-    table.set(offset + 3, false);
-    ;
-};
+    return imports;
+}
 
-export function __wbindgen_throw(arg0, arg1) {
-    throw new Error(getStringFromWasm0(arg0, arg1));
-};
+function __wbg_init_memory(imports, memory) {
 
+}
+
+function __wbg_finalize_init(instance, module) {
+    wasm = instance.exports;
+    __wbg_init.__wbindgen_wasm_module = module;
+    cachedUint8ArrayMemory0 = null;
+
+
+    wasm.__wbindgen_start();
+    return wasm;
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module !== 'undefined') {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+
+    __wbg_init_memory(imports);
+
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+
+    const instance = new WebAssembly.Instance(module, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module_or_path !== 'undefined') {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
+
+    if (typeof module_or_path === 'undefined') {
+        module_or_path = new URL('reference_test_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
+
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
+
+    __wbg_init_memory(imports);
+
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+export { initSync };
+export default __wbg_init;

--- a/crates/cli/tests/reference/import.rs
+++ b/crates/cli/tests/reference/import.rs
@@ -1,3 +1,5 @@
+// FLAGS: --target=web
+
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -15,12 +17,27 @@ extern "C" {
     fn reload();
     #[wasm_bindgen(js_namespace = ["window", "document"])]
     fn write(s: &str);
+}
 
-    // module import
-    #[wasm_bindgen(module = "./foo.js")]
+// module import
+#[wasm_bindgen(module = "tests/wasm/imports.js")]
+extern "C" {
     fn bar_from_foo();
-    #[wasm_bindgen(inline_js = "export function add(a,b) { return a + b; }")]
+}
+
+#[wasm_bindgen(raw_module = "foo-raw")]
+extern "C" {
+    fn bar_from_foo_raw();
+}
+
+#[wasm_bindgen(inline_js = "export function add(a,b) { return a + b; }")]
+extern "C" {
     fn add(a: f64, b: f64) -> f64;
+}
+
+#[link(wasm_import_module = "pure-extern")]
+extern "C" {
+    fn extern_fn();
 }
 
 #[wasm_bindgen(js_namespace = ["a"])]
@@ -45,6 +62,10 @@ extern "C" {
 #[wasm_bindgen]
 pub fn exported() -> Result<(), JsValue> {
     bar_from_foo();
+    bar_from_foo_raw();
+    unsafe {
+        extern_fn();
+    }
     let _ = add(CONST.with(Clone::clone), 2.0);
     reload();
     write("");

--- a/crates/cli/tests/reference/import.wat
+++ b/crates/cli/tests/reference/import.wat
@@ -3,7 +3,7 @@
   (type (;1;) (func (result i32)))
   (type (;2;) (func (result i32 i32)))
   (type (;3;) (func (param i32)))
-  (import "./reference_test_bg.js" "__wbindgen_init_externref_table" (func (;0;) (type 0)))
+  (import "wbg" "__wbindgen_init_externref_table" (func (;0;) (type 0)))
   (func $"exported multivalue shim" (;1;) (type 2) (result i32 i32))
   (func $__wbindgen_exn_store (;2;) (type 3) (param i32))
   (func $__externref_table_alloc (;3;) (type 1) (result i32))
@@ -19,4 +19,3 @@
   (export "__wbindgen_start" (func 0))
   (@custom "target_features" (after code) "\08+\0bbulk-memory+\0fbulk-memory-opt+\16call-indirect-overlong+\0amultivalue+\0fmutable-globals+\13nontrapping-fptoint+\0freference-types+\08sign-ext")
 )
-

--- a/crates/cli/tests/reference/import.wat
+++ b/crates/cli/tests/reference/import.wat
@@ -19,3 +19,4 @@
   (export "__wbindgen_start" (func 0))
   (@custom "target_features" (after code) "\08+\0bbulk-memory+\0fbulk-memory-opt+\16call-indirect-overlong+\0amultivalue+\0fmutable-globals+\13nontrapping-fptoint+\0freference-types+\08sign-ext")
 )
+

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -160,9 +160,9 @@ macro_rules! attrgen {
             (method, false, Method(Span)),
             (static_method_of, false, StaticMethodOf(Span, Ident)),
             (js_namespace, false, JsNamespace(Span, JsNamespace, Vec<Span>)),
-            (module, false, Module(Span, String, Span)),
-            (raw_module, false, RawModule(Span, String, Span)),
-            (inline_js, false, InlineJs(Span, String, Span)),
+            (module, true, Module(Span, String, Span)),
+            (raw_module, true, RawModule(Span, String, Span)),
+            (inline_js, true, InlineJs(Span, String, Span)),
             (getter, false, Getter(Span, Option<String>)),
             (setter, false, Setter(Span, Option<String>)),
             (indexing_getter, false, IndexingGetter(Span)),
@@ -2202,7 +2202,7 @@ pub fn check_unused_attrs(tokens: &mut TokenStream) {
             let unused_attrs = unused_attrs.iter().map(|UnusedState { error, ident }| {
                 if *error {
                     let text = format!("invalid attribute {} in this position", ident);
-                    quote::quote! { ::core::compile_error!(#text); }
+                    quote::quote_spanned! { ident.span() => ::core::compile_error!(#text); }
                 } else {
                     quote::quote! { let #ident: (); }
                 }

--- a/crates/macro/ui-tests/unused-fn-attrs.stderr
+++ b/crates/macro/ui-tests/unused-fn-attrs.stderr
@@ -29,209 +29,97 @@ error: unused wasm_bindgen attribute
    |                        ^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_return_type in this position
-  --> ui-tests/unused-fn-attrs.rs:46:1
+  --> ui-tests/unused-fn-attrs.rs:47:5
    |
-46 | / #[wasm_bindgen(
-47 | |     unchecked_return_type = "something",
-48 | |     return_description = "something",
-49 | |     unchecked_param_type = "something",
-50 | |     param_description = "somthing"
-51 | | )]
-   | |__^
-   |
-   = note: this error originates in the derive macro `::wasm_bindgen::__rt::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+47 |     unchecked_return_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute return_description in this position
-  --> ui-tests/unused-fn-attrs.rs:46:1
+  --> ui-tests/unused-fn-attrs.rs:48:5
    |
-46 | / #[wasm_bindgen(
-47 | |     unchecked_return_type = "something",
-48 | |     return_description = "something",
-49 | |     unchecked_param_type = "something",
-50 | |     param_description = "somthing"
-51 | | )]
-   | |__^
-   |
-   = note: this error originates in the derive macro `::wasm_bindgen::__rt::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+48 |     return_description = "something",
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_param_type in this position
-  --> ui-tests/unused-fn-attrs.rs:46:1
+  --> ui-tests/unused-fn-attrs.rs:49:5
    |
-46 | / #[wasm_bindgen(
-47 | |     unchecked_return_type = "something",
-48 | |     return_description = "something",
-49 | |     unchecked_param_type = "something",
-50 | |     param_description = "somthing"
-51 | | )]
-   | |__^
-   |
-   = note: this error originates in the derive macro `::wasm_bindgen::__rt::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+49 |     unchecked_param_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute param_description in this position
-  --> ui-tests/unused-fn-attrs.rs:46:1
+  --> ui-tests/unused-fn-attrs.rs:50:5
    |
-46 | / #[wasm_bindgen(
-47 | |     unchecked_return_type = "something",
-48 | |     return_description = "something",
-49 | |     unchecked_param_type = "something",
-50 | |     param_description = "somthing"
-51 | | )]
-   | |__^
-   |
-   = note: this error originates in the derive macro `::wasm_bindgen::__rt::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+50 |     param_description = "somthing"
+   |     ^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_return_type in this position
-  --> ui-tests/unused-fn-attrs.rs:54:1
+  --> ui-tests/unused-fn-attrs.rs:55:5
    |
-54 | / #[wasm_bindgen(
-55 | |     unchecked_return_type = "something",
-56 | |     return_description = "something",
-57 | |     unchecked_param_type = "something",
-58 | |     param_description = "somthing"
-59 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+55 |     unchecked_return_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute return_description in this position
-  --> ui-tests/unused-fn-attrs.rs:54:1
+  --> ui-tests/unused-fn-attrs.rs:56:5
    |
-54 | / #[wasm_bindgen(
-55 | |     unchecked_return_type = "something",
-56 | |     return_description = "something",
-57 | |     unchecked_param_type = "something",
-58 | |     param_description = "somthing"
-59 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+56 |     return_description = "something",
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_param_type in this position
-  --> ui-tests/unused-fn-attrs.rs:54:1
+  --> ui-tests/unused-fn-attrs.rs:57:5
    |
-54 | / #[wasm_bindgen(
-55 | |     unchecked_return_type = "something",
-56 | |     return_description = "something",
-57 | |     unchecked_param_type = "something",
-58 | |     param_description = "somthing"
-59 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+57 |     unchecked_param_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute param_description in this position
-  --> ui-tests/unused-fn-attrs.rs:54:1
+  --> ui-tests/unused-fn-attrs.rs:58:5
    |
-54 | / #[wasm_bindgen(
-55 | |     unchecked_return_type = "something",
-56 | |     return_description = "something",
-57 | |     unchecked_param_type = "something",
-58 | |     param_description = "somthing"
-59 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+58 |     param_description = "somthing"
+   |     ^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_return_type in this position
-  --> ui-tests/unused-fn-attrs.rs:65:1
+  --> ui-tests/unused-fn-attrs.rs:66:5
    |
-65 | / #[wasm_bindgen(
-66 | |     unchecked_return_type = "something",
-67 | |     return_description = "something",
-68 | |     unchecked_param_type = "something",
-69 | |     param_description = "somthing"
-70 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+66 |     unchecked_return_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute return_description in this position
-  --> ui-tests/unused-fn-attrs.rs:65:1
+  --> ui-tests/unused-fn-attrs.rs:67:5
    |
-65 | / #[wasm_bindgen(
-66 | |     unchecked_return_type = "something",
-67 | |     return_description = "something",
-68 | |     unchecked_param_type = "something",
-69 | |     param_description = "somthing"
-70 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+67 |     return_description = "something",
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_param_type in this position
-  --> ui-tests/unused-fn-attrs.rs:65:1
+  --> ui-tests/unused-fn-attrs.rs:68:5
    |
-65 | / #[wasm_bindgen(
-66 | |     unchecked_return_type = "something",
-67 | |     return_description = "something",
-68 | |     unchecked_param_type = "something",
-69 | |     param_description = "somthing"
-70 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+68 |     unchecked_param_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute param_description in this position
-  --> ui-tests/unused-fn-attrs.rs:65:1
+  --> ui-tests/unused-fn-attrs.rs:69:5
    |
-65 | / #[wasm_bindgen(
-66 | |     unchecked_return_type = "something",
-67 | |     return_description = "something",
-68 | |     unchecked_param_type = "something",
-69 | |     param_description = "somthing"
-70 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+69 |     param_description = "somthing"
+   |     ^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_return_type in this position
-  --> ui-tests/unused-fn-attrs.rs:75:1
+  --> ui-tests/unused-fn-attrs.rs:76:5
    |
-75 | / #[wasm_bindgen(
-76 | |     unchecked_return_type = "something",
-77 | |     return_description = "something",
-78 | |     unchecked_param_type = "something",
-79 | |     param_description = "somthing"
-80 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+76 |     unchecked_return_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute return_description in this position
-  --> ui-tests/unused-fn-attrs.rs:75:1
+  --> ui-tests/unused-fn-attrs.rs:77:5
    |
-75 | / #[wasm_bindgen(
-76 | |     unchecked_return_type = "something",
-77 | |     return_description = "something",
-78 | |     unchecked_param_type = "something",
-79 | |     param_description = "somthing"
-80 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+77 |     return_description = "something",
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute unchecked_param_type in this position
-  --> ui-tests/unused-fn-attrs.rs:75:1
+  --> ui-tests/unused-fn-attrs.rs:78:5
    |
-75 | / #[wasm_bindgen(
-76 | |     unchecked_return_type = "something",
-77 | |     return_description = "something",
-78 | |     unchecked_param_type = "something",
-79 | |     param_description = "somthing"
-80 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+78 |     unchecked_param_type = "something",
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid attribute param_description in this position
-  --> ui-tests/unused-fn-attrs.rs:75:1
+  --> ui-tests/unused-fn-attrs.rs:79:5
    |
-75 | / #[wasm_bindgen(
-76 | |     unchecked_return_type = "something",
-77 | |     return_description = "something",
-78 | |     unchecked_param_type = "something",
-79 | |     param_description = "somthing"
-80 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+79 |     param_description = "somthing"
+   |     ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The reference tests for imports used invalid syntax, and because we don't error on attributes in invalid position by default, it was silently passing anyway.

I've changed the import attributes to error by default (by the way, why do we not do this for all attributes? it seems like a pretty common footgun), fixed the test, changed it to `--target web` so that we could actually see imported files in the JS snapshot, and updated snapshots.