### PR TITLE
Simplify Clippy CI config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
         -- -D warnings
 
   # Run `cargo clippy` over crates that support `no_std`
-  clippy_no_std:
+  clippy_wasm_no_std:
     strategy:
       matrix:
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 
   # Run `cargo clippy` over everything
   clippy:
-    name: Clippy
+    name: Clippy (native)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -57,7 +57,7 @@ jobs:
 
   # Run `cargo clippy` over all Wasm crates
   clippy_wasm:
-    name: Clippy (wasm)
+    name: Clippy (Wasm)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -76,11 +76,11 @@ jobs:
   clippy_no_std:
     strategy:
       matrix:
-        flags:
-          - ""
-          # Also with `target_feature = "atomics"` support.
-          - --config "target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics'"
-    name: Clippy `no_std`
+        include:
+          - name: "no_std"
+          - name: "no_std + atomics"
+            flags: --config "target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics'"
+    name: Clippy (Wasm + ${{ matrix.name }})
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,18 +44,6 @@ jobs:
           tool: taplo-cli
       - run: taplo fmt --check
 
-  # Run `cargo check` over everything
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt
-    - run: cargo check --all
-    - run: cargo check --no-default-features
-
   # Run `cargo clippy` over everything
   clippy:
     name: Clippy
@@ -64,25 +52,12 @@ jobs:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
       with:
-        targets: wasm32-unknown-unknown
         components: clippy,rustfmt
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-cli -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-cli-support -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-futures -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro-support -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-shared -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-test -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-test-macro -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p typescript-tests -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-webidl -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p webidl-tests -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-benchmark -- -D warnings
+    - run: cargo clippy --no-deps --all --all-features -- -D warnings
 
-  # Run `cargo clippy` over web-sys and js-sys crates
-  clippy_web_sys:
-    name: Clippy (web-sys)
+  # Run `cargo clippy` over all Wasm crates
+  clippy_wasm:
+    name: Clippy (wasm)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -90,11 +65,21 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
         components: clippy
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p js-sys --all-targets -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p web-sys --all-targets -- -D warnings
+    - run: >
+        cargo clippy --no-deps --all --all-features
+        --target wasm32-unknown-unknown
+        --exclude wasm-bindgen-cli*
+        --exclude wasm-bindgen-*macro*
+        -- -D warnings
 
   # Run `cargo clippy` over crates that support `no_std`
   clippy_no_std:
+    strategy:
+      matrix:
+        flags:
+          - ""
+          # Also with `target_feature = "atomics"` support.
+          - "--config target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics'"
     name: Clippy `no_std`
     runs-on: ubuntu-latest
     steps:
@@ -103,43 +88,15 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
         components: clippy
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p js-sys -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p web-sys -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-futures -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-test -- -D warnings
-
-  # Run `cargo clippy` over crates that support `no_std` with `target_feature = "atomics"` support.
-  clippy_no_std_atomics:
-    name: Clippy `no_std` with `atomics`
-    runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -Ctarget-feature=+atomics
-    steps:
-    - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@nightly
-      with:
-        targets: wasm32-unknown-unknown
-        components: clippy,rust-src
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen -Zbuild-std=core,alloc -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p js-sys -Zbuild-std=core,alloc -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p web-sys -Zbuild-std=core,alloc -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-futures -Zbuild-std=core,alloc -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-test -Zbuild-std=core,alloc -- -D warnings
-
-  # Run `cargo clippy` over the project
-  clippy_project:
-    name: Clippy (project)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: wasm32-unknown-unknown
-        components: clippy
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown --tests -- -D warnings
-    - run: for i in examples/*/; do cd "$i"; cargo +stable clippy --no-deps --all-features --target wasm32-unknown-unknown -- -D warnings || exit 1; cd ../..; done
+    - run: >
+        cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown
+        -p wasm-bindgen
+        -p js-sys
+        -p web-sys
+        -p wasm-bindgen-futures
+        -p wasm-bindgen-test
+        ${{ matrix.flags }}
+        -- -D warnings
 
   test_wasm_bindgen:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         targets: wasm32-unknown-unknown
-        components: clippy
+        components: clippy,rustfmt
     - run: >
         cargo clippy --no-deps --all --all-features
         --target wasm32-unknown-unknown

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,7 @@ jobs:
         --target wasm32-unknown-unknown
         --exclude wasm-bindgen-cli*
         --exclude wasm-bindgen-*macro*
+        --exclude wasm-bindgen-webidl
         -- -D warnings
 
   # Run `cargo clippy` over crates that support `no_std`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         flags:
           - ""
           # Also with `target_feature = "atomics"` support.
-          - "--config target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics'"
+          - --config "target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics'"
     name: Clippy `no_std`
     runs-on: ubuntu-latest
     steps:

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -108,7 +108,7 @@ impl Project {
 
     fn dep(&mut self, line: &str) -> &mut Project {
         self.deps.push_str(line);
-        self.deps.push_str("\n");
+        self.deps.push('\n');
         self
     }
 
@@ -313,7 +313,7 @@ fn bin_crate_works_without_name_section() {
     // the names is too long.
     // Unfortunately, we can't use `walrus` to do this because it gives the name
     // section special treatment, so instead we use `wasmparser` directly.
-    let mut contents = fs::read(&wasm).unwrap();
+    let mut contents = fs::read(wasm).unwrap();
     for payload in wasmparser::Parser::new(0).parse_all(&contents.clone()) {
         match payload.unwrap() {
             Payload::CustomSection(reader) if reader.name() == "name" => {
@@ -340,7 +340,7 @@ fn bin_crate_works_without_name_section() {
         }
     }
 
-    fs::write(&wasm, contents).unwrap();
+    fs::write(wasm, contents).unwrap();
 
     // Then run wasm-bindgen on the result.
     let (mut cmd, out_dir) = project.wasm_bindgen("--target nodejs");

--- a/crates/cli/tests/wasm-bindgen/reference.rs
+++ b/crates/cli/tests/wasm-bindgen/reference.rs
@@ -99,7 +99,7 @@ impl Sanitizer {
 
     fn sanitize(&mut self, s: &str) -> String {
         // Cast descriptors for closures contain unstable function indices, so we need to sanitize the hash.
-        let s = self.sanitize_one(&s, regex!(r"__wbindgen_cast_[0-9a-f]{16}"), |idx| {
+        let s = self.sanitize_one(s, regex!(r"__wbindgen_cast_[0-9a-f]{16}"), |idx| {
             format!("__wbindgen_cast_{idx:016x}")
         });
 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ default:
     @just --list
 
 clippy *ARGS="":
-    cargo clippy --all-features --workspace {{ARGS}} -- -D warnings
+    cargo clippy --all-features --all-targets --workspace {{ARGS}} -- -D warnings
 
 test-macro:
     cargo test -p wasm-bindgen-test-macro


### PR DESCRIPTION
Since https://github.com/wasm-bindgen/wasm-bindgen/pull/4437 was merged, we can just use `--all --all-targets` with Clippy for checking on host.

We also don't need the separate `cargo check` task - `cargo clippy` is just a wrapper that checks both built-in Rust lints as well as its own - and can merge other 2 tasks using a matrix.

This revealed that we were not covering test projects, which Clippy found some issues in, so I fixed those as part of the PR.