### PR TITLE
Add integration test for experimental-nodejs-module

### DIFF
--- a/examples/nodejs_and_deno/cargo-and-wasm-bindgen.js
+++ b/examples/nodejs_and_deno/cargo-and-wasm-bindgen.js
@@ -1,0 +1,27 @@
+import { execFileSync } from 'node:child_process';
+import * as assert from 'node:assert/strict';
+
+let { reason, filenames } = JSON.parse(execFileSync(
+  'cargo',
+  [
+    'build',
+    '--target',
+    'wasm32-unknown-unknown',
+    '--release',
+    '--message-format=json'
+  ],
+  {
+    stdio: ['inherit', 'pipe', 'inherit'],
+    encoding: 'utf-8'
+  }
+)
+  .trimEnd()
+  .split('\n')
+  .at(-2));
+
+assert.equal(reason, 'compiler-artifact', 'the message before the build-finished message should be a compiler-artifact');
+assert.equal(filenames.length, 1, 'there should be only one output filename');
+
+execFileSync('wasm-bindgen', [...filenames, ...process.argv.slice(2)], {
+	stdio: 'inherit'
+});

--- a/examples/nodejs_and_deno/package.json
+++ b/examples/nodejs_and_deno/package.json
@@ -1,12 +1,14 @@
 {
 	"type": "module",
 	"scripts": {
-		"build:nodejs": "wasm-pack build --target nodejs --out-dir ../dist/nodejs_and_deno --out-name nodejs",
-		"build:deno": "wasm-pack build --target deno --out-dir ../dist/nodejs_and_deno --out-name deno",
-		"build": "npm run build:nodejs && npm run build:deno",
+		"build:nodejs": "wasm-pack build --target nodejs --out-dir ../dist/nodejs_and_deno/nodejs",
+		"build:deno": "wasm-pack build --target deno --out-dir ../dist/nodejs_and_deno/deno",
+		"build:experimental-nodejs-module": "node cargo-and-wasm-bindgen.js --target experimental-nodejs-module --out-dir ../dist/nodejs_and_deno/experimental-nodejs-module",
+		"build": "npm run build:nodejs && npm run build:deno && npm run build:experimental-nodejs-module",
 
 		"test:nodejs": "node test.js nodejs",
 		"test:deno": "deno run --allow-read test.js deno",
-		"test": "npm run test:nodejs && npm run test:deno"
+		"test:experimental-nodejs-module": "node test.js experimental-nodejs-module",
+		"test": "npm run test:nodejs && npm run test:deno && npm run test:experimental-nodejs-module"
 	}
 }

--- a/examples/nodejs_and_deno/test.js
+++ b/examples/nodejs_and_deno/test.js
@@ -2,5 +2,5 @@ import { argv } from 'node:process';
 
 const targetName = argv[2];
 
-const { greet } = await import(`../dist/nodejs_and_deno/${targetName}.js`);
+const { greet } = await import(`../dist/nodejs_and_deno/${targetName}/node_and_deno.js`);
 greet(targetName);


### PR DESCRIPTION
We can't use wasm-pack here like we do for all other tests, but at least with Cargo's message-format=json the custom script is pretty trivial.