### PR TITLE
Fix Symbol.dispose override, use Symbol.dispose by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * Added bindings for `WeakRef`.
   [#4659](https://github.com/wasm-bindgen/wasm-bindgen/pull/4659)
+* Support `Symbol.dispose` by default, without overwriting the global `Symbol.dispose`
+  when unsupported, using `Symbol.for('wbg_symbol_dispose')` when unavailable.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 
 * Added bindings for `WeakRef`.
   [#4659](https://github.com/wasm-bindgen/wasm-bindgen/pull/4659)
+
 * Support `Symbol.dispose` by default, without overwriting the global `Symbol.dispose`
   when unsupported, using `Symbol.for('wbg_symbol_dispose')` when unavailable.
+  [#4666](https://github.com/wasm-bindgen/wasm-bindgen/pull/4666)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 * Added bindings for `WeakRef`.
   [#4659](https://github.com/wasm-bindgen/wasm-bindgen/pull/4659)
 
-* Support `Symbol.dispose` by default, without overwriting the global `Symbol.dispose`
-  when unsupported, using `Symbol.for('wbg_symbol_dispose')` when unavailable.
+* Support `Symbol.dispose` methods by default, when it is supported in the environment.
   [#4666](https://github.com/wasm-bindgen/wasm-bindgen/pull/4666)
 
 ### Fixed

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1238,7 +1238,7 @@ wasm = wasmInstance.exports;
             }}
             ",
         );
-        ts_dst.push_str("  [symbolDispose](): void;\n");
+        ts_dst.push_str("  [Symbol.dispose](): void;\n");
         dst.push_str(&class.contents);
         ts_dst.push_str(&class.typescript);
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1734,7 +1734,7 @@ wasm = wasmInstance.exports;
         if !self.should_write_global("symbol_dispose") {
             return Ok(());
         }
-        self.global("const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');");
+        self.global("const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');");
         Ok(())
     }
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -40,7 +40,6 @@ pub struct Bindgen {
     multi_value: bool,
     encode_into: EncodeInto,
     split_linked_modules: bool,
-    symbol_dispose: bool,
     generate_reset_state: bool,
 }
 
@@ -90,7 +89,6 @@ impl Bindgen {
         let externref =
             env::var("WASM_BINDGEN_ANYREF").is_ok() || env::var("WASM_BINDGEN_EXTERNREF").is_ok();
         let multi_value = env::var("WASM_BINDGEN_MULTI_VALUE").is_ok();
-        let symbol_dispose = env::var("WASM_BINDGEN_EXPERIMENTAL_SYMBOL_DISPOSE").is_ok();
         Bindgen {
             input: Input::None,
             out_name: None,
@@ -111,7 +109,6 @@ impl Bindgen {
             encode_into: EncodeInto::Test,
             omit_default_module_path: true,
             split_linked_modules: false,
-            symbol_dispose,
             generate_reset_state: false,
         }
     }

--- a/crates/cli/tests/reference/builder.d.ts
+++ b/crates/cli/tests/reference/builder.d.ts
@@ -3,6 +3,6 @@
 export class ClassBuilder {
   private constructor();
   free(): void;
-  [symbolDispose](): void;
+  [Symbol.dispose](): void;
   static builder(): ClassBuilder;
 }

--- a/crates/cli/tests/reference/builder.d.ts
+++ b/crates/cli/tests/reference/builder.d.ts
@@ -3,5 +3,6 @@
 export class ClassBuilder {
   private constructor();
   free(): void;
+  [symbolDispose](): void;
   static builder(): ClassBuilder;
 }

--- a/crates/cli/tests/reference/builder.js
+++ b/crates/cli/tests/reference/builder.js
@@ -40,8 +40,6 @@ const ClassBuilderFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_classbuilder_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
-
 export class ClassBuilder {
 
     static __wrap(ptr) {
@@ -63,10 +61,6 @@ export class ClassBuilder {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_classbuilder_free(ptr, 0);
     }
-
-    [symbolDispose]() {{
-        this.free();
-    }}
     /**
      * @returns {ClassBuilder}
      */
@@ -75,6 +69,7 @@ export class ClassBuilder {
         return ClassBuilder.__wrap(ret);
     }
 }
+if (Symbol.dispose) ClassBuilder.prototype[Symbol.dispose] = ClassBuilder.prototype.free;
 
 export function __wbg_wbindgenthrow_4c11a24fca429ccf(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/builder.js
+++ b/crates/cli/tests/reference/builder.js
@@ -40,6 +40,8 @@ const ClassBuilderFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_classbuilder_free(ptr >>> 0, 1));
 
+const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+
 export class ClassBuilder {
 
     static __wrap(ptr) {
@@ -61,6 +63,10 @@ export class ClassBuilder {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_classbuilder_free(ptr, 0);
     }
+
+    [symbolDispose]() {{
+        this.free();
+    }}
     /**
      * @returns {ClassBuilder}
      */

--- a/crates/cli/tests/reference/builder.js
+++ b/crates/cli/tests/reference/builder.js
@@ -40,7 +40,7 @@ const ClassBuilderFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_classbuilder_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
 
 export class ClassBuilder {
 

--- a/crates/cli/tests/reference/constructor.d.ts
+++ b/crates/cli/tests/reference/constructor.d.ts
@@ -2,5 +2,6 @@
 /* eslint-disable */
 export class ClassConstructor {
   free(): void;
+  [symbolDispose](): void;
   constructor();
 }

--- a/crates/cli/tests/reference/constructor.d.ts
+++ b/crates/cli/tests/reference/constructor.d.ts
@@ -2,6 +2,6 @@
 /* eslint-disable */
 export class ClassConstructor {
   free(): void;
-  [symbolDispose](): void;
+  [Symbol.dispose](): void;
   constructor();
 }

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -40,8 +40,6 @@ const ClassConstructorFinalization = (typeof FinalizationRegistry === 'undefined
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_classconstructor_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
-
 export class ClassConstructor {
 
     __destroy_into_raw() {
@@ -55,10 +53,6 @@ export class ClassConstructor {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_classconstructor_free(ptr, 0);
     }
-
-    [symbolDispose]() {{
-        this.free();
-    }}
     constructor() {
         const ret = wasm.classconstructor_new();
         this.__wbg_ptr = ret >>> 0;
@@ -66,6 +60,7 @@ export class ClassConstructor {
         return this;
     }
 }
+if (Symbol.dispose) ClassConstructor.prototype[Symbol.dispose] = ClassConstructor.prototype.free;
 
 export function __wbg_wbindgenthrow_4c11a24fca429ccf(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -40,7 +40,7 @@ const ClassConstructorFinalization = (typeof FinalizationRegistry === 'undefined
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_classconstructor_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
 
 export class ClassConstructor {
 

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -40,6 +40,8 @@ const ClassConstructorFinalization = (typeof FinalizationRegistry === 'undefined
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_classconstructor_free(ptr >>> 0, 1));
 
+const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+
 export class ClassConstructor {
 
     __destroy_into_raw() {
@@ -53,6 +55,10 @@ export class ClassConstructor {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_classconstructor_free(ptr, 0);
     }
+
+    [symbolDispose]() {{
+        this.free();
+    }}
     constructor() {
         const ret = wasm.classconstructor_new();
         this.__wbg_ptr = ret >>> 0;

--- a/crates/cli/tests/reference/echo.d.ts
+++ b/crates/cli/tests/reference/echo.d.ts
@@ -75,4 +75,5 @@ export function echo_option_vec_struct(a?: Foo[] | null): Foo[] | undefined;
 export class Foo {
   private constructor();
   free(): void;
+  [symbolDispose](): void;
 }

--- a/crates/cli/tests/reference/echo.d.ts
+++ b/crates/cli/tests/reference/echo.d.ts
@@ -75,5 +75,5 @@ export function echo_option_vec_struct(a?: Foo[] | null): Foo[] | undefined;
 export class Foo {
   private constructor();
   free(): void;
-  [symbolDispose](): void;
+  [Symbol.dispose](): void;
 }

--- a/crates/cli/tests/reference/echo.js
+++ b/crates/cli/tests/reference/echo.js
@@ -1206,7 +1206,7 @@ const FooFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_foo_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
 
 export class Foo {
 

--- a/crates/cli/tests/reference/echo.js
+++ b/crates/cli/tests/reference/echo.js
@@ -1206,6 +1206,8 @@ const FooFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_foo_free(ptr >>> 0, 1));
 
+const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+
 export class Foo {
 
     static __wrap(ptr) {
@@ -1234,6 +1236,10 @@ export class Foo {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_foo_free(ptr, 0);
     }
+
+    [symbolDispose]() {{
+        this.free();
+    }}
 }
 
 export function __wbg_foo_new(arg0) {

--- a/crates/cli/tests/reference/echo.js
+++ b/crates/cli/tests/reference/echo.js
@@ -1206,8 +1206,6 @@ const FooFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_foo_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
-
 export class Foo {
 
     static __wrap(ptr) {
@@ -1236,11 +1234,8 @@ export class Foo {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_foo_free(ptr, 0);
     }
-
-    [symbolDispose]() {{
-        this.free();
-    }}
 }
+if (Symbol.dispose) Foo.prototype[Symbol.dispose] = Foo.prototype.free;
 
 export function __wbg_foo_new(arg0) {
     const ret = Foo.__wrap(arg0);

--- a/crates/cli/tests/reference/function-attrs.d.ts
+++ b/crates/cli/tests/reference/function-attrs.d.ts
@@ -13,7 +13,7 @@ export function fn_with_attr(firstArg: number, secondArg: boolean | undefined): 
 export class HoldsNumber {
   private constructor();
   free(): void;
-  [symbolDispose](): void;
+  [Symbol.dispose](): void;
   /**
    * Description for static_fn_with_attr
    * @param firstArg - some number

--- a/crates/cli/tests/reference/function-attrs.d.ts
+++ b/crates/cli/tests/reference/function-attrs.d.ts
@@ -13,6 +13,7 @@ export function fn_with_attr(firstArg: number, secondArg: boolean | undefined): 
 export class HoldsNumber {
   private constructor();
   free(): void;
+  [symbolDispose](): void;
   /**
    * Description for static_fn_with_attr
    * @param firstArg - some number

--- a/crates/cli/tests/reference/getter-setter.d.ts
+++ b/crates/cli/tests/reference/getter-setter.d.ts
@@ -3,6 +3,7 @@
 export class Foo {
   private constructor();
   free(): void;
+  [symbolDispose](): void;
   x: number;
   get y(): number | undefined;
   set y(value: number | null | undefined);

--- a/crates/cli/tests/reference/getter-setter.d.ts
+++ b/crates/cli/tests/reference/getter-setter.d.ts
@@ -3,7 +3,7 @@
 export class Foo {
   private constructor();
   free(): void;
-  [symbolDispose](): void;
+  [Symbol.dispose](): void;
   x: number;
   get y(): number | undefined;
   set y(value: number | null | undefined);

--- a/crates/cli/tests/reference/getter-setter.js
+++ b/crates/cli/tests/reference/getter-setter.js
@@ -102,7 +102,7 @@ const FooFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_foo_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
 
 export class Foo {
 

--- a/crates/cli/tests/reference/getter-setter.js
+++ b/crates/cli/tests/reference/getter-setter.js
@@ -102,8 +102,6 @@ const FooFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_foo_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
-
 export class Foo {
 
     __destroy_into_raw() {
@@ -117,10 +115,6 @@ export class Foo {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_foo_free(ptr, 0);
     }
-
-    [symbolDispose]() {{
-        this.free();
-    }}
     /**
      * @returns {number}
      */
@@ -208,6 +202,7 @@ export class Foo {
         wasm.foo_set_x_static(isLikeNone(value) ? 0xFFFFFF : value ? 1 : 0);
     }
 }
+if (Symbol.dispose) Foo.prototype[Symbol.dispose] = Foo.prototype.free;
 
 export function __wbg_wbindgenthrow_4c11a24fca429ccf(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/getter-setter.js
+++ b/crates/cli/tests/reference/getter-setter.js
@@ -102,6 +102,8 @@ const FooFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_foo_free(ptr >>> 0, 1));
 
+const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+
 export class Foo {
 
     __destroy_into_raw() {
@@ -115,6 +117,10 @@ export class Foo {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_foo_free(ptr, 0);
     }
+
+    [symbolDispose]() {{
+        this.free();
+    }}
     /**
      * @returns {number}
      */

--- a/crates/cli/tests/reference/raw.d.ts
+++ b/crates/cli/tests/reference/raw.d.ts
@@ -4,7 +4,7 @@ export function test1(test: number): number;
 export class Test {
   private constructor();
   free(): void;
-  [symbolDispose](): void;
+  [Symbol.dispose](): void;
   static test1(test: number): Test;
   test2(test: number): void;
 }

--- a/crates/cli/tests/reference/raw.d.ts
+++ b/crates/cli/tests/reference/raw.d.ts
@@ -4,6 +4,7 @@ export function test1(test: number): number;
 export class Test {
   private constructor();
   free(): void;
+  [symbolDispose](): void;
   static test1(test: number): Test;
   test2(test: number): void;
 }

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -48,7 +48,7 @@ const TestFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_test_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
 
 export class Test {
 

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -48,6 +48,8 @@ const TestFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_test_free(ptr >>> 0, 1));
 
+const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+
 export class Test {
 
     static __wrap(ptr) {
@@ -69,6 +71,10 @@ export class Test {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_test_free(ptr, 0);
     }
+
+    [symbolDispose]() {{
+        this.free();
+    }}
     /**
      * @param {number} test
      * @returns {Test}

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -48,8 +48,6 @@ const TestFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_test_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
-
 export class Test {
 
     static __wrap(ptr) {
@@ -71,10 +69,6 @@ export class Test {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_test_free(ptr, 0);
     }
-
-    [symbolDispose]() {{
-        this.free();
-    }}
     /**
      * @param {number} test
      * @returns {Test}
@@ -90,6 +84,7 @@ export class Test {
         wasm.test_test2(this.__wbg_ptr, test);
     }
 }
+if (Symbol.dispose) Test.prototype[Symbol.dispose] = Test.prototype.free;
 
 export function __wbg_wbindgenthrow_4c11a24fca429ccf(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/self-type.d.ts
+++ b/crates/cli/tests/reference/self-type.d.ts
@@ -2,6 +2,7 @@
 /* eslint-disable */
 export class Test {
   free(): void;
+  [symbolDispose](): void;
   constructor();
   consume_self(): void;
   ref_self(): void;

--- a/crates/cli/tests/reference/self-type.d.ts
+++ b/crates/cli/tests/reference/self-type.d.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 export class Test {
   free(): void;
-  [symbolDispose](): void;
+  [Symbol.dispose](): void;
   constructor();
   consume_self(): void;
   ref_self(): void;

--- a/crates/cli/tests/reference/self-type.js
+++ b/crates/cli/tests/reference/self-type.js
@@ -40,7 +40,7 @@ const TestFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_test_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
 
 export class Test {
 

--- a/crates/cli/tests/reference/self-type.js
+++ b/crates/cli/tests/reference/self-type.js
@@ -40,8 +40,6 @@ const TestFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_test_free(ptr >>> 0, 1));
 
-const symbolDispose = Symbol.dispose || Symbol.for('wbg_symbol_dispose');
-
 export class Test {
 
     __destroy_into_raw() {
@@ -55,10 +53,6 @@ export class Test {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_test_free(ptr, 0);
     }
-
-    [symbolDispose]() {{
-        this.free();
-    }}
     constructor() {
         const ret = wasm.test_new();
         this.__wbg_ptr = ret >>> 0;
@@ -86,6 +80,7 @@ export class Test {
         wasm.test_self_ref_mut_Self(this.__wbg_ptr);
     }
 }
+if (Symbol.dispose) Test.prototype[Symbol.dispose] = Test.prototype.free;
 
 export function __wbg_wbindgenthrow_4c11a24fca429ccf(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/self-type.js
+++ b/crates/cli/tests/reference/self-type.js
@@ -40,6 +40,8 @@ const TestFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_test_free(ptr >>> 0, 1));
 
+const symbolDispose = Symbol.dispose || Symbol('Symbol.dispose');
+
 export class Test {
 
     __destroy_into_raw() {
@@ -53,6 +55,10 @@ export class Test {
         const ptr = this.__destroy_into_raw();
         wasm.__wbg_test_free(ptr, 0);
     }
+
+    [symbolDispose]() {{
+        this.free();
+    }}
     constructor() {
         const ret = wasm.test_new();
         this.__wbg_ptr = ret >>> 0;

--- a/examples/explicit-resource-management/package.json
+++ b/examples/explicit-resource-management/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"build": "cross-env WASM_BINDGEN_EXPERIMENTAL_SYMBOL_DISPOSE=1 wasm-pack build --target deno --out-dir ../dist/explicit-resource-management",
+		"build": "cross-env wasm-pack build --target deno --out-dir ../dist/explicit-resource-management",
 		"postbuild": "node ../cp-dist.mjs index.html"
 	},
 	"dependencies": {


### PR DESCRIPTION
Follow-on to https://github.com/wasm-bindgen/wasm-bindgen/pull/4514, resolves https://github.com/wasm-bindgen/wasm-bindgen/issues/4513.

To avoid overwriting `Symbol.dispose` when unavailable we instead use `Symbol.for('wbg_symbol_dispose')` as the symbol instead.