### PR TITLE
Downgrade some debug logs to trace

### DIFF
--- a/crates/cli-support/src/interpreter/mod.rs
+++ b/crates/cli-support/src/interpreter/mod.rs
@@ -255,8 +255,8 @@ impl Interpreter {
 
     fn call(&mut self, id: FunctionId, module: &Module, args: &[i32]) -> Option<i32> {
         let func = module.funcs.get(id);
-        log::debug!("starting a call of {:?} {:?}", id, func.name);
-        log::debug!("arguments {args:?}");
+        log::trace!("starting a call of {:?} {:?}", id, func.name);
+        log::trace!("arguments {args:?}");
         let local = match &func.kind {
             walrus::FunctionKind::Local(l) => l,
             _ => panic!("can only call locally defined functions"),
@@ -367,12 +367,12 @@ impl Frame<'_> {
             }
 
             Instr::Return(_) => {
-                log::debug!("return");
+                log::trace!("return");
                 self.done = true;
             }
 
             Instr::Drop(_) => {
-                log::debug!("drop");
+                log::trace!("drop");
                 stack.pop().unwrap();
             }
 
@@ -385,7 +385,7 @@ impl Frame<'_> {
                 // here by directly inlining it.
                 if Some(func) == self.interp.describe_id {
                     let val = stack.pop().unwrap();
-                    log::debug!("__wbindgen_describe({val})");
+                    log::trace!("__wbindgen_describe({val})");
                     self.interp.descriptor.push(val as u32);
 
                 // If this function is calling the `__wbindgen_describe_closure`
@@ -397,7 +397,7 @@ impl Frame<'_> {
                     let val = stack.pop().unwrap();
                     stack.pop();
                     stack.pop();
-                    log::debug!("__wbindgen_describe_closure({val})");
+                    log::trace!("__wbindgen_describe_closure({val})");
                     self.interp.descriptor_table_idx = Some(val as u32);
                     stack.push(0)
 
@@ -442,7 +442,7 @@ impl Frame<'_> {
                 }
 
                 if let Instr::ReturnCall(_) = instr {
-                    log::debug!("return_call");
+                    log::trace!("return_call");
                     self.done = true;
                 }
             }


### PR DESCRIPTION
Emitting a log on every single `__wbindgen_describe()` aka `inform()` call, let alone on some individual instructions is way too verbose when you just want to get some debug logging, and belongs at tracing level.