### PR TITLE
Remove dead VectorIntoJsValue trait

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -452,13 +452,6 @@ impl ToTokens for ast::Struct {
                     #wasm_bindgen::convert::js_value_vector_from_abi(js)
                 }
             }
-
-            #[automatically_derived]
-            impl #wasm_bindgen::__rt::VectorIntoJsValue for #name {
-                fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#name]>) -> #wasm_bindgen::JsValue {
-                    #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#name]>, #wasm_bindgen::JsValue)
-                }
-            }
         })
         .to_tokens(tokens);
 
@@ -1154,13 +1147,6 @@ impl ToTokens for ast::ImportType {
                 }
 
                 impl JsObject for #rust_name {}
-
-                #[automatically_derived]
-                impl #wasm_bindgen::__rt::VectorIntoJsValue for #rust_name {
-                    fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#rust_name]>) -> #wasm_bindgen::JsValue {
-                        #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#rust_name]>, #wasm_bindgen::JsValue)
-                    }
-                }
             };
         })
         .to_tokens(tokens);
@@ -1720,13 +1706,6 @@ impl ToTokens for ast::Enum {
                     js: Self::Abi
                 ) -> #wasm_bindgen::__rt::alloc::boxed::Box<[#enum_name]> {
                     #wasm_bindgen::convert::js_value_vector_from_abi(js)
-                }
-            }
-
-            #[automatically_derived]
-            impl #wasm_bindgen::__rt::VectorIntoJsValue for #enum_name {
-                fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::alloc::boxed::Box<[#enum_name]>) -> #wasm_bindgen::JsValue {
-                    #wasm_bindgen::wbg_cast!(vector, #wasm_bindgen::__rt::alloc::boxed::Box<[#enum_name]>, #wasm_bindgen::JsValue)
                 }
             }
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1719,18 +1719,6 @@ macro_rules! typed_arrays {
 
 typed_arrays!(u8 u16 u32 u64 i8 i16 i32 i64 f32 f64);
 
-impl __rt::VectorIntoJsValue for JsValue {
-    fn vector_into_jsvalue(vector: Box<[JsValue]>) -> JsValue {
-        wbg_cast!(vector, Box<[JsValue]>, JsValue)
-    }
-}
-
-impl __rt::VectorIntoJsValue for String {
-    fn vector_into_jsvalue(vector: Box<[String]>) -> JsValue {
-        wbg_cast!(vector, Box<[String]>, JsValue)
-    }
-}
-
 impl<T> From<Vec<T>> for JsValue
 where
     JsValue: From<Box<[T]>>,

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -7,7 +7,6 @@ use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicU8, Ordering};
 
 use alloc::alloc::{alloc, dealloc, realloc, Layout};
-use alloc::boxed::Box;
 use alloc::rc::Rc;
 use once_cell::unsync::Lazy;
 
@@ -707,16 +706,4 @@ pub const fn encode_u32_to_fixed_len_bytes(value: u32) -> [u8; 5] {
     }
     result[4] = (value >> (7 * 4)) as u8;
     result
-}
-
-/// Trait for element types to implement `Into<JsValue>` for vectors of
-/// themselves, which isn't possible directly thanks to the orphan rule.
-pub trait VectorIntoJsValue: Sized {
-    fn vector_into_jsvalue(vector: Box<[Self]>) -> JsValue;
-}
-
-impl<T: VectorIntoJsValue> From<Box<[T]>> for JsValue {
-    fn from(vector: Box<[T]>) -> Self {
-        T::vector_into_jsvalue(vector)
-    }
 }


### PR DESCRIPTION
Looks like it's only implemented, but never used.