### PR TITLE
Fix running coverage with no_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@
 * Fix infinite recursion caused by the lack of proc-macro hygiene.
   [#4601](https://github.com/wasm-bindgen/wasm-bindgen/pull/4601)
 
+* Fix running coverage with no_modules.
+  [#4604](https://github.com/wasm-bindgen/wasm-bindgen/pull/4604)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.100](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.99...0.2.100)

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -40,7 +40,7 @@ pub(crate) fn spawn(
     "#;
 
     let wbg_import_script = if test_mode.no_modules() {
-        String::from(
+        format!(
             r#"
             let Context = wasm_bindgen.WasmBindgenTestContext;
             let __wbgtest_console_debug = wasm_bindgen.__wbgtest_console_debug;


### PR DESCRIPTION
close https://github.com/wasm-bindgen/wasm-bindgen/issues/4485

In addition, `wasm-bindgen` is an amazing tool, I am interested in spending some time maintaining `wasm-bindgen`. At least for now, I can help solve some issues. What are the requirements for joining `wasm-bindgen`?