### PR TITLE
Deduplicate Closure invocation implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@
 * Fix incorrect memory loading and storing assertions during post-processing.
   [#4554](https://github.com/wasm-bindgen/wasm-bindgen/pull/4554)
 
-* Fix test `--exact` option not working as expected
+* Fix test `--exact` option not working as expected.
   [#4549](https://github.com/wasm-bindgen/wasm-bindgen/pull/4549)
+
+* Fix tables being removed even though they are used by stack closures.
+  [#4119](https://github.com/wasm-bindgen/wasm-bindgen/pull/4564)
 
 --------------------------------------------------------------------------------
 

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -101,7 +101,6 @@ pub struct Function {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Closure {
-    pub shim_idx: u32,
     pub dtor_idx: u32,
     pub function: Function,
     pub mutable: bool,
@@ -263,12 +262,14 @@ fn get_string(data: &mut &[u32]) -> String {
 
 impl Closure {
     fn decode(data: &mut &[u32]) -> Closure {
-        let shim_idx = get(data);
         let dtor_idx = get(data);
-        let mutable = get(data) == REFMUT;
+        let mutable = match get(data) {
+            0 => false,
+            1 => true,
+            other => panic!("expected bool value, got {other}"),
+        };
         assert_eq!(get(data), FUNCTION);
         Closure {
-            shim_idx,
             dtor_idx,
             mutable,
             function: Function::decode(data),

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -199,7 +199,7 @@ impl<'a> Context<'a> {
                 let mut function = descriptor.function.clone();
                 function.arguments.insert(0, Descriptor::I32);
                 function.arguments.insert(0, Descriptor::I32);
-                let adapter = self.table_element_adapter(descriptor.shim_idx, function)?;
+                let adapter = self.table_element_adapter(descriptor.function.shim_idx, function)?;
                 self.aux.import_map.insert(
                     id,
                     AuxImport::Closure {

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -167,9 +167,7 @@ impl<'a> Context<'a> {
 
             // If any closures exist we need to prevent the function table from
             // getting gc'd
-            if !closure_imports.is_empty() {
-                self.aux.function_table = self.module.tables.main_function_table()?;
-            }
+            self.aux.function_table = self.module.tables.main_function_table()?;
 
             // Register all the injected closure imports as that they're expected
             // to manufacture a particular type of closure.

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -469,6 +469,32 @@ fn function_table_preserved() {
 }
 
 #[test]
+fn function_table_preserved_for_stack_closures() {
+    let (mut cmd, _out_dir) = Project::new("function_table_preserved_for_stack_closures")
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen]
+                extern "C" {
+                    fn take_closure(closure: &dyn Fn());
+                }
+
+                #[wasm_bindgen]
+                pub extern fn pass_closure() {
+                    take_closure(&|| {
+                        // Noop, just ensure that the compilation succeeds.
+                        // See https://github.com/wasm-bindgen/wasm-bindgen/issues/4119.
+                    });
+                }
+            "#,
+        )
+        .wasm_bindgen("");
+    cmd.assert().success();
+}
+
+#[test]
 fn constructor_cannot_return_option_struct() {
     let (mut cmd, _out_dir) = Project::new("constructor_cannot_return_option_struct")
         .file(
@@ -478,7 +504,7 @@ fn constructor_cannot_return_option_struct() {
 
                 #[wasm_bindgen]
                 pub struct Foo(());
-                
+
                 #[wasm_bindgen]
                 impl Foo {
                     #[wasm_bindgen(constructor)]

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -345,7 +345,7 @@ where
                 }
                 drop(Box::from_raw(FatPtr::<T> { fields: (a, b) }.ptr));
             }
-            inform(destroy::<T> as u32);
+            inform(destroy::<T> as usize as u32);
 
             inform(T::IS_MUT as u32);
             T::describe();

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -13,7 +13,6 @@ use core::mem::{self, ManuallyDrop};
 
 use crate::convert::*;
 use crate::describe::*;
-use crate::throw_str;
 use crate::JsValue;
 use crate::UnwrapThrowExt;
 
@@ -334,7 +333,22 @@ where
         #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
         extern "C" fn describe<T: WasmClosure + ?Sized>() {
             inform(CLOSURE);
-            T::describe()
+
+            unsafe extern "C" fn destroy<T: ?Sized>(a: usize, b: usize) {
+                // This can be called by the JS glue in erroneous situations
+                // such as when the closure has already been destroyed. If
+                // that's the case let's not make things worse by
+                // segfaulting and/or asserting, so just ignore null
+                // pointers.
+                if a == 0 {
+                    return;
+                }
+                drop(Box::from_raw(FatPtr::<T> { fields: (a, b) }.ptr));
+            }
+            inform(destroy::<T> as u32);
+
+            inform(T::IS_MUT as u32);
+            T::describe();
         }
 
         #[inline(never)]
@@ -530,8 +544,8 @@ where
 /// This trait is not stable and it's not recommended to use this in bounds or
 /// implement yourself.
 #[doc(hidden)]
-pub unsafe trait WasmClosure {
-    fn describe();
+pub unsafe trait WasmClosure: WasmDescribe {
+    const IS_MUT: bool;
 }
 
 /// An internal trait for the `Closure` type.
@@ -566,59 +580,7 @@ macro_rules! doit {
             where $($var: FromWasmAbi + 'static,)*
                   R: ReturnWasmAbi + 'static,
         {
-            #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-            fn describe() {
-                #[allow(non_snake_case)]
-                #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-                unsafe extern "C" fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
-                    a: usize,
-                    b: usize,
-                    $(
-                    $arg1: <$var::Abi as WasmAbi>::Prim1,
-                    $arg2: <$var::Abi as WasmAbi>::Prim2,
-                    $arg3: <$var::Abi as WasmAbi>::Prim3,
-                    $arg4: <$var::Abi as WasmAbi>::Prim4,
-                    )*
-                ) -> WasmRet<R::Abi> {
-                    if a == 0 {
-                        throw_str("closure invoked after being dropped");
-                    }
-                    // Make sure all stack variables are converted before we
-                    // convert `ret` as it may throw (for `Result`, for
-                    // example)
-                    let ret = {
-                        let f: *const dyn Fn($($var),*) -> R =
-                            FatPtr { fields: (a, b) }.ptr;
-                        $(
-                            let $var = <$var as FromWasmAbi>::from_abi($var::Abi::join($arg1, $arg2, $arg3, $arg4));
-                        )*
-                        (*f)($($var),*)
-                    };
-                    ret.return_abi().into()
-                }
-
-                inform(invoke::<$($var,)* R> as usize as u32);
-
-                unsafe extern "C" fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
-                    a: usize,
-                    b: usize,
-                ) {
-                    // This can be called by the JS glue in erroneous situations
-                    // such as when the closure has already been destroyed. If
-                    // that's the case let's not make things worse by
-                    // segfaulting and/or asserting, so just ignore null
-                    // pointers.
-                    if a == 0 {
-                        return;
-                    }
-                    drop(Box::from_raw(FatPtr::<dyn Fn($($var,)*) -> R> {
-                        fields: (a, b)
-                    }.ptr));
-                }
-                inform(destroy::<$($var,)* R> as usize as u32);
-
-                <&Self>::describe();
-            }
+            const IS_MUT: bool = false;
         }
 
         #[allow(coherence_leak_check)]
@@ -626,56 +588,7 @@ macro_rules! doit {
             where $($var: FromWasmAbi + 'static,)*
                   R: ReturnWasmAbi + 'static,
         {
-            #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-            fn describe() {
-                #[allow(non_snake_case)]
-                #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-                unsafe extern "C" fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
-                    a: usize,
-                    b: usize,
-                    $(
-                    $arg1: <$var::Abi as WasmAbi>::Prim1,
-                    $arg2: <$var::Abi as WasmAbi>::Prim2,
-                    $arg3: <$var::Abi as WasmAbi>::Prim3,
-                    $arg4: <$var::Abi as WasmAbi>::Prim4,
-                    )*
-                ) -> WasmRet<R::Abi> {
-                    if a == 0 {
-                        throw_str("closure invoked recursively or after being dropped");
-                    }
-                    // Make sure all stack variables are converted before we
-                    // convert `ret` as it may throw (for `Result`, for
-                    // example)
-                    let ret = {
-                        let f: *const dyn FnMut($($var),*) -> R =
-                            FatPtr { fields: (a, b) }.ptr;
-                        let f = f as *mut dyn FnMut($($var),*) -> R;
-                        $(
-                            let $var = <$var as FromWasmAbi>::from_abi($var::Abi::join($arg1, $arg2, $arg3, $arg4));
-                        )*
-                        (*f)($($var),*)
-                    };
-                    ret.return_abi().into()
-                }
-
-                inform(invoke::<$($var,)* R> as usize as u32);
-
-                unsafe extern "C" fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
-                    a: usize,
-                    b: usize,
-                ) {
-                    // See `Fn()` above for why we simply return
-                    if a == 0 {
-                        return;
-                    }
-                    drop(Box::from_raw(FatPtr::<dyn FnMut($($var,)*) -> R> {
-                        fields: (a, b)
-                    }.ptr));
-                }
-                inform(destroy::<$($var,)* R> as usize as u32);
-
-                <&mut Self>::describe();
-            }
+            const IS_MUT: bool = true;
         }
 
         #[allow(non_snake_case, unused_parens)]
@@ -769,48 +682,7 @@ where
     A: RefFromWasmAbi,
     R: ReturnWasmAbi + 'static,
 {
-    #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-    fn describe() {
-        #[allow(non_snake_case)]
-        #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-        unsafe extern "C" fn invoke<A: RefFromWasmAbi, R: ReturnWasmAbi>(
-            a: usize,
-            b: usize,
-            arg1: <A::Abi as WasmAbi>::Prim1,
-            arg2: <A::Abi as WasmAbi>::Prim2,
-            arg3: <A::Abi as WasmAbi>::Prim3,
-            arg4: <A::Abi as WasmAbi>::Prim4,
-        ) -> WasmRet<R::Abi> {
-            if a == 0 {
-                throw_str("closure invoked after being dropped");
-            }
-            // Make sure all stack variables are converted before we
-            // convert `ret` as it may throw (for `Result`, for
-            // example)
-            let ret = {
-                let f: *const dyn Fn(&A) -> R = FatPtr { fields: (a, b) }.ptr;
-                let arg = <A as RefFromWasmAbi>::ref_from_abi(A::Abi::join(arg1, arg2, arg3, arg4));
-                (*f)(&*arg)
-            };
-            ret.return_abi().into()
-        }
-
-        inform(invoke::<A, R> as usize as u32);
-
-        #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-        unsafe extern "C" fn destroy<A: RefFromWasmAbi, R: ReturnWasmAbi>(a: usize, b: usize) {
-            // See `Fn()` above for why we simply return
-            if a == 0 {
-                return;
-            }
-            drop(Box::from_raw(
-                FatPtr::<dyn Fn(&A) -> R> { fields: (a, b) }.ptr,
-            ));
-        }
-        inform(destroy::<A, R> as usize as u32);
-
-        <&Self>::describe();
-    }
+    const IS_MUT: bool = false;
 }
 
 unsafe impl<A, R> WasmClosure for dyn FnMut(&A) -> R
@@ -818,49 +690,7 @@ where
     A: RefFromWasmAbi,
     R: ReturnWasmAbi + 'static,
 {
-    #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-    fn describe() {
-        #[allow(non_snake_case)]
-        #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-        unsafe extern "C" fn invoke<A: RefFromWasmAbi, R: ReturnWasmAbi>(
-            a: usize,
-            b: usize,
-            arg1: <A::Abi as WasmAbi>::Prim1,
-            arg2: <A::Abi as WasmAbi>::Prim2,
-            arg3: <A::Abi as WasmAbi>::Prim3,
-            arg4: <A::Abi as WasmAbi>::Prim4,
-        ) -> WasmRet<R::Abi> {
-            if a == 0 {
-                throw_str("closure invoked recursively or after being dropped");
-            }
-            // Make sure all stack variables are converted before we
-            // convert `ret` as it may throw (for `Result`, for
-            // example)
-            let ret = {
-                let f: *const dyn FnMut(&A) -> R = FatPtr { fields: (a, b) }.ptr;
-                let f = f as *mut dyn FnMut(&A) -> R;
-                let arg = <A as RefFromWasmAbi>::ref_from_abi(A::Abi::join(arg1, arg2, arg3, arg4));
-                (*f)(&*arg)
-            };
-            ret.return_abi().into()
-        }
-
-        inform(invoke::<A, R> as usize as u32);
-
-        #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-        unsafe extern "C" fn destroy<A: RefFromWasmAbi, R: ReturnWasmAbi>(a: usize, b: usize) {
-            // See `Fn()` above for why we simply return
-            if a == 0 {
-                return;
-            }
-            drop(Box::from_raw(
-                FatPtr::<dyn FnMut(&A) -> R> { fields: (a, b) }.ptr,
-            ));
-        }
-        inform(destroy::<A, R> as usize as u32);
-
-        <&mut Self>::describe();
-    }
+    const IS_MUT: bool = true;
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
This is a branch I had lying around, just cleaned up.

Basically, I noticed that owned closures (represented via `wasm_bindgen::Closure`) and closure conversions (bindings for `&dyn Fn()/FnMut()`) duplicated the infrastructure for their invocations, even though they're naturally doing exactly same thing.

The only difference between them is in the JS bindings and presence of a destructor, so that's the only thing I'm keeping in `wasm_bindgen::Closure`'s descriptor.

I think there's a lot more that could be deduplicated between them, but for now just wanted to submit what I already had as it's already a noticeable cleanup.

Fixes #4119.