### PR TITLE
Make debug cfg a non-feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,10 @@ wasm-bindgen-test-crate-b = { path = 'tests/crates/b' }
 workspace = true
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)', 'cfg(xxx_debug_only_print_generated_code)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(wasm_bindgen_unstable_test_coverage)',
+  'cfg(xxx_debug_only_print_generated_code)',
+] }
 
 [workspace.lints.clippy]
 large_enum_variant = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ strict-macro = ["wasm-bindgen-macro/strict-macro"]
 # are handled correctly
 gg-alloc = ["wasm-bindgen-test/gg-alloc"]
 
+# INTERNAL ONLY and deprecated, to be removed in the next major version.
+xxx_debug_only_print_generated_code = []
+
 [dependencies]
 cfg-if = "1.0.0"
 once_cell = { version = "1.12", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,6 @@ strict-macro = ["wasm-bindgen-macro/strict-macro"]
 # are handled correctly
 gg-alloc = ["wasm-bindgen-test/gg-alloc"]
 
-# INTERNAL ONLY: This is only for debugging wasm-bindgen! No stability guarantees, so enable
-# this at your own peril!
-xxx_debug_only_print_generated_code = ["wasm-bindgen-macro/xxx_debug_only_print_generated_code"]
-
 [dependencies]
 cfg-if = "1.0.0"
 once_cell = { version = "1.12", default-features = false }
@@ -68,15 +64,11 @@ wasm-bindgen-futures = { path = 'crates/futures' }
 wasm-bindgen-test-crate-a = { path = 'tests/crates/a' }
 wasm-bindgen-test-crate-b = { path = 'tests/crates/b' }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+[lints]
+workspace = true
 
-[lints.clippy]
-large_enum_variant = "allow"
-new_without_default = "allow"
-overly_complex_bool_expr = "allow"
-too_many_arguments = "allow"
-type_complexity = "allow"
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)', 'cfg(xxx_debug_only_print_generated_code)'] }
 
 [workspace.lints.clippy]
 large_enum_variant = "allow"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,8 @@
-// Empty `build.rs` so that `[package] links = ...` works in `Cargo.toml`.
+// Mostly no-op `build.rs` so that `[package] links = ...` works in `Cargo.toml`.
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    #[cfg(feature = "xxx_debug_only_print_generated_code")]
+    {
+        println!("cargo:warning=The `xxx_debug_only_print_generated_code` internal feature is deprecated and will be removed in the next major version.");
+    }
 }

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -18,7 +18,6 @@ proc-macro = true
 
 [features]
 strict-macro = ["wasm-bindgen-macro-support/strict-macro"]
-xxx_debug_only_print_generated_code = []
 
 [dependencies]
 quote = "1.0"

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -10,7 +10,7 @@ use quote::quote;
 pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand(attr.into(), input.into()) {
         Ok(tokens) => {
-            if cfg!(feature = "xxx_debug_only_print_generated_code") {
+            if cfg!(xxx_debug_only_print_generated_code) {
                 println!("{}", tokens);
             }
             tokens.into()
@@ -36,7 +36,7 @@ pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
 pub fn link_to(input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_link_to(input.into()) {
         Ok(tokens) => {
-            if cfg!(feature = "xxx_debug_only_print_generated_code") {
+            if cfg!(xxx_debug_only_print_generated_code) {
                 println!("{}", tokens);
             }
             tokens.into()
@@ -52,7 +52,7 @@ pub fn link_to(input: TokenStream) -> TokenStream {
 pub fn __wasm_bindgen_class_marker(attr: TokenStream, input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_class_marker(attr.into(), input.into()) {
         Ok(tokens) => {
-            if cfg!(feature = "xxx_debug_only_print_generated_code") {
+            if cfg!(xxx_debug_only_print_generated_code) {
                 println!("{}", tokens);
             }
             tokens.into()
@@ -65,7 +65,7 @@ pub fn __wasm_bindgen_class_marker(attr: TokenStream, input: TokenStream) -> Tok
 pub fn __wasm_bindgen_struct_marker(item: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_struct_marker(item.into()) {
         Ok(tokens) => {
-            if cfg!(feature = "xxx_debug_only_print_generated_code") {
+            if cfg!(xxx_debug_only_print_generated_code) {
                 println!("{}", tokens);
             }
             tokens.into()


### PR DESCRIPTION
I've been wondering why, when running e.g. `cargo check --all-features`, I'm getting tons of dumped noise in my terminal, until found this.

This clearly should be an internal cfg like the `wasm_bindgen_unstable_test_coverage` and not a feature that gets opted into automatically.