### PR TITLE
Test with Wasm MVP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         targets: wasm32-unknown-unknown
+        components: rust-src
     - uses: actions/setup-node@v5
       with:
         node-version: '20'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,13 +145,13 @@ jobs:
     strategy:
       matrix:
         runs:
-          - name: "wasm-bindgen"
+          - name: default
             run: |
               cargo test --target wasm32-unknown-unknown
               cargo test --target wasm32-unknown-unknown -p wasm-bindgen-futures
-          - name: "wasm-bindgen (serde-serialize)"
+          - name: serde-serialize
             run: cargo test --target wasm32-unknown-unknown --features serde-serialize
-          - name: "wasm-bindgen (enable-interning)"
+          - name: enable-interning
             run: cargo test --target wasm32-unknown-unknown --features enable-interning
     name: "Run wasm-bindgen crate tests (${{ matrix.runs.name }})"
     runs-on: ubuntu-latest
@@ -167,34 +167,15 @@ jobs:
         node-version: '20'
     - run: ${{ matrix.runs.run }}
 
-  test_wasm_bindgen_envs:
+  test_wasm_bindgen_custom:
     strategy:
       matrix:
         envs:
-          - name: "externref"
-            env:
-              WASM_BINDGEN_EXTERNREF: 1
-          - name: "multi-value"
-            env:
-              WASM_BINDGEN_MULTI_VALUE: 1
-    name: "Run wasm-bindgen crate tests with ${{ matrix.envs.name }} feature"
-    runs-on: ubuntu-latest
-    env:
-      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-      WASM_BINDGEN_EXTERNREF: ${{ matrix.envs.WASM_BINDGEN_EXTERNREF }}
-      WASM_BINDGEN_MULTI_VALUE: ${{ matrix.envs.WASM_BINDGEN_MULTI_VALUE }}
-    steps:
-    - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: wasm32-unknown-unknown
-    - uses: actions/setup-node@v5
-      with:
-        node-version: '20'
-    - run: cargo test --target wasm32-unknown-unknown
-
-  test_threads:
-    name: "Run wasm-bindgen crate tests with multithreading"
+          - name: mvp
+            rustflags: -C target-cpu=mvp
+          - name: atomics
+            rustflags: -C target-feature=+atomics
+    name: "Run wasm-bindgen crate tests (${{ matrix.envs.name }})"
     runs-on: ubuntu-latest
     env:
       WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
@@ -203,10 +184,10 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         targets: wasm32-unknown-unknown
-        components: clippy,rust-src
-    - run: |
-        RUSTFLAGS='-C target-feature=+atomics' \
-          cargo test --target wasm32-unknown-unknown -Z build-std=std,panic_abort
+    - uses: actions/setup-node@v5
+      with:
+        node-version: '20'
+    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std=std,panic_abort --config="target.wasm32-unknown-unknown.rustflags='${{ matrix.envs.RUSTFLAGS }}'"
 
   # I don't know why this is failing so comment this out for now, but ideally
   # this would be figured out at some point and solved.


### PR DESCRIPTION
Just using the same trick @daxpedda used for reference tests. Ideally we'd test properly with Rust 1.57 for full MSRV coverage, but we can't do that at the moment as our Cargo workspace is not compatible with Rust that old.

This way we'll at least catch any issues in the generated JS when not targeting externref & multivalue.