### PR TITLE
Fix memory import on all targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
+## [0.2.105](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.104...0.2.105)
+
+### Fixed
+
+* Fixed multithreading JS output for targets `bundler`, `deno` and `module`.
+
 ## [0.2.104](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.103...0.2.104)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
-## [0.2.105](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.104...0.2.105)
+## Unreleased
 
 ### Fixed
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -408,7 +408,7 @@ impl<'a> Context<'a> {
         if let Some(mem) = self.module.memories.iter().next() {
             if let Some(id) = mem.import {
                 self.module.imports.get_mut(id).module = PLACEHOLDER_MODULE.to_owned();
-                let mut init_memory = format!("new WebAssembly.Memory({{");
+                let mut init_memory = "new WebAssembly.Memory({".to_string();
                 init_memory.push_str(&format!("initial:{}", mem.initial));
                 if let Some(max) = mem.maximum {
                     init_memory.push_str(&format!(",maximum:{max}"));

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -975,8 +975,6 @@ wasm = wasmInstance.exports;
                         module_or_path = fetch(module_or_path);
                     }}
 
-                    __wbg_init_memory(imports{init_memory_arg});
-
                     const {{ instance, module }} = await __wbg_load(await module_or_path, imports);
 
                     return __wbg_finalize_init(instance, module{init_stack_size_arg});

--- a/crates/cli/tests/reference/import-target-web.js
+++ b/crates/cli/tests/reference/import-target-web.js
@@ -204,8 +204,6 @@ async function __wbg_init(module_or_path) {
         module_or_path = fetch(module_or_path);
     }
 
-    __wbg_init_memory(imports);
-
     const { instance, module } = await __wbg_load(await module_or_path, imports);
 
     return __wbg_finalize_init(instance, module);

--- a/crates/cli/tests/reference/import-target-web.js
+++ b/crates/cli/tests/reference/import-target-web.js
@@ -150,10 +150,6 @@ function __wbg_get_imports() {
     return imports;
 }
 
-function __wbg_init_memory(imports, memory) {
-
-}
-
 function __wbg_finalize_init(instance, module) {
     wasm = instance.exports;
     __wbg_init.__wbindgen_wasm_module = module;
@@ -177,8 +173,6 @@ function initSync(module) {
     }
 
     const imports = __wbg_get_imports();
-
-    __wbg_init_memory(imports);
 
     if (!(module instanceof WebAssembly.Module)) {
         module = new WebAssembly.Module(module);

--- a/crates/cli/tests/reference/targets-target-bundler-atomics.bg.js
+++ b/crates/cli/tests/reference/targets-target-bundler-atomics.bg.js
@@ -63,3 +63,5 @@ export function __wbindgen_init_externref_table() {
     ;
 };
 
+export const memory = new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
+

--- a/crates/cli/tests/reference/targets-target-bundler-atomics.wat
+++ b/crates/cli/tests/reference/targets-target-bundler-atomics.wat
@@ -8,7 +8,7 @@
   (import "./reference_test_bg.js" "__wbg_random_0000000000000000" (func (;0;) (type 1)))
   (import "./reference_test_bg.js" "__wbg_wbindgenthrow_0000000000000001" (func (;1;) (type 3)))
   (import "./reference_test_bg.js" "__wbindgen_init_externref_table" (func (;2;) (type 0)))
-  (import "env" "memory" (memory (;0;) 18 16384 shared))
+  (import "./reference_test_bg.js" "memory" (memory (;0;) 18 16384 shared))
   (func $add_that_might_fail (;3;) (type 4) (param i32 i32) (result i32))
   (func $__wbindgen_thread_destroy (;4;) (type 5) (param i32 i32 i32))
   (func (;5;) (type 2) (param i32))

--- a/crates/cli/tests/reference/targets-target-deno-atomics.js
+++ b/crates/cli/tests/reference/targets-target-deno-atomics.js
@@ -1,4 +1,4 @@
-import * as import0 from 'env'
+
 
 let cachedUint8ArrayMemory0 = null;
 
@@ -50,8 +50,9 @@ const imports = {
             table.set(offset + 3, false);
             ;
         },
+        memory: new WebAssembly.Memory({initial:18,maximum:16384,shared:true}),
     },
-    'env': import0,
+
 };
 
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);

--- a/crates/cli/tests/reference/targets-target-deno-atomics.wat
+++ b/crates/cli/tests/reference/targets-target-deno-atomics.wat
@@ -8,7 +8,7 @@
   (import "__wbindgen_placeholder__" "__wbg_random_0000000000000000" (func (;0;) (type 1)))
   (import "__wbindgen_placeholder__" "__wbg_wbindgenthrow_0000000000000001" (func (;1;) (type 3)))
   (import "__wbindgen_placeholder__" "__wbindgen_init_externref_table" (func (;2;) (type 0)))
-  (import "env" "memory" (memory (;0;) 18 16384 shared))
+  (import "__wbindgen_placeholder__" "memory" (memory (;0;) 18 16384 shared))
   (func $add_that_might_fail (;3;) (type 4) (param i32 i32) (result i32))
   (func $__wbindgen_thread_destroy (;4;) (type 5) (param i32 i32 i32))
   (func (;5;) (type 2) (param i32))

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.bg.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.bg.js
@@ -57,3 +57,5 @@ export function __wbindgen_init_externref_table() {
     ;
 };
 
+export const memory = new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
+

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.js
@@ -2,7 +2,7 @@
 let imports = {};
 import * as import0 from './reference_test_bg.js';
 imports['./reference_test_bg.js'] = import0;
-imports.wbg = { memory: new WebAssembly.Memory({initial:18,maximum:16384,shared:true}) };
+
 import { readFileSync } from 'node:fs';
 
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.wat
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.wat
@@ -8,7 +8,7 @@
   (import "./reference_test_bg.js" "__wbg_random_0000000000000000" (func (;0;) (type 1)))
   (import "./reference_test_bg.js" "__wbg_wbindgenthrow_0000000000000001" (func (;1;) (type 3)))
   (import "./reference_test_bg.js" "__wbindgen_init_externref_table" (func (;2;) (type 0)))
-  (import "wbg" "memory" (memory (;0;) 18 16384 shared))
+  (import "./reference_test_bg.js" "memory" (memory (;0;) 18 16384 shared))
   (func $add_that_might_fail (;3;) (type 4) (param i32 i32) (result i32))
   (func $__wbindgen_thread_destroy (;4;) (type 5) (param i32 i32 i32))
   (func (;5;) (type 2) (param i32))

--- a/crates/cli/tests/reference/targets-target-module-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-atomics.js
@@ -1,7 +1,6 @@
 import source wasmModule from "./reference_test_bg.wasm";
 
 let wasm;
-import * as import0 from 'env'
 
 let cachedUint8ArrayMemory0 = null;
 
@@ -53,8 +52,9 @@ const imports = {
             table.set(offset + 3, false);
             ;
         },
+        memory: new WebAssembly.Memory({initial:18,maximum:16384,shared:true}),
     },
-    'env': import0,
+
 };
 
 const wasmInstance = new WebAssembly.Instance(wasmModule, imports);

--- a/crates/cli/tests/reference/targets-target-module-atomics.wat
+++ b/crates/cli/tests/reference/targets-target-module-atomics.wat
@@ -8,7 +8,7 @@
   (import "__wbindgen_placeholder__" "__wbg_random_0000000000000000" (func (;0;) (type 1)))
   (import "__wbindgen_placeholder__" "__wbg_wbindgenthrow_0000000000000001" (func (;1;) (type 3)))
   (import "__wbindgen_placeholder__" "__wbindgen_init_externref_table" (func (;2;) (type 0)))
-  (import "env" "memory" (memory (;0;) 18 16384 shared))
+  (import "__wbindgen_placeholder__" "memory" (memory (;0;) 18 16384 shared))
   (func $add_that_might_fail (;3;) (type 4) (param i32 i32) (result i32))
   (func $__wbindgen_thread_destroy (;4;) (type 5) (param i32 i32 i32))
   (func (;5;) (type 2) (param i32))

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
@@ -1,7 +1,6 @@
 import source wasmModule from "./reference_test_bg.wasm";
 
 let wasm;
-import * as import0 from 'env'
 
 let cachedUint8ArrayMemory0 = null;
 
@@ -64,8 +63,9 @@ const imports = {
             table.set(offset + 3, false);
             ;
         },
+        memory: new WebAssembly.Memory({initial:18,maximum:16384,shared:true}),
     },
-    'env': import0,
+
 };
 
 const wasmInstance = new WebAssembly.Instance(wasmModule, imports);

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.wat
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.wat
@@ -8,7 +8,7 @@
   (import "__wbindgen_placeholder__" "__wbg_random_0000000000000000" (func (;0;) (type 1)))
   (import "__wbindgen_placeholder__" "__wbg_wbindgenthrow_0000000000000001" (func (;1;) (type 3)))
   (import "__wbindgen_placeholder__" "__wbindgen_init_externref_table" (func (;2;) (type 0)))
-  (import "env" "memory" (memory (;0;) 18 16384 shared))
+  (import "__wbindgen_placeholder__" "memory" (memory (;0;) 18 16384 shared))
   (func $add_that_might_fail (;3;) (type 4) (param i32 i32) (result i32))
   (func $__wbindgen_thread_destroy (;4;) (type 5) (param i32 i32 i32))
   (func (;5;) (type 2) (param i32))

--- a/crates/cli/tests/reference/targets-target-no-modules-atomics.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-atomics.js
@@ -73,7 +73,7 @@ let wasm_bindgen;
         }
     }
 
-    function __wbg_get_imports() {
+    function __wbg_get_imports(memory) {
         const imports = {};
         imports.wbg = {};
         imports.wbg.__wbg_random_0000000000000000 = function() {
@@ -93,12 +93,9 @@ let wasm_bindgen;
             table.set(offset + 3, false);
             ;
         };
+        imports.wbg.memory = memory || new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
 
         return imports;
-    }
-
-    function __wbg_init_memory(imports, memory) {
-        imports.wbg.memory = memory || new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
     }
 
     function __wbg_finalize_init(instance, module, thread_stack_size) {
@@ -123,9 +120,7 @@ let wasm_bindgen;
             }
         }
 
-        const imports = __wbg_get_imports();
-
-        __wbg_init_memory(imports, memory);
+        const imports = __wbg_get_imports(memory);
 
         if (!(module instanceof WebAssembly.Module)) {
             module = new WebAssembly.Module(module);
@@ -151,7 +146,7 @@ let wasm_bindgen;
         if (typeof module_or_path === 'undefined' && typeof script_src !== 'undefined') {
             module_or_path = script_src.replace(/\.js$/, '_bg.wasm');
         }
-        const imports = __wbg_get_imports();
+        const imports = __wbg_get_imports(memory);
 
         if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
             module_or_path = fetch(module_or_path);

--- a/crates/cli/tests/reference/targets-target-no-modules-atomics.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-atomics.js
@@ -152,8 +152,6 @@ let wasm_bindgen;
             module_or_path = fetch(module_or_path);
         }
 
-        __wbg_init_memory(imports, memory);
-
         const { instance, module } = await __wbg_load(await module_or_path, imports);
 
         return __wbg_finalize_init(instance, module, thread_stack_size);

--- a/crates/cli/tests/reference/targets-target-no-modules.js
+++ b/crates/cli/tests/reference/targets-target-no-modules.js
@@ -125,8 +125,6 @@ let wasm_bindgen;
             module_or_path = fetch(module_or_path);
         }
 
-        __wbg_init_memory(imports);
-
         const { instance, module } = await __wbg_load(await module_or_path, imports);
 
         return __wbg_finalize_init(instance, module);

--- a/crates/cli/tests/reference/targets-target-no-modules.js
+++ b/crates/cli/tests/reference/targets-target-no-modules.js
@@ -72,10 +72,6 @@ let wasm_bindgen;
         return imports;
     }
 
-    function __wbg_init_memory(imports, memory) {
-
-    }
-
     function __wbg_finalize_init(instance, module) {
         wasm = instance.exports;
         __wbg_init.__wbindgen_wasm_module = module;
@@ -98,8 +94,6 @@ let wasm_bindgen;
         }
 
         const imports = __wbg_get_imports();
-
-        __wbg_init_memory(imports);
 
         if (!(module instanceof WebAssembly.Module)) {
             module = new WebAssembly.Module(module);

--- a/crates/cli/tests/reference/targets-target-nodejs-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-atomics.js
@@ -52,7 +52,9 @@ exports.__wbindgen_init_externref_table = function() {
     table.set(offset + 3, false);
     ;
 };
-imports.wbg = { memory: new WebAssembly.Memory({initial:18,maximum:16384,shared:true}) };
+
+exports.memory = new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
+
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);
 const wasmModule = new WebAssembly.Module(wasmBytes);

--- a/crates/cli/tests/reference/targets-target-nodejs-atomics.wat
+++ b/crates/cli/tests/reference/targets-target-nodejs-atomics.wat
@@ -8,7 +8,7 @@
   (import "__wbindgen_placeholder__" "__wbg_random_0000000000000000" (func (;0;) (type 1)))
   (import "__wbindgen_placeholder__" "__wbg_wbindgenthrow_0000000000000001" (func (;1;) (type 3)))
   (import "__wbindgen_placeholder__" "__wbindgen_init_externref_table" (func (;2;) (type 0)))
-  (import "wbg" "memory" (memory (;0;) 18 16384 shared))
+  (import "__wbindgen_placeholder__" "memory" (memory (;0;) 18 16384 shared))
   (func $add_that_might_fail (;3;) (type 4) (param i32 i32) (result i32))
   (func $__wbindgen_thread_destroy (;4;) (type 5) (param i32 i32 i32))
   (func (;5;) (type 2) (param i32))

--- a/crates/cli/tests/reference/targets-target-web-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-atomics.js
@@ -153,8 +153,6 @@ async function __wbg_init(module_or_path, memory) {
         module_or_path = fetch(module_or_path);
     }
 
-    __wbg_init_memory(imports, memory);
-
     const { instance, module } = await __wbg_load(await module_or_path, imports);
 
     return __wbg_finalize_init(instance, module, thread_stack_size);

--- a/crates/cli/tests/reference/targets-target-web-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-atomics.js
@@ -74,7 +74,7 @@ async function __wbg_load(module, imports) {
     }
 }
 
-function __wbg_get_imports() {
+function __wbg_get_imports(memory) {
     const imports = {};
     imports.wbg = {};
     imports.wbg.__wbg_random_0000000000000000 = function() {
@@ -94,12 +94,9 @@ function __wbg_get_imports() {
         table.set(offset + 3, false);
         ;
     };
+    imports.wbg.memory = memory || new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
 
     return imports;
-}
-
-function __wbg_init_memory(imports, memory) {
-    imports.wbg.memory = memory || new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
 }
 
 function __wbg_finalize_init(instance, module, thread_stack_size) {
@@ -124,9 +121,7 @@ function initSync(module, memory) {
         }
     }
 
-    const imports = __wbg_get_imports();
-
-    __wbg_init_memory(imports, memory);
+    const imports = __wbg_get_imports(memory);
 
     if (!(module instanceof WebAssembly.Module)) {
         module = new WebAssembly.Module(module);
@@ -152,7 +147,7 @@ async function __wbg_init(module_or_path, memory) {
     if (typeof module_or_path === 'undefined') {
         module_or_path = new URL('reference_test_bg.wasm', import.meta.url);
     }
-    const imports = __wbg_get_imports();
+    const imports = __wbg_get_imports(memory);
 
     if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
         module_or_path = fetch(module_or_path);

--- a/crates/cli/tests/reference/targets-target-web.js
+++ b/crates/cli/tests/reference/targets-target-web.js
@@ -66,10 +66,6 @@ function __wbg_get_imports() {
     return imports;
 }
 
-function __wbg_init_memory(imports, memory) {
-
-}
-
 function __wbg_finalize_init(instance, module) {
     wasm = instance.exports;
     __wbg_init.__wbindgen_wasm_module = module;
@@ -92,8 +88,6 @@ function initSync(module) {
     }
 
     const imports = __wbg_get_imports();
-
-    __wbg_init_memory(imports);
 
     if (!(module instanceof WebAssembly.Module)) {
         module = new WebAssembly.Module(module);

--- a/crates/cli/tests/reference/targets-target-web.js
+++ b/crates/cli/tests/reference/targets-target-web.js
@@ -119,8 +119,6 @@ async function __wbg_init(module_or_path) {
         module_or_path = fetch(module_or_path);
     }
 
-    __wbg_init_memory(imports);
-
     const { instance, module } = await __wbg_load(await module_or_path, imports);
 
     return __wbg_finalize_init(instance, module);

--- a/crates/cli/tests/reference/wasm-export-types.js
+++ b/crates/cli/tests/reference/wasm-export-types.js
@@ -169,10 +169,6 @@ function __wbg_get_imports() {
     return imports;
 }
 
-function __wbg_init_memory(imports, memory) {
-
-}
-
 function __wbg_finalize_init(instance, module) {
     wasm = instance.exports;
     __wbg_init.__wbindgen_wasm_module = module;
@@ -196,8 +192,6 @@ function initSync(module) {
     }
 
     const imports = __wbg_get_imports();
-
-    __wbg_init_memory(imports);
 
     if (!(module instanceof WebAssembly.Module)) {
         module = new WebAssembly.Module(module);

--- a/crates/cli/tests/reference/wasm-export-types.js
+++ b/crates/cli/tests/reference/wasm-export-types.js
@@ -223,8 +223,6 @@ async function __wbg_init(module_or_path) {
         module_or_path = fetch(module_or_path);
     }
 
-    __wbg_init_memory(imports);
-
     const { instance, module } = await __wbg_load(await module_or_path, imports);
 
     return __wbg_finalize_init(instance, module);


### PR DESCRIPTION
This moves memory import handling to target-independent portion of processing, which both simplifies code a bit and fixes the atomics JS output for multiple targets at once where previously they'd try to import memory from `env` JS module, which doesn't exist.