### PR TITLE
Add `get_raw` and `set_raw` for `WebAssembly.Table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 
 ### Added
 
-* Added `new_with_value` and `grow_with_value` for for `WebAssembly.Table`.
+* Added `get_raw` and `set_raw` for `WebAssembly.Table`.
+  [#4701](https://github.com/wasm-bindgen/wasm-bindgen/pull/4701)
+
+* Added `new_with_value` and `grow_with_value` for `WebAssembly.Table`.
   [#4698](https://github.com/wasm-bindgen/wasm-bindgen/pull/4698)
 
 ### Fixed

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4834,6 +4834,13 @@ pub mod WebAssembly {
         #[wasm_bindgen(method, catch, js_namespace = WebAssembly)]
         pub fn get(this: &Table, index: u32) -> Result<Function, JsValue>;
 
+        /// The `get()` prototype method of the `WebAssembly.Table()` object
+        /// retrieves a function reference stored at a given index.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get)
+        #[wasm_bindgen(method, catch, js_namespace = WebAssembly, js_name = get)]
+        pub fn get_raw(this: &Table, index: u32) -> Result<JsValue, JsValue>;
+
         /// The `grow()` prototype method of the `WebAssembly.Table` object
         /// increases the size of the `Table` instance by a specified number of
         /// elements.
@@ -4860,6 +4867,13 @@ pub mod WebAssembly {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set)
         #[wasm_bindgen(method, catch, js_namespace = WebAssembly)]
         pub fn set(this: &Table, index: u32, function: &Function) -> Result<(), JsValue>;
+
+        /// The `set()` prototype method of the `WebAssembly.Table` object mutates a
+        /// reference stored at a given index to a different value.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set)
+        #[wasm_bindgen(method, catch, js_namespace = WebAssembly, js_name = set)]
+        pub fn set_raw(this: &Table, index: u32, value: &JsValue) -> Result<(), JsValue>;
     }
 
     // WebAssembly.Tag

--- a/crates/js-sys/tests/wasm/WebAssembly.rs
+++ b/crates/js-sys/tests/wasm/WebAssembly.rs
@@ -204,6 +204,19 @@ fn memory_works() {
 }
 
 #[wasm_bindgen_test]
+fn table_get_and_set_raw() {
+    let obj = Object::new();
+    Reflect::set(obj.as_ref(), &"element".into(), &"externref".into()).unwrap();
+    Reflect::set(obj.as_ref(), &"initial".into(), &1.into()).unwrap();
+    let tbl = WebAssembly::Table::new(&obj).unwrap();
+
+    assert_eq!(tbl.length(), 1);
+    tbl.set_raw(0, &JsValue::from(42)).unwrap();
+    let value = tbl.get_raw(0).unwrap();
+    assert_eq!(value, JsValue::from(42));
+}
+
+#[wasm_bindgen_test]
 fn new_and_grow_with_value() {
     let obj = Object::new();
     Reflect::set(obj.as_ref(), &"element".into(), &"externref".into()).unwrap();
@@ -211,11 +224,11 @@ fn new_and_grow_with_value() {
     let tbl = WebAssembly::Table::new_with_value(&obj, JsValue::from(42)).unwrap();
 
     assert_eq!(tbl.length(), 1);
-    let value = tbl.get(0).unwrap();
-    assert_eq!(JsValue::from(value), JsValue::from(42));
+    let value = tbl.get_raw(0).unwrap();
+    assert_eq!(value, JsValue::from(42));
 
     tbl.grow_with_value(1, JsValue::from(43)).unwrap();
     assert_eq!(tbl.length(), 2);
-    let value = tbl.get(1).unwrap();
-    assert_eq!(JsValue::from(value), JsValue::from(43));
+    let value = tbl.get_raw(1).unwrap();
+    assert_eq!(value, JsValue::from(43));
 }


### PR DESCRIPTION
According to <https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table/set#value>, the type of value is now not just a wasm function.

Naming is hard, if you have any suggestions, please let me know.