### PR TITLE
Use test-each for fixture tests

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,13 +40,9 @@ wasm-bindgen-shared = { path = "../shared", version = "=0.2.100" }
 assert_cmd = "2"
 diff = "0.1"
 predicates = "3"
-rayon = "1.0"
+test-each = "0.3"
 wasmparser = "0.214"
 wasmprinter = "0.214"
-
-[[test]]
-harness = false
-name = "reference"
 
 [features]
 default = ["rustls-tls"]

--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -61,58 +61,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use walrus::ModuleConfig;
 
-fn main() -> Result<()> {
-    let filter = env::args().nth(1);
-
-    let mut tests = Vec::new();
-    let dir = repo_root().join("crates/cli/tests/reference");
-    for entry in dir.read_dir()? {
-        let path = entry?.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
-            continue;
-        }
-        if let Some(filter) = &filter {
-            if !path.display().to_string().contains(filter) {
-                continue;
-            }
-        }
-        tests.push(path);
-    }
-    tests.sort();
-
-    let is_ci = env::var("CI").is_ok();
-    if !is_ci {
-        // sort test files by when they were last modified, so that we run the most
-        // recently modified tests first. This just makes iterating on tests a bit
-        // easier.
-        tests.sort_by_cached_key(|p| fs::metadata(p).unwrap().modified().unwrap());
-        tests.reverse();
-    }
-
-    let mut errs_iter = tests.iter().filter_map(|t| {
-        println!("  {}", t.file_name().unwrap().to_string_lossy());
-        runtest(t).err().map(|e| (t, e))
-    });
-
-    let Some(first_error) = errs_iter.next() else {
-        println!("{} tests passed", tests.len());
-        return Ok(());
-    };
-
-    let mut errs = vec![first_error];
-    if is_ci {
-        // one error should be enough for local testing to ensure fast iteration
-        // only find all errors in CI
-        errs.extend(errs_iter);
-    }
-
-    eprintln!("failed tests:\n");
-    for (test, err) in errs {
-        eprintln!("{} failure\n{}", test.display(), tab(&format!("{err:?}")));
-    }
-    bail!("tests failed");
-}
-
+#[test_each::path(glob = "crates/cli/tests/reference/*.rs")]
 fn runtest(test: &Path) -> Result<()> {
     let contents = fs::read_to_string(test)?;
     let td = tempfile::TempDir::new()?;

--- a/crates/externref-xform/Cargo.toml
+++ b/crates/externref-xform/Cargo.toml
@@ -19,7 +19,7 @@ walrus = "0.23"
 wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.100" }
 
 [dev-dependencies]
-rayon = "1.0"
+test-each = "0.3"
 wasmprinter = "0.214"
 wast = "214"
 wat = "~1.214"

--- a/crates/externref-xform/tests/all.rs
+++ b/crates/externref-xform/tests/all.rs
@@ -6,17 +6,11 @@
 //! `BLESS=1` in the environment. Otherwise the test are checked against the
 //! listed expectation.
 
-use anyhow::{anyhow, bail, Context, Result};
-use rayon::prelude::*;
-use std::env;
+use anyhow::{anyhow, bail, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 use walrus::ModuleConfig;
 use wast::parser::{Parse, Parser};
-
-fn main() {
-    run("tests".as_ref(), runtest);
-}
 
 fn runtest(test: &Test) -> Result<String> {
     let wasm = wat::parse_file(&test.file)?;
@@ -54,68 +48,11 @@ fn runtest(test: &Test) -> Result<String> {
     Ok(printed)
 }
 
-fn run(dir: &Path, run: fn(&Test) -> Result<String>) {
-    let mut tests = Vec::new();
-    find_tests(dir, &mut tests);
-    let filter = std::env::args().nth(1);
-
-    let bless = env::var("BLESS").is_ok();
-    let tests = tests
-        .iter()
-        .filter(|test| {
-            if let Some(filter) = &filter {
-                if let Some(s) = test.file_name().and_then(|s| s.to_str()) {
-                    if !s.contains(filter) {
-                        return false;
-                    }
-                }
-            }
-            true
-        })
-        .collect::<Vec<_>>();
-
-    println!("\nrunning {} tests\n", tests.len());
-
-    let errors = tests
-        .par_iter()
-        .filter_map(|test| run_test(test, bless, run).err())
-        .collect::<Vec<_>>();
-
-    if !errors.is_empty() {
-        for msg in errors.iter() {
-            eprintln!("error: {msg:?}");
-        }
-
-        panic!("{} tests failed", errors.len())
-    }
-
-    println!("test result: ok. {} passed\n", tests.len());
-}
-
-fn run_test(test: &Path, bless: bool, run: fn(&Test) -> anyhow::Result<String>) -> Result<()> {
-    (|| -> Result<_> {
-        let expected = Test::from_file(test)?;
-        let actual = run(&expected)?;
-        expected.check(&actual, bless)?;
-        Ok(())
-    })()
-    .context(format!("test failed - {}", test.display()))?;
-    Ok(())
-}
-
-fn find_tests(path: &Path, tests: &mut Vec<PathBuf>) {
-    for f in path.read_dir().unwrap() {
-        let f = f.unwrap();
-        if f.file_type().unwrap().is_dir() {
-            find_tests(&f.path(), tests);
-            continue;
-        }
-        match f.path().extension().and_then(|s| s.to_str()) {
-            Some("wat") => {}
-            _ => continue,
-        }
-        tests.push(f.path());
-    }
+#[test_each::path(glob = "crates/externref-xform/tests/*.wat")]
+fn run_test(test: &Path) -> Result<()> {
+    let expected = Test::from_file(test)?;
+    let actual = runtest(&expected)?;
+    expected.check(&actual)
 }
 
 struct Test {
@@ -173,8 +110,8 @@ impl Test {
         })
     }
 
-    fn check(&self, output: &str, bless: bool) -> Result<()> {
-        if bless {
+    fn check(&self, output: &str) -> Result<()> {
+        if option_env!("BLESS").is_some() {
             update_output(&self.file, output)
         } else if let Some(pattern) = &self.assertion {
             if output == pattern {

--- a/crates/multi-value-xform/Cargo.toml
+++ b/crates/multi-value-xform/Cargo.toml
@@ -19,14 +19,10 @@ walrus = "0.23"
 wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.100" }
 
 [dev-dependencies]
-rayon = "1.0"
+test-each = "0.3"
 wasmprinter = "0.214"
 wast = "214"
 wat = "1.0"
 
 [lints]
 workspace = true
-
-[[test]]
-harness = false
-name = "all"

--- a/crates/multi-value-xform/tests/all.rs
+++ b/crates/multi-value-xform/tests/all.rs
@@ -6,17 +6,11 @@
 //! `BLESS=1` in the environment. Otherwise the test are checked against the
 //! listed expectation.
 
-use anyhow::{bail, Context, Result};
-use rayon::prelude::*;
-use std::env;
+use anyhow::{bail, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 use walrus::ModuleConfig;
 use wast::parser::{Parse, Parser};
-
-fn main() {
-    run("tests".as_ref(), runtest);
-}
 
 fn runtest(test: &Test) -> Result<String> {
     let wasm = wat::parse_file(&test.file)?;
@@ -49,68 +43,11 @@ fn runtest(test: &Test) -> Result<String> {
     Ok(printed)
 }
 
-fn run(dir: &Path, run: fn(&Test) -> Result<String>) {
-    let mut tests = Vec::new();
-    find_tests(dir, &mut tests);
-    let filter = std::env::args().nth(1);
-
-    let bless = env::var("BLESS").is_ok();
-    let tests = tests
-        .iter()
-        .filter(|test| {
-            if let Some(filter) = &filter {
-                if let Some(s) = test.file_name().and_then(|s| s.to_str()) {
-                    if !s.contains(filter) {
-                        return false;
-                    }
-                }
-            }
-            true
-        })
-        .collect::<Vec<_>>();
-
-    println!("\nrunning {} tests\n", tests.len());
-
-    let errors = tests
-        .par_iter()
-        .filter_map(|test| run_test(test, bless, run).err())
-        .collect::<Vec<_>>();
-
-    if !errors.is_empty() {
-        for msg in errors.iter() {
-            eprintln!("error: {msg:?}");
-        }
-
-        panic!("{} tests failed", errors.len())
-    }
-
-    println!("test result: ok. {} passed\n", tests.len());
-}
-
-fn run_test(test: &Path, bless: bool, run: fn(&Test) -> anyhow::Result<String>) -> Result<()> {
-    (|| -> Result<_> {
-        let expected = Test::from_file(test)?;
-        let actual = run(&expected)?;
-        expected.check(&actual, bless)?;
-        Ok(())
-    })()
-    .context(format!("test failed - {}", test.display()))?;
-    Ok(())
-}
-
-fn find_tests(path: &Path, tests: &mut Vec<PathBuf>) {
-    for f in path.read_dir().unwrap() {
-        let f = f.unwrap();
-        if f.file_type().unwrap().is_dir() {
-            find_tests(&f.path(), tests);
-            continue;
-        }
-        match f.path().extension().and_then(|s| s.to_str()) {
-            Some("wat") => {}
-            _ => continue,
-        }
-        tests.push(f.path());
-    }
+#[test_each::path(glob = "crates/multi-value-xform/tests/*.wat")]
+fn run_test(test: &Path) -> Result<()> {
+    let expected = Test::from_file(test)?;
+    let actual = runtest(&expected)?;
+    expected.check(&actual)
 }
 
 struct Test {
@@ -161,8 +98,8 @@ impl Test {
         })
     }
 
-    fn check(&self, output: &str, bless: bool) -> Result<()> {
-        if bless {
+    fn check(&self, output: &str) -> Result<()> {
+        if option_env!("BLESS").is_some() {
             update_output(&self.file, output)
         } else if let Some(pattern) = &self.assertion {
             if output == pattern {

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -19,14 +19,10 @@ walrus = "0.23"
 wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.100" }
 
 [dev-dependencies]
-rayon = "1.0"
+test-each = "0.3"
 wasmparser = "0.214"
 wasmprinter = "0.214"
 wat = "1.0"
 
 [lints]
 workspace = true
-
-[[test]]
-harness = false
-name = "all"

--- a/crates/threads-xform/tests/all.rs
+++ b/crates/threads-xform/tests/all.rs
@@ -6,16 +6,10 @@
 //! `BLESS=1` in the environment. Otherwise the test are checked against the
 //! listed expectation.
 
-use anyhow::{bail, Context, Result};
-use rayon::prelude::*;
-use std::env;
+use anyhow::{bail, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 use walrus::ModuleConfig;
-
-fn main() {
-    run("tests".as_ref(), runtest);
-}
 
 fn runtest(test: &Test) -> Result<String> {
     let wasm = wat::parse_file(&test.file)?;
@@ -35,68 +29,11 @@ fn runtest(test: &Test) -> Result<String> {
     Ok(printed)
 }
 
-fn run(dir: &Path, run: fn(&Test) -> Result<String>) {
-    let mut tests = Vec::new();
-    find_tests(dir, &mut tests);
-    let filter = std::env::args().nth(1);
-
-    let bless = env::var("BLESS").is_ok();
-    let tests = tests
-        .iter()
-        .filter(|test| {
-            if let Some(filter) = &filter {
-                if let Some(s) = test.file_name().and_then(|s| s.to_str()) {
-                    if !s.contains(filter) {
-                        return false;
-                    }
-                }
-            }
-            true
-        })
-        .collect::<Vec<_>>();
-
-    println!("\nrunning {} tests\n", tests.len());
-
-    let errors = tests
-        .par_iter()
-        .filter_map(|test| run_test(test, bless, run).err())
-        .collect::<Vec<_>>();
-
-    if !errors.is_empty() {
-        for msg in errors.iter() {
-            eprintln!("error: {msg:?}");
-        }
-
-        panic!("{} tests failed", errors.len())
-    }
-
-    println!("test result: ok. {} passed\n", tests.len());
-}
-
-fn run_test(test: &Path, bless: bool, run: fn(&Test) -> anyhow::Result<String>) -> Result<()> {
-    (|| -> Result<_> {
-        let expected = Test::from_file(test)?;
-        let actual = run(&expected)?;
-        expected.check(&actual, bless)?;
-        Ok(())
-    })()
-    .context(format!("test failed - {}", test.display()))?;
-    Ok(())
-}
-
-fn find_tests(path: &Path, tests: &mut Vec<PathBuf>) {
-    for f in path.read_dir().unwrap() {
-        let f = f.unwrap();
-        if f.file_type().unwrap().is_dir() {
-            find_tests(&f.path(), tests);
-            continue;
-        }
-        match f.path().extension().and_then(|s| s.to_str()) {
-            Some("wat") => {}
-            _ => continue,
-        }
-        tests.push(f.path());
-    }
+#[test_each::path(glob = "crates/threads-xform/tests/*.wat")]
+fn run_test(test: &Path) -> Result<()> {
+    let expected = Test::from_file(test)?;
+    let actual = runtest(&expected)?;
+    expected.check(&actual)
 }
 
 struct Test {
@@ -136,8 +73,8 @@ impl Test {
         })
     }
 
-    fn check(&self, output: &str, bless: bool) -> Result<()> {
-        if bless {
+    fn check(&self, output: &str) -> Result<()> {
+        if option_env!("BLESS").is_some() {
             update_output(&self.file, output)
         } else if let Some(pattern) = &self.assertion {
             if output == pattern {


### PR DESCRIPTION
This improves integration with cargo test's filtering, IDE test explorers, and, perhaps most excitingly, tools like [cargo nextest](https://nexte.st/) so we can run tests in parallel which makes them much faster (especially the `reference` tests which need to compile each `.rs` file).

It's also less custom code to maintain.