### PR TITLE
make mime error detection more accurate

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -904,7 +904,11 @@ __wbg_set_wasm(wasm);"
                                 return await WebAssembly.instantiateStreaming(module, imports);
 
                             }} catch (e) {{
-                                if (module.headers.get('Content-Type') != 'application/wasm') {{
+                                const expectedTypes = new Set(['basic', 'cors', 'default']);
+
+                                const validResponse = module.ok && expectedTypes.has(module.type);
+
+                                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {{
                                     console.warn(\"`WebAssembly.instantiateStreaming` failed \
                                                     because your server does not serve Wasm with \
                                                     `application/wasm` MIME type. Falling back to \

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -897,6 +897,8 @@ __wbg_set_wasm(wasm);"
 
         let js = format!(
             "\
+                const EXPECTED_RESPONSE_TYPES = new Set(['basic', 'cors', 'default']);
+
                 async function __wbg_load(module, imports) {{
                     if (typeof Response === 'function' && module instanceof Response) {{
                         if (typeof WebAssembly.instantiateStreaming === 'function') {{
@@ -904,9 +906,7 @@ __wbg_set_wasm(wasm);"
                                 return await WebAssembly.instantiateStreaming(module, imports);
 
                             }} catch (e) {{
-                                const expectedTypes = new Set(['basic', 'cors', 'default']);
-
-                                const validResponse = module.ok && expectedTypes.has(module.type);
+                                const validResponse = module.ok && EXPECTED_RESPONSE_TYPES.has(module.type);
 
                                 if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {{
                                     console.warn(\"`WebAssembly.instantiateStreaming` failed \

--- a/crates/cli/tests/reference/targets-1.js
+++ b/crates/cli/tests/reference/targets-1.js
@@ -17,7 +17,11 @@ async function __wbg_load(module, imports) {
                 return await WebAssembly.instantiateStreaming(module, imports);
 
             } catch (e) {
-                if (module.headers.get('Content-Type') != 'application/wasm') {
+                const expectedTypes = new Set(['basic', 'cors', 'default']);
+
+                const validResponse = module.ok && expectedTypes.has(module.type);
+
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
                     console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
 
                 } else {

--- a/crates/cli/tests/reference/targets-1.js
+++ b/crates/cli/tests/reference/targets-1.js
@@ -10,6 +10,8 @@ export function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 
+const EXPECTED_RESPONSE_TYPES = new Set(['basic', 'cors', 'default']);
+
 async function __wbg_load(module, imports) {
     if (typeof Response === 'function' && module instanceof Response) {
         if (typeof WebAssembly.instantiateStreaming === 'function') {
@@ -17,9 +19,7 @@ async function __wbg_load(module, imports) {
                 return await WebAssembly.instantiateStreaming(module, imports);
 
             } catch (e) {
-                const expectedTypes = new Set(['basic', 'cors', 'default']);
-
-                const validResponse = module.ok && expectedTypes.has(module.type);
+                const validResponse = module.ok && EXPECTED_RESPONSE_TYPES.has(module.type);
 
                 if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
                     console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);

--- a/crates/cli/tests/reference/targets-2.js
+++ b/crates/cli/tests/reference/targets-2.js
@@ -16,6 +16,8 @@ let wasm_bindgen;
         return ret >>> 0;
     };
 
+    const EXPECTED_RESPONSE_TYPES = new Set(['basic', 'cors', 'default']);
+
     async function __wbg_load(module, imports) {
         if (typeof Response === 'function' && module instanceof Response) {
             if (typeof WebAssembly.instantiateStreaming === 'function') {
@@ -23,9 +25,7 @@ let wasm_bindgen;
                     return await WebAssembly.instantiateStreaming(module, imports);
 
                 } catch (e) {
-                    const expectedTypes = new Set(['basic', 'cors', 'default']);
-
-                    const validResponse = module.ok && expectedTypes.has(module.type);
+                    const validResponse = module.ok && EXPECTED_RESPONSE_TYPES.has(module.type);
 
                     if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
                         console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);

--- a/crates/cli/tests/reference/targets-2.js
+++ b/crates/cli/tests/reference/targets-2.js
@@ -23,7 +23,11 @@ let wasm_bindgen;
                     return await WebAssembly.instantiateStreaming(module, imports);
 
                 } catch (e) {
-                    if (module.headers.get('Content-Type') != 'application/wasm') {
+                    const expectedTypes = new Set(['basic', 'cors', 'default']);
+
+                    const validResponse = module.ok && expectedTypes.has(module.type);
+
+                    if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
                         console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
 
                     } else {

--- a/crates/cli/tests/reference/wasm-export-types.js
+++ b/crates/cli/tests/reference/wasm-export-types.js
@@ -104,6 +104,8 @@ export function example_128(a) {
     return ret[0] === 0 ? undefined : (BigInt.asUintN(64, ret[1]) | (BigInt.asUintN(64, ret[2]) << BigInt(64)));
 }
 
+const EXPECTED_RESPONSE_TYPES = new Set(['basic', 'cors', 'default']);
+
 async function __wbg_load(module, imports) {
     if (typeof Response === 'function' && module instanceof Response) {
         if (typeof WebAssembly.instantiateStreaming === 'function') {
@@ -111,9 +113,7 @@ async function __wbg_load(module, imports) {
                 return await WebAssembly.instantiateStreaming(module, imports);
 
             } catch (e) {
-                const expectedTypes = new Set(['basic', 'cors', 'default']);
-
-                const validResponse = module.ok && expectedTypes.has(module.type);
+                const validResponse = module.ok && EXPECTED_RESPONSE_TYPES.has(module.type);
 
                 if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
                     console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);

--- a/crates/cli/tests/reference/wasm-export-types.js
+++ b/crates/cli/tests/reference/wasm-export-types.js
@@ -111,7 +111,11 @@ async function __wbg_load(module, imports) {
                 return await WebAssembly.instantiateStreaming(module, imports);
 
             } catch (e) {
-                if (module.headers.get('Content-Type') != 'application/wasm') {
+                const expectedTypes = new Set(['basic', 'cors', 'default']);
+
+                const validResponse = module.ok && expectedTypes.has(module.type);
+
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
                     console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
 
                 } else {


### PR DESCRIPTION
`instantiateStreaming` might fail for a [variety of reasons](https://webassembly.github.io/spec/web-api/#dom-webassembly-instantiatestreaming). We can't just assume that an invalid MIME type is an oversight on the server. For instance, many 4xx or 5xx responses will be served as `text/html` so re-trying with `instantiate()` is just bound to cause more confusion.