### PR TITLE
Fix intrinsic typo

### DIFF
--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -139,7 +139,7 @@ impl<'a> Context<'a> {
             "__wbindgen_object_clone_ref",
             vec![Descriptor::I32],
             Descriptor::I32,
-            AuxImport::Intrinsic(Intrinsic::Throw),
+            AuxImport::Intrinsic(Intrinsic::ObjectCloneRef),
         )?;
         self.add_aux_import_to_import_map(
             "__wbindgen_object_drop_ref",


### PR DESCRIPTION
Eeek, not sure why I typed that in the first place but this slipped by in #4636.

Another reason to fix CI not running with the non-externref JS fallback (as in externref mode this intrinsic gets replaced with an inline function)...