### PR TITLE
Add helper macro for "generic" casts

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -456,7 +456,7 @@ impl ToTokens for ast::Struct {
             #[automatically_derived]
             impl #wasm_bindgen::__rt::VectorIntoJsValue for #name {
                 fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#name]>) -> #wasm_bindgen::JsValue {
-                    #wasm_bindgen::__rt::js_value_vector_into_jsvalue(vector)
+                    #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#name]>, #wasm_bindgen::JsValue)
                 }
             }
         })
@@ -1154,6 +1154,13 @@ impl ToTokens for ast::ImportType {
                 }
 
                 impl JsObject for #rust_name {}
+
+                #[automatically_derived]
+                impl #wasm_bindgen::__rt::VectorIntoJsValue for #rust_name {
+                    fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#rust_name]>) -> #wasm_bindgen::JsValue {
+                        #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#rust_name]>, #wasm_bindgen::JsValue)
+                    }
+                }
             };
         })
         .to_tokens(tokens);
@@ -1719,7 +1726,7 @@ impl ToTokens for ast::Enum {
             #[automatically_derived]
             impl #wasm_bindgen::__rt::VectorIntoJsValue for #enum_name {
                 fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#enum_name]>) -> #wasm_bindgen::JsValue {
-                    #wasm_bindgen::__rt::js_value_vector_into_jsvalue(vector)
+                    #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#enum_name]>, #wasm_bindgen::JsValue)
                 }
             }
         })

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -79,10 +79,6 @@ fn slice(contents: Descriptor) -> Descriptor {
     Descriptor::Ref(Box::new(Descriptor::Slice(Box::new(contents))))
 }
 
-fn vector(contents: Descriptor) -> Descriptor {
-    Descriptor::Vector(Box::new(contents))
-}
-
 intrinsics! {
     pub enum Intrinsic {
         #[symbol = "__wbindgen_jsval_eq"]
@@ -121,9 +117,6 @@ intrinsics! {
         #[symbol = "__wbindgen_is_falsy"]
         #[signature = fn(ref_externref()) -> Boolean]
         IsFalsy,
-        #[symbol = "__wbindgen_as_number"]
-        #[signature = fn(ref_externref()) -> F64]
-        AsNumber,
         #[symbol = "__wbindgen_try_into_number"]
         #[signature = fn(ref_externref()) -> Externref]
         TryIntoNumber,
@@ -193,27 +186,9 @@ intrinsics! {
         #[symbol = "__wbindgen_cb_drop"]
         #[signature = fn(Externref) -> Boolean]
         CallbackDrop,
-        #[symbol = "__wbindgen_number_new"]
-        #[signature = fn(F64) -> Externref]
-        NumberNew,
-        #[symbol = "__wbindgen_bigint_from_i64"]
-        #[signature = fn(I64) -> Externref]
-        BigIntFromI64,
-        #[symbol = "__wbindgen_bigint_from_u64"]
-        #[signature = fn(U64) -> Externref]
-        BigIntFromU64,
-        #[symbol = "__wbindgen_bigint_from_i128"]
-        #[signature = fn(I64, U64) -> Externref]
-        BigIntFromI128,
-        #[symbol = "__wbindgen_bigint_from_u128"]
-        #[signature = fn(U64, U64) -> Externref]
-        BigIntFromU128,
         #[symbol = "__wbindgen_bigint_get_as_i64"]
         #[signature = fn(ref_externref()) -> opt_i64()]
         BigIntGetAsI64,
-        #[symbol = "__wbindgen_string_new"]
-        #[signature = fn(ref_string()) -> Externref]
-        StringNew,
         #[symbol = "__wbindgen_number_get"]
         #[signature = fn(ref_externref()) -> opt_f64()]
         NumberGet,
@@ -247,45 +222,6 @@ intrinsics! {
         #[symbol = "__wbindgen_copy_to_typed_array"]
         #[signature = fn(slice(U8), ref_externref()) -> Unit]
         CopyToTypedArray,
-        #[symbol = "__wbindgen_uint8_array_new"]
-        #[signature = fn(vector(U8)) -> Externref]
-        Uint8ArrayNew,
-        #[symbol = "__wbindgen_uint8_clamped_array_new"]
-        #[signature = fn(vector(ClampedU8)) -> Externref]
-        Uint8ClampedArrayNew,
-        #[symbol = "__wbindgen_uint16_array_new"]
-        #[signature = fn(vector(U16)) -> Externref]
-        Uint16ArrayNew,
-        #[symbol = "__wbindgen_uint32_array_new"]
-        #[signature = fn(vector(U32)) -> Externref]
-        Uint32ArrayNew,
-        #[symbol = "__wbindgen_biguint64_array_new"]
-        #[signature = fn(vector(U64)) -> Externref]
-        BigUint64ArrayNew,
-        #[symbol = "__wbindgen_int8_array_new"]
-        #[signature = fn(vector(I8)) -> Externref]
-        Int8ArrayNew,
-        #[symbol = "__wbindgen_int16_array_new"]
-        #[signature = fn(vector(I16)) -> Externref]
-        Int16ArrayNew,
-        #[symbol = "__wbindgen_int32_array_new"]
-        #[signature = fn(vector(I32)) -> Externref]
-        Int32ArrayNew,
-        #[symbol = "__wbindgen_bigint64_array_new"]
-        #[signature = fn(vector(I64)) -> Externref]
-        BigInt64ArrayNew,
-        #[symbol = "__wbindgen_float32_array_new"]
-        #[signature = fn(vector(F32)) -> Externref]
-        Float32ArrayNew,
-        #[symbol = "__wbindgen_float64_array_new"]
-        #[signature = fn(vector(F64)) -> Externref]
-        Float64ArrayNew,
-        #[symbol = "__wbindgen_array_new"]
-        #[signature = fn() -> Externref]
-        ArrayNew,
-        #[symbol = "__wbindgen_array_push"]
-        #[signature = fn(ref_externref(), Externref) -> Unit]
-        ArrayPush,
         #[symbol = "__wbindgen_externref_heap_live_count"]
         #[signature = fn() -> I32]
         ExternrefHeapLiveCount,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3669,11 +3669,6 @@ __wbg_set_wasm(wasm);"
                 format!("!{}", args[0])
             }
 
-            Intrinsic::AsNumber => {
-                assert_eq!(args.len(), 1);
-                format!("+{}", args[0])
-            }
-
             Intrinsic::TryIntoNumber => {
                 assert_eq!(args.len(), 1);
                 prelude.push_str("let result;\n");
@@ -3816,26 +3811,6 @@ __wbg_set_wasm(wasm);"
                 "false".to_string()
             }
 
-            Intrinsic::NumberNew => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
-            Intrinsic::BigIntFromI64 | Intrinsic::BigIntFromU64 => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
-            Intrinsic::BigIntFromI128 | Intrinsic::BigIntFromU128 => {
-                assert_eq!(args.len(), 2);
-                format!("{} << BigInt(64) | {}", args[0], args[1])
-            }
-
-            Intrinsic::StringNew => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
             Intrinsic::NumberGet => {
                 assert_eq!(args.len(), 1);
                 prelude.push_str(&format!("const obj = {};\n", args[0]));
@@ -3927,31 +3902,6 @@ __wbg_set_wasm(wasm);"
                     src = args[0],
                     dst = args[1]
                 )
-            }
-
-            Intrinsic::Uint8ArrayNew
-            | Intrinsic::Uint8ClampedArrayNew
-            | Intrinsic::Uint16ArrayNew
-            | Intrinsic::Uint32ArrayNew
-            | Intrinsic::BigUint64ArrayNew
-            | Intrinsic::Int8ArrayNew
-            | Intrinsic::Int16ArrayNew
-            | Intrinsic::Int32ArrayNew
-            | Intrinsic::BigInt64ArrayNew
-            | Intrinsic::Float32ArrayNew
-            | Intrinsic::Float64ArrayNew => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
-            Intrinsic::ArrayNew => {
-                assert_eq!(args.len(), 0);
-                "[]".to_string()
-            }
-
-            Intrinsic::ArrayPush => {
-                assert_eq!(args.len(), 2);
-                format!("{}.push({})", args[0], args[1])
             }
 
             Intrinsic::ExternrefHeapLiveCount => {

--- a/crates/cli/tests/reference/echo.js
+++ b/crates/cli/tests/reference/echo.js
@@ -4,6 +4,38 @@ export function __wbg_set_wasm(val) {
 }
 
 
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+const MAX_SAFARI_DECODE_BYTES = 2146435072;
+let numBytesDecoded = 0;
+function decodeText(ptr, len) {
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return decodeText(ptr, len);
+}
+
 function debugString(val) {
     // primitive types
     const type = typeof val;
@@ -70,15 +102,6 @@ function debugString(val) {
 }
 
 let WASM_VECTOR_LEN = 0;
-
-let cachedUint8ArrayMemory0 = null;
-
-function getUint8ArrayMemory0() {
-    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
-        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-    }
-    return cachedUint8ArrayMemory0;
-}
 
 const lTextEncoder = typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
 
@@ -147,29 +170,6 @@ function getDataViewMemory0() {
 
 function isLikeNone(x) {
     return x === undefined || x === null;
-}
-
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-const MAX_SAFARI_DECODE_BYTES = 2146435072;
-let numBytesDecoded = 0;
-function decodeText(ptr, len) {
-    numBytesDecoded += len;
-    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
-        cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-        cachedTextDecoder.decode();
-        numBytesDecoded = len;
-    }
-    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
-}
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return decodeText(ptr, len);
 }
 /**
  * @param {number} a
@@ -1236,6 +1236,11 @@ export class Foo {
     }
 }
 
+export function __wbg_cast_38bad4997839d643(arg0, arg1) {
+    const ret = /* cast */(getStringFromWasm0(arg0, arg1));
+    return ret;
+};
+
 export function __wbg_foo_new(arg0) {
     const ret = Foo.__wrap(arg0);
     return ret;
@@ -1272,11 +1277,6 @@ export function __wbindgen_string_get(arg0, arg1) {
     var len1 = WASM_VECTOR_LEN;
     getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
     getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
-};
-
-export function __wbindgen_string_new(arg0, arg1) {
-    const ret = getStringFromWasm0(arg0, arg1);
-    return ret;
 };
 
 export function __wbindgen_throw(arg0, arg1) {

--- a/crates/cli/tests/reference/modules.js
+++ b/crates/cli/tests/reference/modules.js
@@ -40,6 +40,11 @@ export function exported() {
     wasm.exported();
 }
 
+export function __wbg_cast_38bad4997839d643(arg0, arg1) {
+    const ret = /* cast */(getStringFromWasm0(arg0, arg1));
+    return ret;
+};
+
 export function __wbg_parseFloat_2be7f01c31025438(arg0, arg1) {
     const ret = parseFloat(getStringFromWasm0(arg0, arg1));
     return ret;
@@ -59,11 +64,6 @@ export function __wbindgen_init_externref_table() {
     table.set(offset + 2, true);
     table.set(offset + 3, false);
     ;
-};
-
-export function __wbindgen_string_new(arg0, arg1) {
-    const ret = getStringFromWasm0(arg0, arg1);
-    return ret;
 };
 
 export function __wbindgen_throw(arg0, arg1) {

--- a/crates/cli/tests/reference/result.js
+++ b/crates/cli/tests/reference/result.js
@@ -86,6 +86,11 @@ export function __wbg_Error_fcfdb1a705a32d74(arg0, arg1) {
     return ret;
 };
 
+export function __wbg_cast_55f8fbc0872e729e(arg0) {
+    const ret = /* cast */(arg0);
+    return ret;
+};
+
 export function __wbindgen_init_externref_table() {
     const table = wasm.__wbindgen_export_0;
     const offset = table.grow(4);
@@ -95,11 +100,6 @@ export function __wbindgen_init_externref_table() {
     table.set(offset + 2, true);
     table.set(offset + 3, false);
     ;
-};
-
-export function __wbindgen_number_new(arg0) {
-    const ret = arg0;
-    return ret;
 };
 
 export function __wbindgen_throw(arg0, arg1) {

--- a/crates/cli/tests/reference/static.js
+++ b/crates/cli/tests/reference/static.js
@@ -50,6 +50,11 @@ export function exported() {
     wasm.exported();
 }
 
+export function __wbg_cast_32bcc2d10060d0c7(arg0) {
+    const ret = /* cast */(arg0);
+    return ret;
+};
+
 export function __wbg_static_accessor_NAMESPACE_OPTIONAL_c9a4344c544120f4() {
     const ret = typeof test === 'undefined' ? null : test?.NAMESPACE_OPTIONAL;
     return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);

--- a/src/cache/intern.rs
+++ b/src/cache/intern.rs
@@ -31,11 +31,14 @@ cfg_if! {
 
         fn intern_str(key: &str) {
             CACHE.with(|cache| {
-                let mut cache = cache.entries.borrow_mut();
+                let entries = &cache.entries;
 
                 // Can't use `entry` because `entry` requires a `String`
-                if !cache.contains_key(key) {
-                    cache.insert(key.to_owned(), JsValue::from(key));
+                if !entries.borrow().contains_key(key) {
+                    // Note: we must not hold the borrow while we create the `JsValue`,
+                    // because it will try to look up the value in the cache first.
+                    let value = JsValue::from(key);
+                    entries.borrow_mut().insert(key.to_owned(), value);
                 }
             })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,35 +166,6 @@ const JSIDX_TRUE: u32 = JSIDX_OFFSET + 2;
 const JSIDX_FALSE: u32 = JSIDX_OFFSET + 3;
 const JSIDX_RESERVED: u32 = JSIDX_OFFSET + 4;
 
-// This macro is a hack to implement "generic" casts and reduce number of
-// boilerplate intrinsics. The implementation generates a no-op JS adapter that
-// simply takes an argument in one type, decodes it from the ABI, does nothing
-// with it on the JS side (by declaring function name as empty, so instead of
-// generating typical JS call that does `ret = foo(arg);` we end up with
-// just `ret = (arg);` and then encoding same value back with a different type.
-//
-// Note that we intentionally keep this macro undocumented as it's not meant
-// for public consumption - it relies on our implementation details, and
-// is intended only for simplifying our own implementation details as well.
-//
-// Someday we'll support generics in #[wasm_bindgen] macro, in which case
-// this can be replaced with a proper generic intrinsic.
-#[macro_export]
-#[doc(hidden)]
-macro_rules! wbg_cast {
-    ($value:expr, $from:ty, $to:ty) => {{
-        use $crate::prelude::wasm_bindgen;
-
-        #[wasm_bindgen(wasm_bindgen = $crate)]
-        extern "C" {
-            #[wasm_bindgen(js_name = "/* cast */")]
-            fn __wbindgen_cast(value: $from) -> $to;
-        }
-
-        __wbindgen_cast($value)
-    }};
-}
-
 impl JsValue {
     /// The `null` JS value constant.
     pub const NULL: JsValue = JsValue::_new(JSIDX_NULL);

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -27,10 +27,6 @@ pub use wasm_bindgen_macro::BindgenedStruct;
 // generating typical JS call that does `ret = foo(arg);` we end up with
 // just `ret = (arg);` and then encoding same value back with a different type.
 //
-// Note that we intentionally keep this macro undocumented as it's not meant
-// for public consumption - it relies on our implementation details, and
-// is intended only for simplifying our own implementation details as well.
-//
 // Someday we'll support generics in #[wasm_bindgen] macro, in which case
 // this can be replaced with a proper generic intrinsic.
 #[doc(hidden)]

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -2,7 +2,6 @@ use crate::JsValue;
 use core::borrow::{Borrow, BorrowMut};
 use core::cell::{Cell, UnsafeCell};
 use core::convert::Infallible;
-use core::mem;
 use core::ops::{Deref, DerefMut};
 #[cfg(target_feature = "atomics")]
 use core::sync::atomic::{AtomicU8, Ordering};
@@ -696,16 +695,4 @@ impl<T: VectorIntoJsValue> From<Box<[T]>> for JsValue {
     fn from(vector: Box<[T]>) -> Self {
         T::vector_into_jsvalue(vector)
     }
-}
-
-pub fn js_value_vector_into_jsvalue<T: Into<JsValue>>(vector: Box<[T]>) -> JsValue {
-    let result = unsafe { JsValue::_new(super::__wbindgen_array_new()) };
-    for value in vector.into_vec() {
-        let js: JsValue = value.into();
-        unsafe { super::__wbindgen_array_push(result.idx, js.idx) }
-        // `__wbindgen_array_push` takes ownership over `js` and has already dropped it,
-        // so don't drop it again.
-        mem::forget(js);
-    }
-    result
 }


### PR DESCRIPTION
The comment on the macro is longer than implementation itself, but TLDR this hacky macro allows us to significantly reduce number of specially supported intrinsics and amount of unsafe code in favour of just going via JS + wasm-bindgen's existing type conversions.

It also provides basis that allows us to remove even more intrinsics in future PRs.