### PR TITLE
Properly share list of tys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rustversion = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.100" }
+wasm-bindgen-shared = { path = "crates/shared", version = "=0.2.100" }
 
 [dev-dependencies]
 once_cell = "1"

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -1,52 +1,7 @@
 use std::char;
 
 use wasm_bindgen_shared::identifier::is_valid_ident;
-
-macro_rules! tys {
-    ($($a:ident)*) => (tys! { @ ($($a)*) 0 });
-    (@ () $v:expr) => {};
-    (@ ($a:ident $($b:ident)*) $v:expr) => {
-        const $a: u32 = $v;
-        tys!(@ ($($b)*) $v+1);
-    }
-}
-
-// NB: this list must be kept in sync with `src/describe.rs`
-tys! {
-    I8
-    U8
-    I16
-    U16
-    I32
-    U32
-    I64
-    U64
-    I128
-    U128
-    F32
-    F64
-    BOOLEAN
-    FUNCTION
-    CLOSURE
-    CACHED_STRING
-    STRING
-    REF
-    REFMUT
-    LONGREF
-    SLICE
-    VECTOR
-    EXTERNREF
-    NAMED_EXTERNREF
-    ENUM
-    STRING_ENUM
-    RUST_STRUCT
-    CHAR
-    OPTIONAL
-    RESULT
-    UNIT
-    CLAMPED
-    NONNULL
-}
+use wasm_bindgen_shared::tys::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Descriptor {

--- a/crates/shared/build.rs
+++ b/crates/shared/build.rs
@@ -26,10 +26,12 @@ fn set_schema_version_env_var() {
         "The `CARGO_MANIFEST_DIR` environment variable is needed to locate the schema file",
     );
     let schema_file = PathBuf::from(cargo_manifest_dir).join("src/lib.rs");
-    let schema_file = std::fs::read(schema_file).unwrap();
+    let schema_file = std::fs::read_to_string(schema_file).unwrap();
+    #[cfg(windows)]
+    let schema_file = schema_file.replace("\r\n", "\n");
 
     let mut hasher = DefaultHasher::new();
-    hasher.write(&schema_file);
+    hasher.write(schema_file.as_bytes());
 
     println!("cargo:rustc-env=SCHEMA_FILE_HASH={}", hasher.finish());
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,4 +1,9 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-shared/0.2")]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
 
 pub mod identifier;
 #[cfg(test)]

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod identifier;
 #[cfg(test)]
 mod schema_hash_approval;
+pub mod tys;
 
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "6242250402756688161";
+const APPROVED_SCHEMA_FILE_HASH: &str = "4036199476881545189";
 
 #[test]
 fn schema_version() {

--- a/crates/shared/src/tys.rs
+++ b/crates/shared/src/tys.rs
@@ -1,0 +1,44 @@
+macro_rules! tys {
+    ($($a:ident)*) => (tys! { @ ($($a)*) 0 });
+    (@ () $v:expr) => {};
+    (@ ($a:ident $($b:ident)*) $v:expr) => {
+        pub const $a: u32 = $v;
+        tys!(@ ($($b)*) $v+1);
+    }
+}
+
+tys! {
+    I8
+    U8
+    I16
+    U16
+    I32
+    U32
+    I64
+    U64
+    I128
+    U128
+    F32
+    F64
+    BOOLEAN
+    FUNCTION
+    CLOSURE
+    CACHED_STRING
+    STRING
+    REF
+    REFMUT
+    LONGREF
+    SLICE
+    VECTOR
+    EXTERNREF
+    NAMED_EXTERNREF
+    ENUM
+    STRING_ENUM
+    RUST_STRUCT
+    CHAR
+    OPTIONAL
+    RESULT
+    UNIT
+    CLAMPED
+    NONNULL
+}

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -11,51 +11,7 @@ use core::{mem::MaybeUninit, ptr::NonNull};
 use crate::{Clamped, JsError, JsObject, JsValue};
 use cfg_if::cfg_if;
 
-macro_rules! tys {
-    ($($a:ident)*) => (tys! { @ ($($a)*) 0 });
-    (@ () $v:expr) => {};
-    (@ ($a:ident $($b:ident)*) $v:expr) => {
-        pub const $a: u32 = $v;
-        tys!(@ ($($b)*) $v+1);
-    }
-}
-
-// NB: this list must be kept in sync with `crates/cli-support/src/descriptor.rs`
-tys! {
-    I8
-    U8
-    I16
-    U16
-    I32
-    U32
-    I64
-    U64
-    I128
-    U128
-    F32
-    F64
-    BOOLEAN
-    FUNCTION
-    CLOSURE
-    CACHED_STRING
-    STRING
-    REF
-    REFMUT
-    LONGREF
-    SLICE
-    VECTOR
-    EXTERNREF
-    NAMED_EXTERNREF
-    ENUM
-    STRING_ENUM
-    RUST_STRUCT
-    CHAR
-    OPTIONAL
-    RESULT
-    UNIT
-    CLAMPED
-    NONNULL
-}
+pub use wasm_bindgen_shared::tys::*;
 
 #[inline(always)] // see the wasm-interpreter crate
 #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]


### PR DESCRIPTION
As far as I can tell, wasm-bindgen crate already depends on wasm-bindgen-shared via macro -> macro-support, so this shouldn't introduce issues with publishing order, and makes sharing the opcodes less error-prone as it no longer relies on human factor.