### PR TITLE
feat: extend call and bind to up to 9 arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 * `TypedArray::new_from_slice(&[T])` constructor that allows to create a
   JS-owned `TypedArray` from a Rust slice.
   [#4555](https://github.com/wasm-bindgen/wasm-bindgen/pull/4555)
+
 * Added `Function::call4` and `Function::bind4` through `Function::call9` `Function::bind9` methods for calling  and binding JavaScript functions with 4-9 arguments.
+  [#4572](https://github.com/wasm-bindgen/wasm-bindgen/pull/4572)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * `TypedArray::new_from_slice(&[T])` constructor that allows to create a
   JS-owned `TypedArray` from a Rust slice.
   [#4555](https://github.com/wasm-bindgen/wasm-bindgen/pull/4555)
+* Added `Function::call4` and `Function::bind4` through `Function::call9` `Function::bind9` methods for calling  and binding JavaScript functions with 4-9 arguments.
 
 ### Changed
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2009,6 +2009,105 @@ extern "C" {
         arg3: &JsValue,
     ) -> Result<JsValue, JsValue>;
 
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call4(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call5(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call6(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call7(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+        arg7: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call8(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+        arg7: &JsValue,
+        arg8: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call9(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+        arg7: &JsValue,
+        arg8: &JsValue,
+        arg9: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
     /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
     /// with a given sequence of arguments preceding any provided when the new function is called.
     ///
@@ -2048,6 +2147,105 @@ extern "C" {
         arg1: &JsValue,
         arg2: &JsValue,
         arg3: &JsValue,
+    ) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind4(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+    ) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind5(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+    ) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind6(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+    ) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind7(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+        arg7: &JsValue,
+    ) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind8(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+        arg7: &JsValue,
+        arg8: &JsValue,
+    ) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind9(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+        arg4: &JsValue,
+        arg5: &JsValue,
+        arg6: &JsValue,
+        arg7: &JsValue,
+        arg8: &JsValue,
+        arg9: &JsValue,
     ) -> Function;
 
     /// The length property indicates the number of arguments expected by the function.

--- a/crates/js-sys/tests/wasm/Function.js
+++ b/crates/js-sys/tests/wasm/Function.js
@@ -17,3 +17,16 @@ exports.call_function = function(f) {
 exports.call_function_arg =  function(f, arg1) {
   return f(arg1);
 };
+exports.sum_many_arguments = function() {
+    return function(a, b, c, d, e, f, g, h, i) {
+        return (a || 0) + (b || 0) + (c || 0) + (d || 0) + (e || 0) + (f || 0) + (g || 0) + (h || 0) + (i || 0);
+    };
+};
+exports.test_context = function() {
+    return { multiplier: 10 };
+};
+exports.multiply_sum = function() {
+    return function(a, b, c, d, e, f, g, h, i) {
+        return this.multiplier * ((a || 0) + (b || 0) + (c || 0) + (d || 0) + (e || 0) + (f || 0) + (g || 0) + (h || 0) + (i || 0));
+    };
+};

--- a/crates/js-sys/tests/wasm/Function.rs
+++ b/crates/js-sys/tests/wasm/Function.rs
@@ -45,6 +45,9 @@ extern "C" {
     fn add_arguments() -> Function;
     fn call_function(f: &Function) -> JsValue;
     fn call_function_arg(f: &Function, arg0: JsValue) -> JsValue;
+    fn sum_many_arguments() -> Function;
+    fn test_context() -> JsValue;
+    fn multiply_sum() -> Function;
 
 }
 
@@ -143,4 +146,202 @@ fn function_inheritance() {
     MAX.with(|max| {
         let _: &Object = max.as_ref();
     });
+}
+
+#[wasm_bindgen_test]
+fn bind4() {
+    let adder = sum_many_arguments();
+    let add_fixed = adder.bind4(
+        &JsValue::NULL,
+        &JsValue::from(1),
+        &JsValue::from(2),
+        &JsValue::from(3),
+        &JsValue::from(4),
+    );
+    assert_eq!(call_function(&add_fixed), 10);
+}
+
+#[wasm_bindgen_test]
+fn bind5() {
+    let adder = sum_many_arguments();
+    let add_fixed = adder.bind5(
+        &JsValue::NULL,
+        &JsValue::from(1),
+        &JsValue::from(2),
+        &JsValue::from(3),
+        &JsValue::from(4),
+        &JsValue::from(5),
+    );
+    assert_eq!(call_function(&add_fixed), 15);
+}
+
+#[wasm_bindgen_test]
+fn bind6() {
+    let adder = sum_many_arguments();
+    let add_fixed = adder.bind6(
+        &JsValue::NULL,
+        &JsValue::from(1),
+        &JsValue::from(2),
+        &JsValue::from(3),
+        &JsValue::from(4),
+        &JsValue::from(5),
+        &JsValue::from(6),
+    );
+    assert_eq!(call_function(&add_fixed), 21);
+}
+
+#[wasm_bindgen_test]
+fn bind7() {
+    let adder = sum_many_arguments();
+    let add_fixed = adder.bind7(
+        &JsValue::NULL,
+        &JsValue::from(1),
+        &JsValue::from(2),
+        &JsValue::from(3),
+        &JsValue::from(4),
+        &JsValue::from(5),
+        &JsValue::from(6),
+        &JsValue::from(7),
+    );
+    assert_eq!(call_function(&add_fixed), 28);
+}
+
+#[wasm_bindgen_test]
+fn bind8() {
+    let adder = sum_many_arguments();
+    let add_fixed = adder.bind8(
+        &JsValue::NULL,
+        &JsValue::from(1),
+        &JsValue::from(2),
+        &JsValue::from(3),
+        &JsValue::from(4),
+        &JsValue::from(5),
+        &JsValue::from(6),
+        &JsValue::from(7),
+        &JsValue::from(8),
+    );
+    assert_eq!(call_function(&add_fixed), 36);
+}
+
+#[wasm_bindgen_test]
+fn call4() {
+    let multiply = multiply_sum();
+    let result = multiply
+        .call4(
+            &test_context(),
+            &JsValue::from(1),
+            &JsValue::from(2),
+            &JsValue::from(3),
+            &JsValue::from(4),
+        )
+        .unwrap();
+    assert_eq!(result, 100);
+}
+
+#[wasm_bindgen_test]
+fn call5() {
+    let multiply = multiply_sum();
+    let result = multiply
+        .call5(
+            &test_context(),
+            &JsValue::from(1),
+            &JsValue::from(2),
+            &JsValue::from(3),
+            &JsValue::from(4),
+            &JsValue::from(5),
+        )
+        .unwrap();
+    assert_eq!(result, 150);
+}
+
+#[wasm_bindgen_test]
+fn call6() {
+    let multiply = multiply_sum();
+    let result = multiply
+        .call6(
+            &test_context(),
+            &JsValue::from(1),
+            &JsValue::from(2),
+            &JsValue::from(3),
+            &JsValue::from(4),
+            &JsValue::from(5),
+            &JsValue::from(6),
+        )
+        .unwrap();
+    assert_eq!(result, 210);
+}
+
+#[wasm_bindgen_test]
+fn call7() {
+    let multiply = multiply_sum();
+    let result = multiply
+        .call7(
+            &test_context(),
+            &JsValue::from(1),
+            &JsValue::from(2),
+            &JsValue::from(3),
+            &JsValue::from(4),
+            &JsValue::from(5),
+            &JsValue::from(6),
+            &JsValue::from(7),
+        )
+        .unwrap();
+    assert_eq!(result, 280);
+}
+
+#[wasm_bindgen_test]
+fn call8() {
+    let multiply = multiply_sum();
+    let result = multiply
+        .call8(
+            &test_context(),
+            &JsValue::from(1),
+            &JsValue::from(2),
+            &JsValue::from(3),
+            &JsValue::from(4),
+            &JsValue::from(5),
+            &JsValue::from(6),
+            &JsValue::from(7),
+            &JsValue::from(8),
+        )
+        .unwrap();
+    assert_eq!(result, 360);
+}
+
+#[wasm_bindgen_test]
+fn bind9() {
+    let adder = sum_many_arguments();
+    let add_fixed = adder.bind9(
+        &JsValue::NULL,
+        &JsValue::from(1),
+        &JsValue::from(2),
+        &JsValue::from(3),
+        &JsValue::from(4),
+        &JsValue::from(5),
+        &JsValue::from(6),
+        &JsValue::from(7),
+        &JsValue::from(8),
+        &JsValue::from(9),
+    );
+    assert_eq!(call_function(&add_fixed), 45);
+}
+
+#[wasm_bindgen_test]
+fn call9() {
+    let multiply = multiply_sum();
+    let result = multiply
+        .call9(
+            &test_context(),
+            &JsValue::from(1),
+            &JsValue::from(2),
+            &JsValue::from(3),
+            &JsValue::from(4),
+            &JsValue::from(5),
+            &JsValue::from(6),
+            &JsValue::from(7),
+            &JsValue::from(8),
+            &JsValue::from(9),
+        )
+        .unwrap();
+    assert_eq!(result, 450);
 }


### PR DESCRIPTION
Extends `bind` and `call` to up to 9 arguments.