### PR TITLE
Self-host functions that don't need to be real intrinsics

### DIFF
--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -94,9 +94,6 @@ intrinsics! {
         #[symbol = "__wbindgen_is_function"]
         #[signature = fn(ref_externref()) -> Boolean]
         IsFunction,
-        #[symbol = "__wbindgen_is_array"]
-        #[signature = fn(ref_externref()) -> Boolean]
-        IsArray,
         #[symbol = "__wbindgen_is_undefined"]
         #[signature = fn(ref_externref()) -> Boolean]
         IsUndefined,
@@ -199,9 +196,6 @@ intrinsics! {
         #[symbol = "__wbindgen_number_new"]
         #[signature = fn(F64) -> Externref]
         NumberNew,
-        #[symbol = "__wbindgen_bigint_from_str"]
-        #[signature = fn(ref_string()) -> Externref]
-        BigIntFromStr,
         #[symbol = "__wbindgen_bigint_from_i64"]
         #[signature = fn(I64) -> Externref]
         BigIntFromI64,
@@ -220,12 +214,6 @@ intrinsics! {
         #[symbol = "__wbindgen_string_new"]
         #[signature = fn(ref_string()) -> Externref]
         StringNew,
-        #[symbol = "__wbindgen_symbol_anonymous_new"]
-        #[signature = fn() -> Externref]
-        SymbolAnonymousNew,
-        #[symbol = "__wbindgen_symbol_named_new"]
-        #[signature = fn(ref_string()) -> Externref]
-        SymbolNamedNew,
         #[symbol = "__wbindgen_number_get"]
         #[signature = fn(ref_externref()) -> opt_f64()]
         NumberGet,
@@ -241,9 +229,6 @@ intrinsics! {
         #[symbol = "__wbindgen_rethrow"]
         #[signature = fn(Externref) -> Unit]
         Rethrow,
-        #[symbol = "__wbindgen_error_new"]
-        #[signature = fn(ref_string()) -> Externref]
-        ErrorNew,
         #[symbol = "__wbindgen_memory"]
         #[signature = fn() -> Externref]
         Memory,
@@ -259,12 +244,6 @@ intrinsics! {
         #[symbol = "__wbindgen_debug_string"]
         #[signature = fn(ref_externref()) -> String]
         DebugString,
-        #[symbol = "__wbindgen_json_parse"]
-        #[signature = fn(ref_string()) -> Externref]
-        JsonParse,
-        #[symbol = "__wbindgen_json_serialize"]
-        #[signature = fn(ref_externref()) -> String]
-        JsonSerialize,
         #[symbol = "__wbindgen_copy_to_typed_array"]
         #[signature = fn(slice(U8), ref_externref()) -> Unit]
         CopyToTypedArray,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3623,11 +3623,6 @@ __wbg_set_wasm(wasm);"
                 format!("typeof({}) === 'function'", args[0])
             }
 
-            Intrinsic::IsArray => {
-                assert_eq!(args.len(), 1);
-                format!("Array.isArray({})", args[0])
-            }
-
             Intrinsic::IsUndefined => {
                 assert_eq!(args.len(), 1);
                 format!("{} === undefined", args[0])
@@ -3826,11 +3821,6 @@ __wbg_set_wasm(wasm);"
                 args[0].clone()
             }
 
-            Intrinsic::BigIntFromStr => {
-                assert_eq!(args.len(), 1);
-                format!("BigInt({})", args[0])
-            }
-
             Intrinsic::BigIntFromI64 | Intrinsic::BigIntFromU64 => {
                 assert_eq!(args.len(), 1);
                 args[0].clone()
@@ -3844,16 +3834,6 @@ __wbg_set_wasm(wasm);"
             Intrinsic::StringNew => {
                 assert_eq!(args.len(), 1);
                 args[0].clone()
-            }
-
-            Intrinsic::SymbolNamedNew => {
-                assert_eq!(args.len(), 1);
-                format!("Symbol({})", args[0])
-            }
-
-            Intrinsic::SymbolAnonymousNew => {
-                assert_eq!(args.len(), 0);
-                "Symbol()".to_string()
             }
 
             Intrinsic::NumberGet => {
@@ -3888,11 +3868,6 @@ __wbg_set_wasm(wasm);"
             Intrinsic::Rethrow => {
                 assert_eq!(args.len(), 1);
                 format!("throw {}", args[0])
-            }
-
-            Intrinsic::ErrorNew => {
-                assert_eq!(args.len(), 1);
-                format!("new Error({})", args[0])
             }
 
             Intrinsic::Module => {
@@ -3943,20 +3918,6 @@ __wbg_set_wasm(wasm);"
                 assert_eq!(args.len(), 1);
                 self.expose_debug_string();
                 format!("debugString({})", args[0])
-            }
-
-            Intrinsic::JsonParse => {
-                assert_eq!(args.len(), 1);
-                format!("JSON.parse({})", args[0])
-            }
-
-            Intrinsic::JsonSerialize => {
-                assert_eq!(args.len(), 1);
-                // Turns out `JSON.stringify(undefined) === undefined`, so if
-                // we're passed `undefined` reinterpret it as `null` for JSON
-                // purposes.
-                prelude.push_str(&format!("const obj = {};\n", args[0]));
-                "JSON.stringify(obj === undefined ? null : obj)".to_string()
             }
 
             Intrinsic::CopyToTypedArray => {

--- a/crates/cli/tests/reference/result.js
+++ b/crates/cli/tests/reference/result.js
@@ -81,8 +81,8 @@ export function result_i32() {
     return ret[0];
 }
 
-export function __wbindgen_error_new(arg0, arg1) {
-    const ret = new Error(getStringFromWasm0(arg0, arg1));
+export function __wbg_Error_fcfdb1a705a32d74(arg0, arg1) {
+    const ret = Error(getStringFromWasm0(arg0, arg1));
     return ret;
 };
 


### PR DESCRIPTION
This makes intrinsics that are simple JS functions just bindings to those JS functions, so that 1) we have fewer intrinsics to specially support and 2) less unsafe code.

This intentionally doesn't touch intrinsics I'm already removing in #4579 to avoid duplicate work, even though some of them could be represented in form of function calls too.