### PR TITLE
Update team and governance docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ greet("World!");
 
 [**📚 Read the `wasm-bindgen` guide here! 📚**](https://wasm-bindgen.github.io/wasm-bindgen/)
 
-You can find general documentation about using Rust and WebAssembly together
-[here](https://rustwasm.github.io/docs).
-
 ## API Docs
 
 - [wasm-bindgen](https://docs.rs/wasm-bindgen)
@@ -127,8 +124,7 @@ at your option.
 
 ## Contribution
 
-**[See the "Contributing" section of the guide for information on
-hacking on `wasm-bindgen`!][contributing]**
+**[See the "Contributing" section of the guide for information on hacking on `wasm-bindgen`!][contributing]**
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,

--- a/guide/src/contributing/governance.md
+++ b/guide/src/contributing/governance.md
@@ -1,0 +1,62 @@
+# Governance of the `wasm-bindgen` Organization
+
+This document describes the lightweight governance structure used in the
+[`wasm-bindgen` organization][org].
+
+- [Code of Conduct](#code-of-conduct)
+- [Membership](#membership)
+  - [Core Team](#core-team)
+- [Changes Policy](#changes-policy)
+
+## Code of Conduct
+
+We abide by the [Rust Code of Conduct][conduct] and ask that you do as well,
+with the moderation role performed by the [core team].
+
+## Membership
+
+We welcome new collaborators in the project! The project is not owned by any
+specific entity or group and belongs to the community as a whole.
+
+If you make two or three significant contributions, you should seriously consider
+requesting collaborator membership.
+
+If you are a collaborator and notice that someone has made two or three significant
+contributions to it, you should also seriously consider nominating them for collaborator
+status!
+
+**To request to join as a Collaborator, post a [collaborator request issue] stating
+your intent to join the project, and it will be reviewed by other members.**
+
+### Core Team
+
+The core team is responsible for project governance and moderation, operating
+based on a majority vote.
+
+The project as a whole seeks to operate on consensus, such that core votes are
+typically only needed in the event of governance changes and process escalations.
+
+Core team members are themselves selected by a core team vote, and are required
+to maintain active participation as core members. Active participation is currently
+defined as regular attendance at monthly core meetings.
+
+## Changes Policy
+
+When merging code changes, the following PR policy applies:
+
+* We operate on a full consensus contribution model based on always assuming good faith.
+
+* All collaborators, including core team members, have equal contribution rights.
+
+* All pull requests must be reviewed and approved of by at least one other collaborator, and ensuring adequate time for reviews before merging.
+
+* All explicit requests for changes on PRs by other collaborators must be resolved prior to merging.
+
+* In case of disagreements, and as a last resort when all other consensus-building methods have been exhausted, escalation to a core team vote
+may be initiated for the next core team meeting.
+
+[org]: https://github.com/rustwasm
+[conduct]: https://www.rust-lang.org/en-US/conduct.html
+[core-team]: https://wasm-bindgen.github.io/wasm-bindgen/contributing/team#core
+[collaborators]: https://wasm-bindgen.github.io/wasm-bindgen/contributing/team#collaborators
+[collaborator request issue]: https://github.com/wasm-bindgen/wasm-bindgen/issues/new?title=Collaborator%20Request

--- a/guide/src/contributing/team.md
+++ b/guide/src/contributing/team.md
@@ -18,17 +18,9 @@ We welcome new members - if you are interested in joining the team, see the [mem
 
 ## Former Members
 
-`wasm-bindgen` was initially developed under the now sunsetted [Rust Wasm initiative], which included team members:
+`wasm-bindgen` was initially developed under the now sunsetted [Rust and WebAssembly Working Group], which included these [former team members]().
 
-* [`alexcrichton`](https://github.com/alexcrichton)
-* [`fitzgen`](https://github.com/fitzgen)
-* [`spastorino`](https://github.com/spastorino)
-* [`ohanar`](https://github.com/ohanar)
-* [`jonathan-s`](https://github.com/jonathan-s)
-* [`sendilkumarn`](https://github.com/sendilkumarn)
-* [`belfz`](https://github.com/belfz)
-* [`afdw`](https://github.com/afdw)
-
-[Rust Wasm initiative]: https://github.com/rustwasm
+[Rust and WebAssembly Working Group]: https://github.com/rustwasm
+[former team members]: https://github.com/orgs/rustwasm/people
 [governance]: https://wasm-bindgen.github.io/wasm-bindgen/contributing/governance
 [membership]: https://wasm-bindgen.github.io/wasm-bindgen/contributing/governance#membership

--- a/guide/src/contributing/team.md
+++ b/guide/src/contributing/team.md
@@ -1,36 +1,34 @@
 # Team
 
-`wasm-bindgen` follows the [`rustwasm` organization's governance described
-here][governance]:
+`wasm-bindgen` follows the project [governance described here][governance].
 
-* All pull requests (including those made by a team member) must be approved by
-  at least one other team member.
+The current project team members are listed below.
 
-* Larger, more nuanced decisions about design, architecture, breaking changes,
-  trade offs, etc are made by team consensus.
+We welcome new members - if you are interested in joining the team, see the [membership] section of the governance document.
 
-[governance]: https://github.com/rustwasm/team/blob/master/GOVERNANCE.md#repositories
+## Owners
 
-## Members
+* [daxpedda](https://github.com/daxpedda)
+* [Ingvar Stepanyan](https://github.com/RReverser)
+* [Guy Bedford](https://github.com/guybedford)
 
-<style>
-img {
-    max-width: 117px;
-    max-height: 117px;
-}
-</style>
+## Collaborators
 
-| [![](https://github.com/alexcrichton.png?size=117)][alexcrichton] | [![](https://github.com/fitzgen.png?size=117)][fitzgen] | [![](https://github.com/spastorino.png?size=117)][spastorino] | [![](https://github.com/ohanar.png?size=117)][ohanar] | [![](https://github.com/jonathan-s.png?size=117)][jonathan-s] |
-|:---:|:---:|:---:|:---:|
-| [`alexcrichton`][alexcrichton] | [`fitzgen`][fitzgen] | [`spastorino`][spastorino] | [`ohanar`][ohanar] | [`jonathan-s`][jonathan-s] |
-| [![](https://github.com/sendilkumarn.png?size=117)][sendilkumarn] | [![](https://github.com/belfz.png?size=117)][belfz] | [![](https://github.com/afdw.png?size=117)][afdw] | | |
-| [`sendilkumarn`][sendilkumarn] | [`belfz`][belfz] | [`afdw`][afdw] | | |
+* [Hood Chatham](https://github.com/hoodmane)
 
-[alexcrichton]: https://github.com/alexcrichton
-[fitzgen]: https://github.com/fitzgen
-[spastorino]: https://github.com/spastorino
-[ohanar]: https://github.com/ohanar
-[jonathan-s]: https://github.com/jonathan-s
-[sendilkumarn]: https://github.com/sendilkumarn
-[belfz]: https://github.com/belfz
-[afdw]: https://github.com/afdw
+## Former Members
+
+`wasm-bindgen` was initially developed under the now sunsetted [Rust Wasm initiative], which included team members:
+
+* [`alexcrichton`](https://github.com/alexcrichton)
+* [`fitzgen`](https://github.com/fitzgen)
+* [`spastorino`](https://github.com/spastorino)
+* [`ohanar`](https://github.com/ohanar)
+* [`jonathan-s`](https://github.com/jonathan-s)
+* [`sendilkumarn`](https://github.com/sendilkumarn)
+* [`belfz`](https://github.com/belfz)
+* [`afdw`](https://github.com/afdw)
+
+[Rust Wasm initiative]: https://github.com/rustwasm
+[governance]: https://wasm-bindgen.github.io/wasm-bindgen/contributing/governance
+[membership]: https://wasm-bindgen.github.io/wasm-bindgen/contributing/governance#membership

--- a/guide/src/contributing/team.md
+++ b/guide/src/contributing/team.md
@@ -18,7 +18,7 @@ We welcome new members - if you are interested in joining the team, see the [mem
 
 ## Former Members
 
-`wasm-bindgen` was initially developed under the now sunsetted [Rust and WebAssembly Working Group], which included these [former team members]().
+`wasm-bindgen` was initially developed under the now sunsetted [Rust and WebAssembly Working Group], which included these [former team members].
 
 [Rust and WebAssembly Working Group]: https://github.com/rustwasm
 [former team members]: https://github.com/orgs/rustwasm/people

--- a/guide/src/contributing/team.md
+++ b/guide/src/contributing/team.md
@@ -6,7 +6,7 @@ The current project team members are listed below.
 
 We welcome new members - if you are interested in joining the team, see the [membership] section of the governance document.
 
-## Owners
+## Core
 
 * [daxpedda](https://github.com/daxpedda)
 * [Ingvar Stepanyan](https://github.com/RReverser)


### PR DESCRIPTION
This updates the team info and governance docs removing old outdated references to the Rust wasm project, clarifying the current team, and updating the process as currently agreed upon.