### PR TITLE
Add helper macro for "generic" casts (#4579)

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -456,7 +456,7 @@ impl ToTokens for ast::Struct {
             #[automatically_derived]
             impl #wasm_bindgen::__rt::VectorIntoJsValue for #name {
                 fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#name]>) -> #wasm_bindgen::JsValue {
-                    #wasm_bindgen::__rt::js_value_vector_into_jsvalue(vector)
+                    #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#name]>, #wasm_bindgen::JsValue)
                 }
             }
         })
@@ -1154,6 +1154,13 @@ impl ToTokens for ast::ImportType {
                 }
 
                 impl JsObject for #rust_name {}
+
+                #[automatically_derived]
+                impl #wasm_bindgen::__rt::VectorIntoJsValue for #rust_name {
+                    fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#rust_name]>) -> #wasm_bindgen::JsValue {
+                        #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#rust_name]>, #wasm_bindgen::JsValue)
+                    }
+                }
             };
         })
         .to_tokens(tokens);
@@ -1719,7 +1726,7 @@ impl ToTokens for ast::Enum {
             #[automatically_derived]
             impl #wasm_bindgen::__rt::VectorIntoJsValue for #enum_name {
                 fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#enum_name]>) -> #wasm_bindgen::JsValue {
-                    #wasm_bindgen::__rt::js_value_vector_into_jsvalue(vector)
+                    #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#enum_name]>, #wasm_bindgen::JsValue)
                 }
             }
         })

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -79,10 +79,6 @@ fn slice(contents: Descriptor) -> Descriptor {
     Descriptor::Ref(Box::new(Descriptor::Slice(Box::new(contents))))
 }
 
-fn vector(contents: Descriptor) -> Descriptor {
-    Descriptor::Vector(Box::new(contents))
-}
-
 intrinsics! {
     pub enum Intrinsic {
         #[symbol = "__wbindgen_jsval_eq"]
@@ -121,9 +117,6 @@ intrinsics! {
         #[symbol = "__wbindgen_is_falsy"]
         #[signature = fn(ref_externref()) -> Boolean]
         IsFalsy,
-        #[symbol = "__wbindgen_as_number"]
-        #[signature = fn(ref_externref()) -> F64]
-        AsNumber,
         #[symbol = "__wbindgen_try_into_number"]
         #[signature = fn(ref_externref()) -> Externref]
         TryIntoNumber,
@@ -193,27 +186,9 @@ intrinsics! {
         #[symbol = "__wbindgen_cb_drop"]
         #[signature = fn(Externref) -> Boolean]
         CallbackDrop,
-        #[symbol = "__wbindgen_number_new"]
-        #[signature = fn(F64) -> Externref]
-        NumberNew,
-        #[symbol = "__wbindgen_bigint_from_i64"]
-        #[signature = fn(I64) -> Externref]
-        BigIntFromI64,
-        #[symbol = "__wbindgen_bigint_from_u64"]
-        #[signature = fn(U64) -> Externref]
-        BigIntFromU64,
-        #[symbol = "__wbindgen_bigint_from_i128"]
-        #[signature = fn(I64, U64) -> Externref]
-        BigIntFromI128,
-        #[symbol = "__wbindgen_bigint_from_u128"]
-        #[signature = fn(U64, U64) -> Externref]
-        BigIntFromU128,
         #[symbol = "__wbindgen_bigint_get_as_i64"]
         #[signature = fn(ref_externref()) -> opt_i64()]
         BigIntGetAsI64,
-        #[symbol = "__wbindgen_string_new"]
-        #[signature = fn(ref_string()) -> Externref]
-        StringNew,
         #[symbol = "__wbindgen_number_get"]
         #[signature = fn(ref_externref()) -> opt_f64()]
         NumberGet,
@@ -247,45 +222,6 @@ intrinsics! {
         #[symbol = "__wbindgen_copy_to_typed_array"]
         #[signature = fn(slice(U8), ref_externref()) -> Unit]
         CopyToTypedArray,
-        #[symbol = "__wbindgen_uint8_array_new"]
-        #[signature = fn(vector(U8)) -> Externref]
-        Uint8ArrayNew,
-        #[symbol = "__wbindgen_uint8_clamped_array_new"]
-        #[signature = fn(vector(ClampedU8)) -> Externref]
-        Uint8ClampedArrayNew,
-        #[symbol = "__wbindgen_uint16_array_new"]
-        #[signature = fn(vector(U16)) -> Externref]
-        Uint16ArrayNew,
-        #[symbol = "__wbindgen_uint32_array_new"]
-        #[signature = fn(vector(U32)) -> Externref]
-        Uint32ArrayNew,
-        #[symbol = "__wbindgen_biguint64_array_new"]
-        #[signature = fn(vector(U64)) -> Externref]
-        BigUint64ArrayNew,
-        #[symbol = "__wbindgen_int8_array_new"]
-        #[signature = fn(vector(I8)) -> Externref]
-        Int8ArrayNew,
-        #[symbol = "__wbindgen_int16_array_new"]
-        #[signature = fn(vector(I16)) -> Externref]
-        Int16ArrayNew,
-        #[symbol = "__wbindgen_int32_array_new"]
-        #[signature = fn(vector(I32)) -> Externref]
-        Int32ArrayNew,
-        #[symbol = "__wbindgen_bigint64_array_new"]
-        #[signature = fn(vector(I64)) -> Externref]
-        BigInt64ArrayNew,
-        #[symbol = "__wbindgen_float32_array_new"]
-        #[signature = fn(vector(F32)) -> Externref]
-        Float32ArrayNew,
-        #[symbol = "__wbindgen_float64_array_new"]
-        #[signature = fn(vector(F64)) -> Externref]
-        Float64ArrayNew,
-        #[symbol = "__wbindgen_array_new"]
-        #[signature = fn() -> Externref]
-        ArrayNew,
-        #[symbol = "__wbindgen_array_push"]
-        #[signature = fn(ref_externref(), Externref) -> Unit]
-        ArrayPush,
         #[symbol = "__wbindgen_externref_heap_live_count"]
         #[signature = fn() -> I32]
         ExternrefHeapLiveCount,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3658,11 +3658,6 @@ __wbg_set_wasm(wasm);"
                 format!("!{}", args[0])
             }
 
-            Intrinsic::AsNumber => {
-                assert_eq!(args.len(), 1);
-                format!("+{}", args[0])
-            }
-
             Intrinsic::TryIntoNumber => {
                 assert_eq!(args.len(), 1);
                 prelude.push_str("let result;\n");
@@ -3805,26 +3800,6 @@ __wbg_set_wasm(wasm);"
                 "false".to_string()
             }
 
-            Intrinsic::NumberNew => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
-            Intrinsic::BigIntFromI64 | Intrinsic::BigIntFromU64 => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
-            Intrinsic::BigIntFromI128 | Intrinsic::BigIntFromU128 => {
-                assert_eq!(args.len(), 2);
-                format!("{} << BigInt(64) | {}", args[0], args[1])
-            }
-
-            Intrinsic::StringNew => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
             Intrinsic::NumberGet => {
                 assert_eq!(args.len(), 1);
                 prelude.push_str(&format!("const obj = {};\n", args[0]));
@@ -3916,31 +3891,6 @@ __wbg_set_wasm(wasm);"
                     src = args[0],
                     dst = args[1]
                 )
-            }
-
-            Intrinsic::Uint8ArrayNew
-            | Intrinsic::Uint8ClampedArrayNew
-            | Intrinsic::Uint16ArrayNew
-            | Intrinsic::Uint32ArrayNew
-            | Intrinsic::BigUint64ArrayNew
-            | Intrinsic::Int8ArrayNew
-            | Intrinsic::Int16ArrayNew
-            | Intrinsic::Int32ArrayNew
-            | Intrinsic::BigInt64ArrayNew
-            | Intrinsic::Float32ArrayNew
-            | Intrinsic::Float64ArrayNew => {
-                assert_eq!(args.len(), 1);
-                args[0].clone()
-            }
-
-            Intrinsic::ArrayNew => {
-                assert_eq!(args.len(), 0);
-                "[]".to_string()
-            }
-
-            Intrinsic::ArrayPush => {
-                assert_eq!(args.len(), 2);
-                format!("{}.push({})", args[0], args[1])
             }
 
             Intrinsic::ExternrefHeapLiveCount => {

--- a/crates/cli/tests/reference/echo.js
+++ b/crates/cli/tests/reference/echo.js
@@ -4,6 +4,38 @@ export function __wbg_set_wasm(val) {
 }
 
 
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+const MAX_SAFARI_DECODE_BYTES = 2146435072;
+let numBytesDecoded = 0;
+function decodeText(ptr, len) {
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return decodeText(ptr, len);
+}
+
 function debugString(val) {
     // primitive types
     const type = typeof val;
@@ -70,15 +102,6 @@ function debugString(val) {
 }
 
 let WASM_VECTOR_LEN = 0;
-
-let cachedUint8ArrayMemory0 = null;
-
-function getUint8ArrayMemory0() {
-    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
-        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-    }
-    return cachedUint8ArrayMemory0;
-}
 
 const lTextEncoder = typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
 
@@ -147,29 +170,6 @@ function getDataViewMemory0() {
 
 function isLikeNone(x) {
     return x === undefined || x === null;
-}
-
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-const MAX_SAFARI_DECODE_BYTES = 2146435072;
-let numBytesDecoded = 0;
-function decodeText(ptr, len) {
-    numBytesDecoded += len;
-    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
-        cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-        cachedTextDecoder.decode();
-        numBytesDecoded = len;
-    }
-    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
-}
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return decodeText(ptr, len);
 }
 /**
  * @param {number} a
@@ -1236,6 +1236,11 @@ export class Foo {
     }
 }
 
+export function __wbg_cast_38bad4997839d643(arg0, arg1) {
+    const ret = /* cast */(getStringFromWasm0(arg0, arg1));
+    return ret;
+};
+
 export function __wbg_foo_new(arg0) {
     const ret = Foo.__wrap(arg0);
     return ret;
@@ -1272,11 +1277,6 @@ export function __wbindgen_string_get(arg0, arg1) {
     var len1 = WASM_VECTOR_LEN;
     getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
     getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
-};
-
-export function __wbindgen_string_new(arg0, arg1) {
-    const ret = getStringFromWasm0(arg0, arg1);
-    return ret;
 };
 
 export function __wbindgen_throw(arg0, arg1) {

--- a/crates/cli/tests/reference/modules.js
+++ b/crates/cli/tests/reference/modules.js
@@ -40,6 +40,11 @@ export function exported() {
     wasm.exported();
 }
 
+export function __wbg_cast_38bad4997839d643(arg0, arg1) {
+    const ret = /* cast */(getStringFromWasm0(arg0, arg1));
+    return ret;
+};
+
 export function __wbg_parseFloat_2be7f01c31025438(arg0, arg1) {
     const ret = parseFloat(getStringFromWasm0(arg0, arg1));
     return ret;
@@ -59,11 +64,6 @@ export function __wbindgen_init_externref_table() {
     table.set(offset + 2, true);
     table.set(offset + 3, false);
     ;
-};
-
-export function __wbindgen_string_new(arg0, arg1) {
-    const ret = getStringFromWasm0(arg0, arg1);
-    return ret;
 };
 
 export function __wbindgen_throw(arg0, arg1) {

--- a/crates/cli/tests/reference/result.js
+++ b/crates/cli/tests/reference/result.js
@@ -86,6 +86,11 @@ export function __wbg_Error_fcfdb1a705a32d74(arg0, arg1) {
     return ret;
 };
 
+export function __wbg_cast_55f8fbc0872e729e(arg0) {
+    const ret = /* cast */(arg0);
+    return ret;
+};
+
 export function __wbindgen_init_externref_table() {
     const table = wasm.__wbindgen_export_0;
     const offset = table.grow(4);
@@ -95,11 +100,6 @@ export function __wbindgen_init_externref_table() {
     table.set(offset + 2, true);
     table.set(offset + 3, false);
     ;
-};
-
-export function __wbindgen_number_new(arg0) {
-    const ret = arg0;
-    return ret;
 };
 
 export function __wbindgen_throw(arg0, arg1) {

--- a/crates/cli/tests/reference/static.js
+++ b/crates/cli/tests/reference/static.js
@@ -50,6 +50,11 @@ export function exported() {
     wasm.exported();
 }
 
+export function __wbg_cast_32bcc2d10060d0c7(arg0) {
+    const ret = /* cast */(arg0);
+    return ret;
+};
+
 export function __wbg_static_accessor_NAMESPACE_OPTIONAL_c9a4344c544120f4() {
     const ret = typeof test === 'undefined' ? null : test?.NAMESPACE_OPTIONAL;
     return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);

--- a/src/cache/intern.rs
+++ b/src/cache/intern.rs
@@ -31,11 +31,14 @@ cfg_if! {
 
         fn intern_str(key: &str) {
             CACHE.with(|cache| {
-                let mut cache = cache.entries.borrow_mut();
+                let entries = &cache.entries;
 
                 // Can't use `entry` because `entry` requires a `String`
-                if !cache.contains_key(key) {
-                    cache.insert(key.to_owned(), JsValue::from(key));
+                if !entries.borrow().contains_key(key) {
+                    // Note: we must not hold the borrow while we create the `JsValue`,
+                    // because it will try to look up the value in the cache first.
+                    let value = JsValue::from(key);
+                    entries.borrow_mut().insert(key.to_owned(), value);
                 }
             })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ impl JsValue {
     #[allow(clippy::should_implement_trait)] // cannot fix without breaking change
     #[inline]
     pub fn from_str(s: &str) -> JsValue {
-        unsafe { JsValue::_new(__wbindgen_string_new(s.as_ptr(), s.len())) }
+        wbg_cast!(s, &str, JsValue)
     }
 
     /// Creates a new JS value which is a number.
@@ -203,7 +203,7 @@ impl JsValue {
     /// allocated number) and returns a handle to the JS version of it.
     #[inline]
     pub fn from_f64(n: f64) -> JsValue {
-        unsafe { JsValue::_new(__wbindgen_number_new(n)) }
+        wbg_cast!(n, f64, JsValue)
     }
 
     /// Creates a new JS value which is a bigint from a string representing a number.
@@ -533,7 +533,7 @@ impl JsValue {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
     #[inline]
     pub fn unchecked_into_f64(&self) -> f64 {
-        unsafe { __wbindgen_as_number(self.idx) }
+        wbg_cast!(self, &JsValue, f64)
     }
 }
 
@@ -961,7 +961,7 @@ macro_rules! numbers {
 numbers! { i8 u8 i16 u16 i32 u32 f32 f64 }
 
 macro_rules! big_numbers {
-    (|$arg:ident|, $($n:ident = $handle:expr,)*) => ($(
+    ($($n:ident)*) => ($(
         impl PartialEq<$n> for JsValue {
             #[inline]
             fn eq(&self, other: &$n) -> bool {
@@ -971,8 +971,8 @@ macro_rules! big_numbers {
 
         impl From<$n> for JsValue {
             #[inline]
-            fn from($arg: $n) -> JsValue {
-                unsafe { JsValue::_new($handle) }
+            fn from(arg: $n) -> JsValue {
+                wbg_cast!(arg, $n, JsValue)
             }
         }
     )*)
@@ -1034,13 +1034,7 @@ macro_rules! try_from_for_num128 {
 try_from_for_num128!(i128, i64);
 try_from_for_num128!(u128, u64);
 
-big_numbers! {
-    |n|,
-    i64 = __wbindgen_bigint_from_i64(n),
-    u64 = __wbindgen_bigint_from_u64(n),
-    i128 = __wbindgen_bigint_from_i128((n >> 64) as i64, n as u64),
-    u128 = __wbindgen_bigint_from_u128((n >> 64) as u64, n as u64),
-}
+big_numbers! { i64 u64 i128 u128 }
 
 // `usize` and `isize` have to be treated a bit specially, because we know that
 // they're 32-bit but the compiler conservatively assumes they might be bigger.
@@ -1098,15 +1092,8 @@ extern "C" {
 externs! {
     #[link(wasm_import_module = "__wbindgen_placeholder__")]
     extern "C" {
-        fn __wbindgen_object_clone_ref(idx: u32) -> u32;
         fn __wbindgen_object_drop_ref(idx: u32) -> ();
 
-        fn __wbindgen_string_new(ptr: *const u8, len: usize) -> u32;
-        fn __wbindgen_number_new(f: f64) -> u32;
-        fn __wbindgen_bigint_from_i64(n: i64) -> u32;
-        fn __wbindgen_bigint_from_u64(n: u64) -> u32;
-        fn __wbindgen_bigint_from_i128(hi: i64, lo: u64) -> u32;
-        fn __wbindgen_bigint_from_u128(hi: u64, lo: u64) -> u32;
 
         fn __wbindgen_externref_heap_live_count() -> u32;
 
@@ -1122,7 +1109,6 @@ externs! {
         fn __wbindgen_in(prop: u32, obj: u32) -> u32;
 
         fn __wbindgen_is_falsy(idx: u32) -> u32;
-        fn __wbindgen_as_number(idx: u32) -> f64;
         fn __wbindgen_try_into_number(idx: u32) -> u32;
         fn __wbindgen_neg(idx: u32) -> u32;
         fn __wbindgen_bit_and(a: u32, b: u32) -> u32;
@@ -1164,21 +1150,6 @@ externs! {
 
         fn __wbindgen_copy_to_typed_array(ptr: *const u8, len: usize, idx: u32) -> ();
 
-        fn __wbindgen_uint8_array_new(ptr: *mut u8, len: usize) -> u32;
-        fn __wbindgen_uint8_clamped_array_new(ptr: *mut u8, len: usize) -> u32;
-        fn __wbindgen_uint16_array_new(ptr: *mut u16, len: usize) -> u32;
-        fn __wbindgen_uint32_array_new(ptr: *mut u32, len: usize) -> u32;
-        fn __wbindgen_biguint64_array_new(ptr: *mut u64, len: usize) -> u32;
-        fn __wbindgen_int8_array_new(ptr: *mut i8, len: usize) -> u32;
-        fn __wbindgen_int16_array_new(ptr: *mut i16, len: usize) -> u32;
-        fn __wbindgen_int32_array_new(ptr: *mut i32, len: usize) -> u32;
-        fn __wbindgen_bigint64_array_new(ptr: *mut i64, len: usize) -> u32;
-        fn __wbindgen_float32_array_new(ptr: *mut f32, len: usize) -> u32;
-        fn __wbindgen_float64_array_new(ptr: *mut f64, len: usize) -> u32;
-
-        fn __wbindgen_array_new() -> u32;
-        fn __wbindgen_array_push(array: u32, value: u32) -> ();
-
         fn __wbindgen_not(idx: u32) -> u32;
 
         fn __wbindgen_exports() -> u32;
@@ -1191,10 +1162,7 @@ externs! {
 impl Clone for JsValue {
     #[inline]
     fn clone(&self) -> JsValue {
-        unsafe {
-            let idx = __wbindgen_object_clone_ref(self.idx);
-            JsValue::_new(idx)
-        }
+        wbg_cast!(self, &JsValue, JsValue)
     }
 }
 
@@ -1736,55 +1704,32 @@ impl From<JsError> for JsValue {
 }
 
 macro_rules! typed_arrays {
-        ($($ty:ident $ctor:ident $clamped_ctor:ident,)*) => {
-            $(
-                impl From<Box<[$ty]>> for JsValue {
-                    fn from(mut vector: Box<[$ty]>) -> Self {
-                        let result = unsafe { JsValue::_new($ctor(vector.as_mut_ptr(), vector.len())) };
-                        mem::forget(vector);
-                        result
-                    }
-                }
+    ($($ty:ident)*) => {$(
+        impl From<Box<[$ty]>> for JsValue {
+            fn from(vector: Box<[$ty]>) -> Self {
+                wbg_cast!(vector, Box<[$ty]>, JsValue)
+            }
+        }
 
-                impl From<Clamped<Box<[$ty]>>> for JsValue {
-                    fn from(mut vector: Clamped<Box<[$ty]>>) -> Self {
-                        let result = unsafe { JsValue::_new($clamped_ctor(vector.as_mut_ptr(), vector.len())) };
-                        mem::forget(vector);
-                        result
-                    }
-                }
-            )*
-        };
-    }
-
-typed_arrays! {
-    u8 __wbindgen_uint8_array_new __wbindgen_uint8_clamped_array_new,
-    u16 __wbindgen_uint16_array_new __wbindgen_uint16_array_new,
-    u32 __wbindgen_uint32_array_new __wbindgen_uint32_array_new,
-    u64 __wbindgen_biguint64_array_new __wbindgen_biguint64_array_new,
-    i8 __wbindgen_int8_array_new __wbindgen_int8_array_new,
-    i16 __wbindgen_int16_array_new __wbindgen_int16_array_new,
-    i32 __wbindgen_int32_array_new __wbindgen_int32_array_new,
-    i64 __wbindgen_bigint64_array_new __wbindgen_bigint64_array_new,
-    f32 __wbindgen_float32_array_new __wbindgen_float32_array_new,
-    f64 __wbindgen_float64_array_new __wbindgen_float64_array_new,
+        impl From<Clamped<Box<[$ty]>>> for JsValue {
+            fn from(vector: Clamped<Box<[$ty]>>) -> Self {
+                wbg_cast!(vector, Clamped<Box<[$ty]>>, JsValue)
+            }
+        }
+    )*};
 }
+
+typed_arrays!(u8 u16 u32 u64 i8 i16 i32 i64 f32 f64);
 
 impl __rt::VectorIntoJsValue for JsValue {
     fn vector_into_jsvalue(vector: Box<[JsValue]>) -> JsValue {
-        __rt::js_value_vector_into_jsvalue::<JsValue>(vector)
-    }
-}
-
-impl<T: JsObject> __rt::VectorIntoJsValue for T {
-    fn vector_into_jsvalue(vector: Box<[T]>) -> JsValue {
-        __rt::js_value_vector_into_jsvalue::<T>(vector)
+        wbg_cast!(vector, Box<[JsValue]>, JsValue)
     }
 }
 
 impl __rt::VectorIntoJsValue for String {
     fn vector_into_jsvalue(vector: Box<[String]>) -> JsValue {
-        __rt::js_value_vector_into_jsvalue::<String>(vector)
+        wbg_cast!(vector, Box<[String]>, JsValue)
     }
 }
 


### PR DESCRIPTION
Reintroduces https://github.com/wasm-bindgen/wasm-bindgen/pull/4579, to be landed after the current release.

The comment on the macro is longer than implementation itself, but TLDR this hacky macro allows us to significantly reduce number of specially supported intrinsics in favour of just going via JS + wasm-bindgen's existing type conversions.

It also provided basis that allows us to remove even more intrinsics in future PRs.