### PR TITLE
Fix warning when using `#[wasm_bindgen(wasm_bindgen=xxx)]` on struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 * Fixed JS memory leak in `wasm_bindgen::Closure`.
   [#4709](https://github.dev/wasm-bindgen/wasm-bindgen/pull/4709)
 
+* Fixed warning when using `#[wasm_bindgen(wasm_bindgen=xxx)]` on struct.
+  [#4715](https://github.dev/wasm-bindgen/wasm-bindgen/pull/4715)
+
 ### Removed
 
 * Internal crate `wasm-bindgen-backend` will no longer be published.

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -550,6 +550,9 @@ impl ConvertToAst<&ast::Program> for &mut syn::ItemStruct {
         }
         let attrs = BindgenAttrs::find(&mut self.attrs)?;
 
+        // the `wasm_bindgen` option has been used before
+        let _ = attrs.wasm_bindgen();
+
         let mut fields = Vec::new();
         let js_name = attrs
             .js_name()

--- a/crates/macro/ui-tests/unused-attributes.rs
+++ b/crates/macro/ui-tests/unused-attributes.rs
@@ -29,4 +29,7 @@ impl MyStruct {
     }
 }
 
+#[wasm_bindgen(wasm_bindgen = wasm_bindgen)]
+struct Foo;
+
 fn main() {}

--- a/tests/struct_derive.rs
+++ b/tests/struct_derive.rs
@@ -1,0 +1,6 @@
+#![deny(warnings)]
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(wasm_bindgen = wasm_bindgen)]
+struct Foo;

--- a/tests/struct_derive.rs
+++ b/tests/struct_derive.rs
@@ -1,6 +1,0 @@
-#![deny(warnings)]
-
-use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen(wasm_bindgen = wasm_bindgen)]
-struct Foo;


### PR DESCRIPTION
It is already used before being passed to `BindgenedStruct`

https://github.com/wasm-bindgen/wasm-bindgen/blob/04a4f52146f60815cf75a971ea536259625215ae/crates/macro-support/src/lib.rs#L34