### PR TITLE
CI: Remove test_wasm_bindgen_wasm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,22 +162,6 @@ jobs:
     - uses: ./.github/actions/setup-geckodriver
     - run: ${{ matrix.runs.run }}
 
-  test_wasm_bindgen_wasm:
-    name: "Run wasm-bindgen wasm test"
-    runs-on: ubuntu-latest
-    env:
-      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-    steps:
-    - uses: actions/checkout@v4
-    - run: rustup update --no-self-update stable && rustup default stable
-    - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-    - run: cargo test --target wasm32-unknown-unknown --test wasm
-      env:
-        WASM_BINDGEN_NO_DEBUG: 1
-
   test_wasm_bindgen_envs:
     strategy:
       matrix:


### PR DESCRIPTION
test_wasm_bindgen already runs Wasm tests among others, so this is just extra repetitive work in CI.