### PR TITLE
fix: generated JS eqeqeq

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -923,7 +923,7 @@ __wbg_set_wasm(wasm);"
                                 return await WebAssembly.instantiateStreaming(module, imports);
 
                             }} catch (e) {{
-                                if (module.headers.get('Content-Type') != 'application/wasm') {{
+                                if (module.headers.get('Content-Type') !== 'application/wasm') {{
                                     console.warn(\"`WebAssembly.instantiateStreaming` failed \
                                                     because your server does not serve Wasm with \
                                                     `application/wasm` MIME type. Falling back to \
@@ -3178,7 +3178,7 @@ __wbg_set_wasm(wasm);"
         self.expose_not_defined();
         let name = self.import_name(js)?;
         let js = format!(
-            "typeof {name} == 'function' ? {name} : notDefined('{name}')",
+            "typeof {name} === 'function' ? {name} : notDefined('{name}')",
             name = name,
         );
         self.wasm_import_definitions.insert(id, js);
@@ -4190,23 +4190,23 @@ __wbg_set_wasm(wasm);"
            function debugString(val) {
                 // primitive types
                 const type = typeof val;
-                if (type == 'number' || type == 'boolean' || val == null) {
+                if (type === 'number' || type === 'boolean' || val === null) {
                     return  `${val}`;
                 }
-                if (type == 'string') {
+                if (type === 'string') {
                     return `\"${val}\"`;
                 }
-                if (type == 'symbol') {
+                if (type === 'symbol') {
                     const description = val.description;
-                    if (description == null) {
+                    if (description === null) {
                         return 'Symbol';
                     } else {
                         return `Symbol(${description})`;
                     }
                 }
-                if (type == 'function') {
+                if (type === 'function') {
                     const name = val.name;
-                    if (typeof name == 'string' && name.length > 0) {
+                    if (typeof name === 'string' && name.length > 0) {
                         return `Function(${name})`;
                     } else {
                         return 'Function';
@@ -4234,7 +4234,7 @@ __wbg_set_wasm(wasm);"
                     // Failed to match the standard '[object ClassName]'
                     return toString.call(val);
                 }
-                if (className == 'Object') {
+                if (className === 'Object') {
                     // we're a user defined class or Object
                     // JSON.stringify avoids problems with cycles, and is generally much
                     // easier than looping through ownProperties of `val`.


### PR DESCRIPTION
The generated JavaScript code does not satisfy eslint's [eqeqeq rule](https://eslint.org/docs/latest/rules/eqeqeq). I changed the JavaScript snippets to use eqeqeq.

Compiler warning:
```
src/pkg/index.js

  Line 123:56:  Expected '!==' and instead saw '!='
```

Generated code `pkg/index.js`

```javascript
async function __wbg_load(module, imports) {
    if (typeof Response === 'function' && module instanceof Response) {
        if (typeof WebAssembly.instantiateStreaming === 'function') {
            try {
                return await WebAssembly.instantiateStreaming(module, imports);

            } catch (e) {
                if (module.headers.get('Content-Type') != 'application/wasm') {
                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);

                } else {
                    throw e;
                }
            }
        }

        const bytes = await module.arrayBuffer();
        return await WebAssembly.instantiate(bytes, imports);

    } else {
        const instance = await WebAssembly.instantiate(module, imports);

        if (instance instanceof WebAssembly.Instance) {
            return { instance, module };

        } else {
            return instance;
        }
    }
}
```