### PR TITLE
Fix flaky `TypedArray::from(&[T])`

### DIFF
--- a/crates/example-tests/src/lib.rs
+++ b/crates/example-tests/src/lib.rs
@@ -166,13 +166,16 @@ impl WebDriver {
 
         // Connect to the Firefox instance.
         let start = Instant::now();
+        let wait_sec = 60;
         let ws = loop {
             match tokio_tungstenite::connect_async(format!("ws://{driver_addr}/session")).await {
                 Ok((ws, _)) => break ws,
                 Err(e) => {
-                    if start.elapsed() > Duration::from_secs(20) {
-                        return Err(e).context("failed to connect to Firefox (after 20s)");
+                    if start.elapsed().as_secs() > wait_sec {
+                        return Err(e)
+                            .context(format!("failed to connect to Firefox (after {wait_sec}s)"));
                     }
+                    eprintln!("Failed to connect to Firefox: {e}, retrying...");
                 }
             }
         };

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -6146,6 +6146,16 @@ macro_rules! arrays {
 
             /// An
             #[doc = $ctor]
+            /// which creates an array from a Rust slice.
+            ///
+            /// [MDN documentation](
+            #[doc = $mdn]
+            /// )
+            #[wasm_bindgen(constructor)]
+            pub fn new_from_slice(slice: &[$ty]) -> $name;
+
+            /// An
+            #[doc = $ctor]
             /// which creates an array with the given buffer but is a
             /// view starting at `byte_offset`.
             ///
@@ -6380,7 +6390,7 @@ macro_rules! arrays {
             #[inline]
             fn from(slice: &'a [$ty]) -> $name {
                 // This is safe because the `new` function makes a copy if its argument is a TypedArray
-                unsafe { $name::new(&$name::view(slice)) }
+                $name::new_from_slice(slice)
             }
         }
 

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -203,3 +203,12 @@ fn to_vec() {
     array.fill(5, 0, 10);
     assert_eq!(array.to_vec(), vec![5, 5, 5, 5, 5, 5, 5, 5, 5, 5]);
 }
+
+#[wasm_bindgen_test]
+fn from_slice_heap_growth() {
+    let slice = std::slice::from_ref(&1);
+
+    _ = (0..10_000)
+        .map(|_i| Int32Array::from(slice))
+        .collect::<Vec<_>>();
+}


### PR DESCRIPTION
Instead of going via an intermediate unsafe view, we can add another safe binding that takes a slice "directly" and clones it into a typed array.

This is safer, generates slightly compact JS with fewer roundtrips, and fixes the flakiness due to allocations that used to happen between creating the slice and actually cloning it.

Fixes #4492.