### PR TITLE
Inline __externref_heap_live_count

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -763,8 +763,7 @@ fn instruction(
             js.push(arg);
         }
 
-        Instruction::CallCore(_)
-        | Instruction::CallExport(_)
+        Instruction::CallExport(_)
         | Instruction::CallAdapter(_)
         | Instruction::CallTableElement(_)
         | Instruction::DeferFree { .. } => {
@@ -1542,11 +1541,6 @@ impl Invocation {
     fn from(instr: &Instruction, module: &Module) -> Result<Invocation, Error> {
         use Instruction::*;
         Ok(match instr {
-            CallCore(f) => Invocation::Core {
-                id: *f,
-                defer: false,
-            },
-
             DeferFree { free, .. } => Invocation::Core {
                 id: *free,
                 defer: true,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3092,9 +3092,7 @@ __wbg_set_wasm(wasm);"
                         call = Some(id);
                     }
                 }
-                Instruction::CallExport(_)
-                | Instruction::CallTableElement(_)
-                | Instruction::CallCore(_) => return Ok(false),
+                Instruction::CallExport(_) | Instruction::CallTableElement(_) => return Ok(false),
                 _ => {}
             }
         }

--- a/crates/cli-support/src/transforms/externref/mod.rs
+++ b/crates/cli-support/src/transforms/externref/mod.rs
@@ -63,7 +63,6 @@ pub struct Meta {
     pub alloc: Option<FunctionId>,
     pub drop: Option<FunctionId>,
     pub drop_slice: Option<FunctionId>,
-    pub live_count: Option<FunctionId>,
 }
 
 struct Transform<'a> {
@@ -214,7 +213,6 @@ impl Context {
         let mut heap_alloc = None;
         let mut heap_dealloc = None;
         let mut drop_slice = None;
-        let mut live_count = None;
 
         // Find exports of some intrinsics which we only need for a runtime
         // implementation.
@@ -228,7 +226,6 @@ impl Context {
                 "__externref_table_alloc" => heap_alloc = Some(f),
                 "__externref_table_dealloc" => heap_dealloc = Some(f),
                 "__externref_drop_slice" => drop_slice = Some(f),
-                "__externref_heap_live_count" => live_count = Some(f),
                 _ => continue,
             }
             to_delete.push(export.id());
@@ -284,7 +281,6 @@ impl Context {
             alloc: heap_alloc,
             drop: heap_dealloc,
             drop_slice,
-            live_count,
         })
     }
 }

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -98,8 +98,6 @@ pub enum AdapterType {
 
 #[derive(Debug, Clone)]
 pub enum Instruction {
-    /// Calls a function by its id.
-    CallCore(walrus::FunctionId),
     /// Call the deallocation function.
     DeferFree {
         free: walrus::FunctionId,
@@ -480,7 +478,7 @@ impl walrus::CustomSection for NonstandardWitSection {
             };
             for instr in instrs {
                 match instr.instr {
-                    DeferFree { free: f, .. } | CallCore(f) => {
+                    DeferFree { free: f, .. } => {
                         roots.push_func(f);
                     }
                     StoreRetptr { mem, .. }

--- a/src/externref.rs
+++ b/src/externref.rs
@@ -13,21 +13,14 @@ externs! {
     }
 }
 
-pub struct Slab {
+#[derive(Default)]
+struct Slab {
     data: Vec<usize>,
     head: usize,
     base: usize,
 }
 
 impl Slab {
-    fn new() -> Slab {
-        Slab {
-            data: Vec::new(),
-            head: 0,
-            base: 0,
-        }
-    }
-
     fn alloc(&mut self) -> usize {
         let ret = self.head;
         if ret == self.data.len() {
@@ -118,19 +111,18 @@ fn internal_error(_msg: &str) -> ! {
 // Management of `externref` is always thread local since an `externref` value
 // can't cross threads in wasm. Indices as a result are always thread-local.
 #[cfg_attr(target_feature = "atomics", thread_local)]
-static HEAP_SLAB: crate::__rt::LazyCell<Cell<Slab>> =
-    crate::__rt::LazyCell::new(|| Cell::new(Slab::new()));
+static HEAP_SLAB: crate::__rt::LazyCell<Cell<Slab>> = crate::__rt::LazyCell::new(Default::default);
+
+fn with_slab<R>(f: impl FnOnce(&mut Slab) -> R) -> R {
+    let mut slot = HEAP_SLAB.take();
+    let ret = f(&mut slot);
+    HEAP_SLAB.replace(slot);
+    ret
+}
 
 #[no_mangle]
 pub extern "C" fn __externref_table_alloc() -> usize {
-    HEAP_SLAB
-        .try_with(|slot| {
-            let mut slab = slot.replace(Slab::new());
-            let ret = slab.alloc();
-            slot.replace(slab);
-            ret
-        })
-        .unwrap_or_else(|_| internal_error("tls access failure"))
+    with_slab(|slab| slab.alloc())
 }
 
 #[no_mangle]
@@ -143,13 +135,7 @@ pub extern "C" fn __externref_table_dealloc(idx: usize) {
     unsafe {
         __wbindgen_externref_table_set_null(idx);
     }
-    HEAP_SLAB
-        .try_with(|slot| {
-            let mut slab = slot.replace(Slab::new());
-            slab.dealloc(idx);
-            slot.replace(slab);
-        })
-        .unwrap_or_else(|_| internal_error("tls access failure"))
+    with_slab(|slab| slab.dealloc(idx))
 }
 
 #[no_mangle]
@@ -162,12 +148,5 @@ pub unsafe extern "C" fn __externref_drop_slice(ptr: *mut JsValue, len: usize) {
 // Implementation of `__wbindgen_externref_heap_live_count` for when we are using
 // `externref` instead of the JS `heap`.
 pub fn __wbindgen_externref_heap_live_count() -> u32 {
-    HEAP_SLAB
-        .try_with(|slot| {
-            let slab = slot.replace(Slab::new());
-            let count = slab.live_count();
-            slot.replace(slab);
-            count
-        })
-        .unwrap_or_else(|_| internal_error("tls access failure"))
+    with_slab(|slab| slab.live_count())
 }

--- a/src/externref.rs
+++ b/src/externref.rs
@@ -161,8 +161,7 @@ pub unsafe extern "C" fn __externref_drop_slice(ptr: *mut JsValue, len: usize) {
 
 // Implementation of `__wbindgen_externref_heap_live_count` for when we are using
 // `externref` instead of the JS `heap`.
-#[no_mangle]
-pub unsafe extern "C" fn __externref_heap_live_count() -> u32 {
+pub fn __wbindgen_externref_heap_live_count() -> u32 {
     HEAP_SLAB
         .try_with(|slot| {
             let slab = slot.replace(Slab::new());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,12 @@ pub use wasm_bindgen_macro::link_to;
 pub mod closure;
 pub mod convert;
 pub mod describe;
-mod externref;
 mod link;
+
+#[cfg(target_feature = "reference-types")]
+mod externref;
+#[cfg(target_feature = "reference-types")]
+use externref::__wbindgen_externref_heap_live_count;
 
 mod cast;
 pub use crate::cast::{JsCast, JsObject};
@@ -1083,6 +1087,7 @@ extern "C" {
 // standard wasm-bindgen ABI conversions.
 #[wasm_bindgen_macro::wasm_bindgen(wasm_bindgen = crate, raw_module = "__wbindgen_placeholder__")]
 extern "C" {
+    #[cfg(not(target_feature = "reference-types"))]
     fn __wbindgen_externref_heap_live_count() -> u32;
 
     fn __wbindgen_is_null(js: &JsValue) -> bool;

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -109,13 +109,6 @@ impl<T, F> LazyCell<T, F> {
 }
 
 impl<T, F: FnOnce() -> T> LazyCell<T, F> {
-    pub(crate) fn try_with<R>(
-        &self,
-        f: impl FnOnce(&T) -> R,
-    ) -> Result<R, core::convert::Infallible> {
-        Ok(f(&self.0 .0))
-    }
-
     pub fn force(this: &Self) -> &T {
         &this.0 .0
     }


### PR DESCRIPTION
Instead of declaring it as a C export in the externref runtime module, having the externref transform search for it and the "proper" `__wbindgen_externref_heap_live_count` intrinsic, and having the transform replace one with another, we can just use a `cfg(target_feature = "reference-types")` to choose the right implementation in the first place.

This allows to remove quite a bit of no longer used transitive code for such a small function.