### PR TITLE
Fix test --exact option not working as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 * Fix incorrect memory loading and storing assertions during post-processing.
   [#4554](https://github.com/wasm-bindgen/wasm-bindgen/pull/4554)
 
+* Fix test `--exact` option not working as expected
+  [#4549](https://github.com/wasm-bindgen/wasm-bindgen/pull/4549)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.100](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.99...0.2.100)

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
@@ -26,7 +26,7 @@ pub fn execute(module: &str, tmpdir: &Path, cli: Cli, tests: Tests) -> Result<()
     );
 
     for test in tests.tests {
-        js_to_execute.push_str(&format!("tests.push('{}')\n", test.name));
+        js_to_execute.push_str(&format!("tests.push('{}')\n", test.export));
     }
 
     js_to_execute.push_str(

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -100,7 +100,10 @@ impl Tests {
 }
 
 struct Test {
+    // test name
     name: String,
+    // symbol name
+    export: String,
     ignored: bool,
 }
 
@@ -130,8 +133,14 @@ fn main() -> anyhow::Result<()> {
             continue;
         };
         let modifiers = name.split_once('_').expect("found invalid identifier").0;
+
+        let Some(name) = export.name.split_once("::").map(|s| s.1) else {
+            continue;
+        };
+
         let test = Test {
-            name: export.name.clone(),
+            name: name.into(),
+            export: export.name.clone(),
             ignored: modifiers.contains('$'),
         };
 
@@ -170,7 +179,7 @@ fn main() -> anyhow::Result<()> {
 
     if cli.list {
         for test in tests.tests {
-            println!("{}: test", test.name.split_once("::").unwrap().1);
+            println!("{}: test", test.name);
         }
 
         // Returning cleanly has the strange effect of outputting

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
@@ -104,7 +104,7 @@ pub fn execute(
     // execute, and then those objects are passed into Wasm for it to execute
     // when it sees fit.
     for test in tests.tests {
-        js_to_execute.push_str(&format!("tests.push('{}')\n", test.name));
+        js_to_execute.push_str(&format!("tests.push('{}')\n", test.export));
     }
     // And as a final addendum, exit with a nonzero code if any tests fail.
     js_to_execute.push_str(

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -281,7 +281,7 @@ pub(crate) fn spawn(
         ));
     }
     for test in tests.tests {
-        js_to_execute.push_str(&format!("tests.push('{}');\n", test.name));
+        js_to_execute.push_str(&format!("tests.push('{}');\n", test.export));
     }
     js_to_execute.push_str("main(tests);\n");
 


### PR DESCRIPTION
The name used in the filter test carries the `_{crate}` prefix, causing exact filtering to fail. The correct behavior should be same as `--list`

close https://github.com/wasm-bindgen/wasm-bindgen/issues/4517 and making nextest work.