### PR TITLE
fix --experimental-reset-state-function heap reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 * Fixed wasm-bindgen-cli's `encode_into` argument not working.
   [#4663](https://github.com/wasm-bindgen/wasm-bindgen/pull/4663)
+
 * Fixed a bug in `--experimental-reset-state-function` support for heap reset.
+  [#4665](https://github.com/wasm-bindgen/wasm-bindgen/pull/4665)
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fixed wasm-bindgen-cli's `encode_into` argument not working.
   [#4663](https://github.com/wasm-bindgen/wasm-bindgen/pull/4663)
+* Fixed a bug in `--experimental-reset-state-function` support for heap reset.
 
 --------------------------------------------------------------------------------
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1409,7 +1409,7 @@ wasm = wasmInstance.exports;
         }
         assert!(!self.config.externref);
         self.global(&format!(
-            "const heap = new Array({INITIAL_HEAP_OFFSET}).fill(undefined);"
+            "let heap = new Array({INITIAL_HEAP_OFFSET}).fill(undefined);"
         ));
         self.global(&format!("heap.push({});", INITIAL_HEAP_VALUES.join(", ")));
     }


### PR DESCRIPTION
Fixes the heap reset const assignment bug for the new `--experimental-reset-state-function` feature.