### PR TITLE
Fix non-cross-platform link_to test

### DIFF
--- a/tests/wasm/link_to.rs
+++ b/tests/wasm/link_to.rs
@@ -10,7 +10,10 @@ extern "C" {
 #[wasm_bindgen_test]
 fn test_module() {
     let link = wasm_bindgen::link_to!(module = "/tests/wasm/linked_module.js");
-    assert_eq!(read_file(&link).unwrap(), "// linked module\n");
+    assert_eq!(
+        read_file(&link).unwrap(),
+        include_str!("./linked_module.js")
+    );
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
The line ending differs between systems, so this test fails on Windows.

`include_str!` avoids that issue, and also makes the test more future-proof in the process (in case content ever changes).