### PR TITLE
Add ESM integration tests for Node & Deno

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,9 +321,10 @@ jobs:
     - uses: denoland/setup-deno@v2
       with:
         deno-version: v2.x
-    - run: npm install
+    - run: npm install -g pnpm@latest-10
+    - run: pnpm install
       working-directory: examples
-    - run: npm test --ignore-scripts
+    - run: pnpm test --ignore-scripts
       working-directory: examples
       env:
         PREBUILT_EXAMPLES: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -324,7 +324,7 @@ jobs:
     - run: npm install -g pnpm@latest-10
     - run: pnpm install
       working-directory: examples
-    - run: pnpm test --ignore-scripts
+    - run: npm test --ignore-scripts
       working-directory: examples
       env:
         PREBUILT_EXAMPLES: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -317,10 +317,10 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
     - uses: actions/setup-node@v5
       with:
-        node-version: 22
+        node-version: 24
     - uses: denoland/setup-deno@v2
       with:
-        deno-version: v1.x
+        deno-version: v2.x
     - run: npm install
       working-directory: examples
     - run: npm test --ignore-scripts

--- a/examples/nodejs_and_deno/package.json
+++ b/examples/nodejs_and_deno/package.json
@@ -5,11 +5,14 @@
 		"build:deno": "wasm-pack build --target deno --out-dir ../dist/nodejs_and_deno/deno",
 		"prebuild:experimental-nodejs-module": "cargo-cp-artifact -a cdylib node_and_deno ../dist/nodejs_and_deno/experimental-nodejs-module/node_and_deno.wasm -- cargo build --message-format=json --target wasm32-unknown-unknown",
 		"build:experimental-nodejs-module": "cd ../dist/nodejs_and_deno/experimental-nodejs-module && wasm-bindgen node_and_deno.wasm --target experimental-nodejs-module --out-dir .",
-		"build": "npm run build:nodejs && npm run build:deno && npm run build:experimental-nodejs-module",
+		"build:esm-integration": "wasm-pack build --out-dir ../dist/nodejs_and_deno/esm-integration",
+		"build": "pnpm /^build:/",
 		"test:nodejs": "node test.js nodejs",
+		"test:nodejs:esm-integration": "node test.js esm-integration",
 		"test:deno": "deno run --allow-read test.js deno",
+		"test:deno:esm-integration": "deno run --allow-read test.js esm-integration",
 		"test:experimental-nodejs-module": "node test.js experimental-nodejs-module",
-		"test": "npm run test:nodejs && npm run test:deno && npm run test:experimental-nodejs-module"
+		"test": "pnpm /^test:/"
 	},
 	"devDependencies": {
 		"cargo-cp-artifact": "^0.1.9"


### PR DESCRIPTION
I just realised that our default target ("bundler") is actually the one built around same ESM integration syntax that Node.js and Deno finally support as well.

We'll need to rename that target eventually, as `bundler` doesn't convey native support at all, but for now just adding integration tests its output in these runtimes to make sure it stays compatible.