### PR TITLE
Experiment with implementing generic wasm_bindgen

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -9,9 +9,9 @@ use walrus::Module;
 
 pub(crate) const PLACEHOLDER_MODULE: &str = "__wbindgen_placeholder__";
 
-mod decode;
-mod descriptor;
-mod descriptors;
+pub mod decode;
+pub mod descriptor;
+pub mod descriptors;
 mod externref;
 mod interpreter;
 mod intrinsic;

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.2.112"
 [features]
 extra-traits = ["syn/extra-traits"]
 strict-macro = []
+default = ["extra-traits"]
 
 [dependencies]
 bumpalo = "3.0.0"

--- a/crates/macro-support/src/ast.rs
+++ b/crates/macro-support/src/ast.rs
@@ -425,6 +425,7 @@ pub struct FunctionArgumentData {
 }
 
 /// Information about a Struct being exported
+#[allow(dead_code)]
 #[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[derive(Clone)]
 pub struct Struct {
@@ -446,6 +447,8 @@ pub struct Struct {
     pub js_namespace: Option<Vec<String>>,
     /// Path to wasm_bindgen
     pub wasm_bindgen: Path,
+    // TODO generiate the type lias
+    pub generate_type_alias: Option<Ident>,
 }
 
 /// The field of a struct

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -1,5 +1,6 @@
-use crate::ast;
-use crate::encode;
+use crate::ast::Import;
+use crate::ast::{self, ImportFunction, ImportStatic, ImportString, ImportType, StringEnum};
+use crate::encode::{self, shared_export, Encode, Encoder, Interner};
 use crate::encode::EncodeChunk;
 use crate::generics::{self, generic_to_concrete};
 use crate::Diagnostic;

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -1,6 +1,5 @@
-use crate::ast::Import;
-use crate::ast::{self, ImportFunction, ImportStatic, ImportString, ImportType, StringEnum};
-use crate::encode::{self, shared_export, Encode, Encoder, Interner};
+use crate::ast::{self};
+use crate::encode::{self};
 use crate::encode::EncodeChunk;
 use crate::generics::{self, generic_to_concrete};
 use crate::Diagnostic;

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -1,6 +1,6 @@
 use crate::ast::{self};
-use crate::encode::{self};
 use crate::encode::EncodeChunk;
+use crate::encode::{self};
 use crate::generics::{self, generic_to_concrete};
 use crate::Diagnostic;
 use proc_macro2::{Ident, Span, TokenStream};
@@ -101,9 +101,7 @@ impl TryToTokens for ast::Program {
 
         let wasm_bindgen = &self.wasm_bindgen;
 
-
         // dbg!(&self);
-
 
         let encoded = encode::encode(self)?;
 

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -102,6 +102,10 @@ impl TryToTokens for ast::Program {
 
         let wasm_bindgen = &self.wasm_bindgen;
 
+
+        // dbg!(&self);
+
+
         let encoded = encode::encode(self)?;
 
         let encoded_chunks: Vec<_> = encoded

--- a/crates/macro-support/src/encode.rs
+++ b/crates/macro-support/src/encode.rs
@@ -40,7 +40,7 @@ pub fn encode(program: &ast::Program) -> Result<EncodeResult, Diagnostic> {
     })
 }
 
-struct Interner {
+pub struct Interner {
     bump: bumpalo::Bump,
     files: RefCell<HashMap<String, LocalFile>>,
     root: PathBuf,
@@ -56,7 +56,7 @@ struct LocalFile {
 }
 
 impl Interner {
-    fn new() -> Interner {
+    pub fn new() -> Interner {
         let root = env::var_os("CARGO_MANIFEST_DIR")
             .expect("should have CARGO_MANIFEST_DIR env var")
             .into();
@@ -198,7 +198,7 @@ fn shared_program<'a>(
     })
 }
 
-fn shared_export<'a>(
+pub fn shared_export<'a>(
     export: &'a ast::Export,
     intern: &'a Interner,
 ) -> Result<Export<'a>, Diagnostic> {
@@ -435,11 +435,11 @@ fn shared_struct_field<'a>(s: &'a ast::StructField, _intern: &'a Interner) -> St
     }
 }
 
-trait Encode {
+pub trait Encode {
     fn encode(&self, dst: &mut Encoder);
 }
 
-struct Encoder {
+pub struct Encoder {
     dst: Vec<EncodeChunk>,
 }
 
@@ -460,11 +460,11 @@ impl Encode for LitOrExpr<'_> {
 }
 
 impl Encoder {
-    fn new() -> Encoder {
+    pub fn new() -> Encoder {
         Encoder { dst: vec![] }
     }
 
-    fn finish(self) -> Vec<EncodeChunk> {
+    pub fn finish(self) -> Vec<EncodeChunk> {
         self.dst
     }
 
@@ -624,7 +624,195 @@ macro_rules! encode_api {
         encode_api!($($rest)*);
     );
 }
-wasm_bindgen_shared::shared_api!(encode_api);
+struct Program<'a>{
+    exports:Vec<Export<'a>> ,enums:Vec<Enum<'a>> ,imports:Vec<Import<'a>> ,structs:Vec<Struct<'a>> ,typescript_custom_sections:Vec<LitOrExpr<'a>> ,local_modules:Vec<LocalModule<'a>> ,inline_js:Vec< &'a str> ,unique_crate_identifier: &'a str,package_json:Option< &'a str> ,linked_modules:Vec<LinkedModule<'a>> ,
+}
+impl <'a>Encode for Program<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.exports.encode(_dst);
+        self.enums.encode(_dst);
+        self.imports.encode(_dst);
+        self.structs.encode(_dst);
+        self.typescript_custom_sections.encode(_dst);
+        self.local_modules.encode(_dst);
+        self.inline_js.encode(_dst);
+        self.unique_crate_identifier.encode(_dst);
+        self.package_json.encode(_dst);
+        self.linked_modules.encode(_dst);
+    }
+
+    }
+struct Import<'a>{
+    module:Option<ImportModule<'a>> ,js_namespace:Option<Vec<String>> ,reexport:Option<String> ,kind:ImportKind<'a> ,
+}
+impl <'a>Encode for Import<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.module.encode(_dst);
+        self.js_namespace.encode(_dst);
+        self.reexport.encode(_dst);
+        self.kind.encode(_dst);
+    }
+
+    }
+struct LinkedModule<'a>{
+    module:ImportModule<'a> ,link_function_name: &'a str,
+}
+impl <'a>Encode for LinkedModule<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.module.encode(_dst);
+        self.link_function_name.encode(_dst);
+    }
+
+    }
+enum ImportModule<'a>{
+    Named(&'a str),RawNamed(&'a str),Inline(u32),
+}
+impl <'a>Encode for ImportModule<'a>{
+    fn encode(&self,dst: &mut Encoder){
+        use self::ImportModule::*;
+        encode_enum!(@arms self dst(0)()Named(&'a str),RawNamed(&'a str),Inline(u32),)
+    }
+
+    }
+enum ImportKind<'a>{
+    Function(ImportFunction<'a>),Static(ImportStatic<'a>),String(ImportString<'a>),Type(ImportType<'a>),Enum(StringEnum<'a>),
+}
+impl <'a>Encode for ImportKind<'a>{
+    fn encode(&self,dst: &mut Encoder){
+        use self::ImportKind::*;
+        encode_enum!(@arms self dst(0)()Function(ImportFunction<'a>),Static(ImportStatic<'a>),String(ImportString<'a>),Type(ImportType<'a>),Enum(StringEnum<'a>),)
+    }
+
+    }
+struct ImportFunction<'a>{
+    shim: &'a str,catch:bool,variadic:bool,assert_no_shim:bool,method:Option<MethodData<'a>> ,structural:bool,function:Function<'a> ,
+}
+impl <'a>Encode for ImportFunction<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.shim.encode(_dst);
+        self.catch.encode(_dst);
+        self.variadic.encode(_dst);
+        self.assert_no_shim.encode(_dst);
+        self.method.encode(_dst);
+        self.structural.encode(_dst);
+        self.function.encode(_dst);
+    }
+
+    }
+struct MethodData<'a>{
+    class: &'a str,kind:MethodKind<'a> ,
+}
+impl <'a>Encode for MethodData<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.class.encode(_dst);
+        self.kind.encode(_dst);
+    }
+
+    }
+enum MethodKind<'a>{
+    Constructor,Operation(Operation<'a>),
+}
+impl <'a>Encode for MethodKind<'a>{
+    fn encode(&self,dst: &mut Encoder){
+        use self::MethodKind::*;
+        encode_enum!(@arms self dst(0)()Constructor,Operation(Operation<'a>),)
+    }
+
+    }
+struct Operation<'a>{
+    is_static:bool,kind:OperationKind<'a> ,
+}
+impl <'a>Encode for Operation<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.is_static.encode(_dst);
+        self.kind.encode(_dst);
+    }
+
+    }
+enum OperationKind<'a>{
+    Regular,RegularThis,Getter(&'a str),Setter(&'a str),IndexingGetter,IndexingSetter,IndexingDeleter,
+}
+impl <'a>Encode for OperationKind<'a>{
+    fn encode(&self,dst: &mut Encoder){
+        use self::OperationKind::*;
+        encode_enum!(@arms self dst(0)()Regular,RegularThis,Getter(&'a str),Setter(&'a str),IndexingGetter,IndexingSetter,IndexingDeleter,)
+    }
+
+    }
+struct ImportStatic<'a>{
+    name: &'a str,shim: &'a str,
+}
+impl <'a>Encode for ImportStatic<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.name.encode(_dst);
+        self.shim.encode(_dst);
+    }
+
+    }
+struct ImportString<'a>{
+    shim: &'a str,string: &'a str,
+}
+impl <'a>Encode for ImportString<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.shim.encode(_dst);
+        self.string.encode(_dst);
+    }
+
+    }
+struct ImportType<'a>{
+    name: &'a str,instanceof_shim: &'a str,vendor_prefixes:Vec< &'a str> ,
+}
+impl <'a>Encode for ImportType<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.name.encode(_dst);
+        self.instanceof_shim.encode(_dst);
+        self.vendor_prefixes.encode(_dst);
+    }
+
+    }
+struct StringEnum<'a>{
+    name: &'a str,variant_values:Vec< &'a str> ,comments:Vec< &'a str> ,generate_typescript:bool,js_namespace:Option<Vec< &'a str>> ,
+}
+impl <'a>Encode for StringEnum<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.name.encode(_dst);
+        self.variant_values.encode(_dst);
+        self.comments.encode(_dst);
+        self.generate_typescript.encode(_dst);
+        self.js_namespace.encode(_dst);
+    }
+
+    }
+pub struct Export<'a>{
+    class:Option< &'a str> ,comments:Vec< &'a str> ,consumed:bool,function:Function<'a> ,js_namespace:Option<Vec< &'a str>> ,method_kind:MethodKind<'a> ,start:bool,
+}
+impl <'a>Encode for Export<'a>{
+    fn encode(&self,_dst: &mut Encoder){
+        self.class.encode(_dst);
+        self.comments.encode(_dst);
+        self.consumed.encode(_dst);
+        self.function.encode(_dst);
+        self.js_namespace.encode(_dst);
+        self.method_kind.encode(_dst);
+        self.start.encode(_dst);
+    }
+
+    }
+encode_api!(struct Enum<'a>{
+    name: &'a str,signed:bool,variants:Vec<EnumVariant<'a>>,comments:Vec<&'a str>,generate_typescript:bool,js_namespace:Option<Vec<&'a str>>,private:bool,
+}struct EnumVariant<'a>{
+    name: &'a str,value:u32,comments:Vec<&'a str>,
+}struct Function<'a>{
+    args:Vec<FunctionArgumentData<'a>>,asyncness:bool,name: &'a str,generate_typescript:bool,generate_jsdoc:bool,variadic:bool,ret_ty_override:Option<&'a str>,ret_desc:Option<&'a str>,
+}struct FunctionArgumentData<'a>{
+    name:String,ty_override:Option<&'a str>,desc:Option<&'a str>,
+}struct Struct<'a>{
+    name: &'a str,fields:Vec<StructField<'a>>,comments:Vec<&'a str>,is_inspectable:bool,generate_typescript:bool,js_namespace:Option<Vec<&'a str>>,private:bool,
+}struct StructField<'a>{
+    name: &'a str,readonly:bool,comments:Vec<&'a str>,generate_typescript:bool,generate_jsdoc:bool,
+}struct LocalModule<'a>{
+    identifier: &'a str,contents: &'a str,linked_module:bool,
+});
 
 fn from_ast_method_kind<'a>(
     function: &'a ast::Function,

--- a/crates/macro-support/src/encode.rs
+++ b/crates/macro-support/src/encode.rs
@@ -624,11 +624,20 @@ macro_rules! encode_api {
         encode_api!($($rest)*);
     );
 }
-struct Program<'a>{
-    exports:Vec<Export<'a>> ,enums:Vec<Enum<'a>> ,imports:Vec<Import<'a>> ,structs:Vec<Struct<'a>> ,typescript_custom_sections:Vec<LitOrExpr<'a>> ,local_modules:Vec<LocalModule<'a>> ,inline_js:Vec< &'a str> ,unique_crate_identifier: &'a str,package_json:Option< &'a str> ,linked_modules:Vec<LinkedModule<'a>> ,
+struct Program<'a> {
+    exports: Vec<Export<'a>>,
+    enums: Vec<Enum<'a>>,
+    imports: Vec<Import<'a>>,
+    structs: Vec<Struct<'a>>,
+    typescript_custom_sections: Vec<LitOrExpr<'a>>,
+    local_modules: Vec<LocalModule<'a>>,
+    inline_js: Vec<&'a str>,
+    unique_crate_identifier: &'a str,
+    package_json: Option<&'a str>,
+    linked_modules: Vec<LinkedModule<'a>>,
 }
-impl <'a>Encode for Program<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+impl<'a> Encode for Program<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.exports.encode(_dst);
         self.enums.encode(_dst);
         self.imports.encode(_dst);
@@ -640,55 +649,66 @@ impl <'a>Encode for Program<'a>{
         self.package_json.encode(_dst);
         self.linked_modules.encode(_dst);
     }
-
-    }
-struct Import<'a>{
-    module:Option<ImportModule<'a>> ,js_namespace:Option<Vec<String>> ,reexport:Option<String> ,kind:ImportKind<'a> ,
 }
-impl <'a>Encode for Import<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct Import<'a> {
+    module: Option<ImportModule<'a>>,
+    js_namespace: Option<Vec<String>>,
+    reexport: Option<String>,
+    kind: ImportKind<'a>,
+}
+impl<'a> Encode for Import<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.module.encode(_dst);
         self.js_namespace.encode(_dst);
         self.reexport.encode(_dst);
         self.kind.encode(_dst);
     }
-
-    }
-struct LinkedModule<'a>{
-    module:ImportModule<'a> ,link_function_name: &'a str,
 }
-impl <'a>Encode for LinkedModule<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct LinkedModule<'a> {
+    module: ImportModule<'a>,
+    link_function_name: &'a str,
+}
+impl<'a> Encode for LinkedModule<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.module.encode(_dst);
         self.link_function_name.encode(_dst);
     }
-
-    }
-enum ImportModule<'a>{
-    Named(&'a str),RawNamed(&'a str),Inline(u32),
 }
-impl <'a>Encode for ImportModule<'a>{
-    fn encode(&self,dst: &mut Encoder){
+enum ImportModule<'a> {
+    Named(&'a str),
+    RawNamed(&'a str),
+    Inline(u32),
+}
+impl<'a> Encode for ImportModule<'a> {
+    fn encode(&self, dst: &mut Encoder) {
         use self::ImportModule::*;
         encode_enum!(@arms self dst(0)()Named(&'a str),RawNamed(&'a str),Inline(u32),)
     }
-
-    }
-enum ImportKind<'a>{
-    Function(ImportFunction<'a>),Static(ImportStatic<'a>),String(ImportString<'a>),Type(ImportType<'a>),Enum(StringEnum<'a>),
 }
-impl <'a>Encode for ImportKind<'a>{
-    fn encode(&self,dst: &mut Encoder){
+enum ImportKind<'a> {
+    Function(ImportFunction<'a>),
+    Static(ImportStatic<'a>),
+    String(ImportString<'a>),
+    Type(ImportType<'a>),
+    Enum(StringEnum<'a>),
+}
+impl<'a> Encode for ImportKind<'a> {
+    fn encode(&self, dst: &mut Encoder) {
         use self::ImportKind::*;
         encode_enum!(@arms self dst(0)()Function(ImportFunction<'a>),Static(ImportStatic<'a>),String(ImportString<'a>),Type(ImportType<'a>),Enum(StringEnum<'a>),)
     }
-
-    }
-struct ImportFunction<'a>{
-    shim: &'a str,catch:bool,variadic:bool,assert_no_shim:bool,method:Option<MethodData<'a>> ,structural:bool,function:Function<'a> ,
 }
-impl <'a>Encode for ImportFunction<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct ImportFunction<'a> {
+    shim: &'a str,
+    catch: bool,
+    variadic: bool,
+    assert_no_shim: bool,
+    method: Option<MethodData<'a>>,
+    structural: bool,
+    function: Function<'a>,
+}
+impl<'a> Encode for ImportFunction<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.shim.encode(_dst);
         self.catch.encode(_dst);
         self.variadic.encode(_dst);
@@ -697,97 +717,111 @@ impl <'a>Encode for ImportFunction<'a>{
         self.structural.encode(_dst);
         self.function.encode(_dst);
     }
-
-    }
-struct MethodData<'a>{
-    class: &'a str,kind:MethodKind<'a> ,
 }
-impl <'a>Encode for MethodData<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct MethodData<'a> {
+    class: &'a str,
+    kind: MethodKind<'a>,
+}
+impl<'a> Encode for MethodData<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.class.encode(_dst);
         self.kind.encode(_dst);
     }
-
-    }
-enum MethodKind<'a>{
-    Constructor,Operation(Operation<'a>),
 }
-impl <'a>Encode for MethodKind<'a>{
-    fn encode(&self,dst: &mut Encoder){
+enum MethodKind<'a> {
+    Constructor,
+    Operation(Operation<'a>),
+}
+impl<'a> Encode for MethodKind<'a> {
+    fn encode(&self, dst: &mut Encoder) {
         use self::MethodKind::*;
         encode_enum!(@arms self dst(0)()Constructor,Operation(Operation<'a>),)
     }
-
-    }
-struct Operation<'a>{
-    is_static:bool,kind:OperationKind<'a> ,
 }
-impl <'a>Encode for Operation<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct Operation<'a> {
+    is_static: bool,
+    kind: OperationKind<'a>,
+}
+impl<'a> Encode for Operation<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.is_static.encode(_dst);
         self.kind.encode(_dst);
     }
-
-    }
-enum OperationKind<'a>{
-    Regular,RegularThis,Getter(&'a str),Setter(&'a str),IndexingGetter,IndexingSetter,IndexingDeleter,
 }
-impl <'a>Encode for OperationKind<'a>{
-    fn encode(&self,dst: &mut Encoder){
+enum OperationKind<'a> {
+    Regular,
+    RegularThis,
+    Getter(&'a str),
+    Setter(&'a str),
+    IndexingGetter,
+    IndexingSetter,
+    IndexingDeleter,
+}
+impl<'a> Encode for OperationKind<'a> {
+    fn encode(&self, dst: &mut Encoder) {
         use self::OperationKind::*;
         encode_enum!(@arms self dst(0)()Regular,RegularThis,Getter(&'a str),Setter(&'a str),IndexingGetter,IndexingSetter,IndexingDeleter,)
     }
-
-    }
-struct ImportStatic<'a>{
-    name: &'a str,shim: &'a str,
 }
-impl <'a>Encode for ImportStatic<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct ImportStatic<'a> {
+    name: &'a str,
+    shim: &'a str,
+}
+impl<'a> Encode for ImportStatic<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.name.encode(_dst);
         self.shim.encode(_dst);
     }
-
-    }
-struct ImportString<'a>{
-    shim: &'a str,string: &'a str,
 }
-impl <'a>Encode for ImportString<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct ImportString<'a> {
+    shim: &'a str,
+    string: &'a str,
+}
+impl<'a> Encode for ImportString<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.shim.encode(_dst);
         self.string.encode(_dst);
     }
-
-    }
-struct ImportType<'a>{
-    name: &'a str,instanceof_shim: &'a str,vendor_prefixes:Vec< &'a str> ,
 }
-impl <'a>Encode for ImportType<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct ImportType<'a> {
+    name: &'a str,
+    instanceof_shim: &'a str,
+    vendor_prefixes: Vec<&'a str>,
+}
+impl<'a> Encode for ImportType<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.name.encode(_dst);
         self.instanceof_shim.encode(_dst);
         self.vendor_prefixes.encode(_dst);
     }
-
-    }
-struct StringEnum<'a>{
-    name: &'a str,variant_values:Vec< &'a str> ,comments:Vec< &'a str> ,generate_typescript:bool,js_namespace:Option<Vec< &'a str>> ,
 }
-impl <'a>Encode for StringEnum<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+struct StringEnum<'a> {
+    name: &'a str,
+    variant_values: Vec<&'a str>,
+    comments: Vec<&'a str>,
+    generate_typescript: bool,
+    js_namespace: Option<Vec<&'a str>>,
+}
+impl<'a> Encode for StringEnum<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.name.encode(_dst);
         self.variant_values.encode(_dst);
         self.comments.encode(_dst);
         self.generate_typescript.encode(_dst);
         self.js_namespace.encode(_dst);
     }
-
-    }
-pub struct Export<'a>{
-    class:Option< &'a str> ,comments:Vec< &'a str> ,consumed:bool,function:Function<'a> ,js_namespace:Option<Vec< &'a str>> ,method_kind:MethodKind<'a> ,start:bool,
 }
-impl <'a>Encode for Export<'a>{
-    fn encode(&self,_dst: &mut Encoder){
+pub struct Export<'a> {
+    class: Option<&'a str>,
+    comments: Vec<&'a str>,
+    consumed: bool,
+    function: Function<'a>,
+    js_namespace: Option<Vec<&'a str>>,
+    method_kind: MethodKind<'a>,
+    start: bool,
+}
+impl<'a> Encode for Export<'a> {
+    fn encode(&self, _dst: &mut Encoder) {
         self.class.encode(_dst);
         self.comments.encode(_dst);
         self.consumed.encode(_dst);
@@ -796,23 +830,59 @@ impl <'a>Encode for Export<'a>{
         self.method_kind.encode(_dst);
         self.start.encode(_dst);
     }
-
+}
+encode_api!(
+    struct Enum<'a> {
+        name: &'a str,
+        signed: bool,
+        variants: Vec<EnumVariant<'a>>,
+        comments: Vec<&'a str>,
+        generate_typescript: bool,
+        js_namespace: Option<Vec<&'a str>>,
+        private: bool,
     }
-encode_api!(struct Enum<'a>{
-    name: &'a str,signed:bool,variants:Vec<EnumVariant<'a>>,comments:Vec<&'a str>,generate_typescript:bool,js_namespace:Option<Vec<&'a str>>,private:bool,
-}struct EnumVariant<'a>{
-    name: &'a str,value:u32,comments:Vec<&'a str>,
-}struct Function<'a>{
-    args:Vec<FunctionArgumentData<'a>>,asyncness:bool,name: &'a str,generate_typescript:bool,generate_jsdoc:bool,variadic:bool,ret_ty_override:Option<&'a str>,ret_desc:Option<&'a str>,
-}struct FunctionArgumentData<'a>{
-    name:String,ty_override:Option<&'a str>,desc:Option<&'a str>,
-}struct Struct<'a>{
-    name: &'a str,fields:Vec<StructField<'a>>,comments:Vec<&'a str>,is_inspectable:bool,generate_typescript:bool,js_namespace:Option<Vec<&'a str>>,private:bool,
-}struct StructField<'a>{
-    name: &'a str,readonly:bool,comments:Vec<&'a str>,generate_typescript:bool,generate_jsdoc:bool,
-}struct LocalModule<'a>{
-    identifier: &'a str,contents: &'a str,linked_module:bool,
-});
+    struct EnumVariant<'a> {
+        name: &'a str,
+        value: u32,
+        comments: Vec<&'a str>,
+    }
+    struct Function<'a> {
+        args: Vec<FunctionArgumentData<'a>>,
+        asyncness: bool,
+        name: &'a str,
+        generate_typescript: bool,
+        generate_jsdoc: bool,
+        variadic: bool,
+        ret_ty_override: Option<&'a str>,
+        ret_desc: Option<&'a str>,
+    }
+    struct FunctionArgumentData<'a> {
+        name: String,
+        ty_override: Option<&'a str>,
+        desc: Option<&'a str>,
+    }
+    struct Struct<'a> {
+        name: &'a str,
+        fields: Vec<StructField<'a>>,
+        comments: Vec<&'a str>,
+        is_inspectable: bool,
+        generate_typescript: bool,
+        js_namespace: Option<Vec<&'a str>>,
+        private: bool,
+    }
+    struct StructField<'a> {
+        name: &'a str,
+        readonly: bool,
+        comments: Vec<&'a str>,
+        generate_typescript: bool,
+        generate_jsdoc: bool,
+    }
+    struct LocalModule<'a> {
+        identifier: &'a str,
+        contents: &'a str,
+        linked_module: bool,
+    }
+);
 
 fn from_ast_method_kind<'a>(
     function: &'a ast::Function,

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -7,7 +7,7 @@ mod error;
 
 mod ast;
 mod codegen;
-mod encode;
+pub mod encode;
 mod generics;
 mod hash;
 mod parser;
@@ -49,7 +49,6 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
             return Ok(item);
         }
     }
-
 
     if let syn::Item::Struct(s) = item {
         let opts: BindgenAttrs = syn::parse2(attr.clone())?;
@@ -214,7 +213,6 @@ impl Parse for ClassMarker {
 pub fn expand_struct_marker(item: TokenStream) -> Result<TokenStream, Diagnostic> {
     parser::reset_attrs_used();
 
-
     let mut s = if let Ok(ItemEnum {
         attrs,
         vis,
@@ -223,8 +221,8 @@ pub fn expand_struct_marker(item: TokenStream) -> Result<TokenStream, Diagnostic
         generics,
         brace_token: _,
         variants: _,
-    }) = syn::parse2::<syn::ItemEnum>(item.clone()) {
-
+    }) = syn::parse2::<syn::ItemEnum>(item.clone())
+    {
         syn::ItemStruct {
             attrs,
             vis,
@@ -237,8 +235,6 @@ pub fn expand_struct_marker(item: TokenStream) -> Result<TokenStream, Diagnostic
     } else {
         syn::parse2::<syn::ItemStruct>(item)?
     };
-
-
 
     let mut program = ast::Program::default();
     program.structs.extend((&mut s).convert(&program)?);

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -21,6 +21,7 @@ use quote::quote;
 use quote::ToTokens;
 use quote::TokenStreamExt;
 use syn::parse::{Parse, ParseStream, Result as SynResult};
+use syn::ItemEnum;
 use syn::Token;
 
 /// Takes the parsed input from a `#[wasm_bindgen]` macro and returns the generated bindings
@@ -29,6 +30,25 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
     // if struct is encountered, add `derive` attribute and let everything happen there (workaround
     // to help parsing cfg_attr correctly).
     let item = syn::parse2::<syn::Item>(input)?;
+
+
+    if let syn::Item::Enum(s) = item {
+        let opts: BindgenAttrs = syn::parse2(attr.clone())?;
+        let wasm_bindgen = opts
+            .wasm_bindgen()
+            .cloned()
+            .unwrap_or_else(|| syn::parse_quote! { ::wasm_bindgen });
+
+        let item = quote! {
+            #[derive(#wasm_bindgen::__rt::BindgenedStruct)]
+            #[wasm_bindgen(#attr)]
+            #s
+        };
+
+        return Ok(item);
+    }
+
+
     if let syn::Item::Struct(s) = item {
         let opts: BindgenAttrs = syn::parse2(attr.clone())?;
         let wasm_bindgen = opts
@@ -192,7 +212,31 @@ impl Parse for ClassMarker {
 pub fn expand_struct_marker(item: TokenStream) -> Result<TokenStream, Diagnostic> {
     parser::reset_attrs_used();
 
-    let mut s: syn::ItemStruct = syn::parse2(item)?;
+
+    let mut s = if let Ok(ItemEnum {
+        attrs,
+        vis,
+        enum_token: _,
+        ident,
+        generics,
+        brace_token: _,
+        variants: _,
+    }) = syn::parse2::<syn::ItemEnum>(item.clone()) {
+
+        syn::ItemStruct {
+            attrs,
+            vis,
+            struct_token: Default::default(),
+            ident,
+            generics,
+            fields: syn::Fields::Unit,
+            semi_token: None,
+        }
+    } else {
+        syn::parse2::<syn::ItemStruct>(item)?
+    };
+
+
 
     let mut program = ast::Program::default();
     program.structs.extend((&mut s).convert(&program)?);

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -21,6 +21,7 @@ use quote::quote;
 use quote::ToTokens;
 use quote::TokenStreamExt;
 use syn::parse::{Parse, ParseStream, Result as SynResult};
+use syn::Fields;
 use syn::ItemEnum;
 use syn::Token;
 
@@ -31,21 +32,22 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
     // to help parsing cfg_attr correctly).
     let item = syn::parse2::<syn::Item>(input)?;
 
+    if let syn::Item::Enum(ref s) = item {
+        if !s.variants.iter().all(|v| matches!(v.fields, Fields::Unit)) {
+            let opts: BindgenAttrs = syn::parse2(attr.clone())?;
+            let wasm_bindgen = opts
+                .wasm_bindgen()
+                .cloned()
+                .unwrap_or_else(|| syn::parse_quote! { ::wasm_bindgen });
 
-    if let syn::Item::Enum(s) = item {
-        let opts: BindgenAttrs = syn::parse2(attr.clone())?;
-        let wasm_bindgen = opts
-            .wasm_bindgen()
-            .cloned()
-            .unwrap_or_else(|| syn::parse_quote! { ::wasm_bindgen });
+            let item = quote! {
+                #[derive(#wasm_bindgen::__rt::BindgenedStruct)]
+                #[wasm_bindgen(#attr)]
+                #s
+            };
 
-        let item = quote! {
-            #[derive(#wasm_bindgen::__rt::BindgenedStruct)]
-            #[wasm_bindgen(#attr)]
-            #s
-        };
-
-        return Ok(item);
+            return Ok(item);
+        }
     }
 
 

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 mod error;
 
-mod ast;
+pub mod ast;
 mod codegen;
 pub mod encode;
 mod generics;

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -41,10 +41,12 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
             #[wasm_bindgen(#attr)]
             #s
         };
+
         return Ok(item);
     }
 
-    let opts = syn::parse2(attr)?;
+    let opts: BindgenAttrs = syn::parse2(attr)?;
+
     let mut tokens = proc_macro2::TokenStream::new();
     let mut program = ast::Program::default();
     item.macro_parse(&mut program, (Some(opts), &mut tokens))?;
@@ -193,12 +195,12 @@ pub fn expand_struct_marker(item: TokenStream) -> Result<TokenStream, Diagnostic
     let mut s: syn::ItemStruct = syn::parse2(item)?;
 
     let mut program = ast::Program::default();
-    program.structs.push((&mut s).convert(&program)?);
+    program.structs.extend((&mut s).convert(&program)?);
 
     let mut tokens = proc_macro2::TokenStream::new();
     program.try_to_tokens(&mut tokens)?;
 
-    parser::check_unused_attrs(&mut tokens);
+    // parser::check_unused_attrs(&mut tokens);
 
     Ok(tokens)
 }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1250,12 +1250,12 @@ fn function_from_decl(
     }
 
     // For imported functions (Extern position), generics are supported and validated.
-    if !matches!(position, FunctionPosition::Extern) && !sig.generics.params.is_empty() {
-        bail_span!(
-            sig.generics,
-            "can't #[wasm_bindgen] functions with lifetime or type parameters"
-        );
-    }
+    // if !matches!(position, FunctionPosition::Extern) && !sig.generics.params.is_empty() {
+    //     bail_span!(
+    //         sig.generics,
+    //         "can't #[wasm_bindgen] functions with lifetime or type parameters"
+    //     );
+    // }
 
     let syn::Signature { inputs, output, .. } = sig;
 
@@ -1606,12 +1606,14 @@ impl MacroParse<BindgenAttrs> for &mut syn::ItemImpl {
         if let Some((_, path, _)) = &self.trait_ {
             bail_span!(path, "#[wasm_bindgen] trait impls are not supported");
         }
+
         if !self.generics.params.is_empty() {
             bail_span!(
                 self.generics,
                 "#[wasm_bindgen] generic impls aren't supported"
             );
         }
+
         let name = match get_ty(&self.self_ty) {
             syn::Type::Path(syn::TypePath {
                 qself: None,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -638,10 +638,10 @@ fn convert(
         };
 
         let attrs = BindgenAttrs::find(&mut field.attrs)?;
-        // if attrs.skip().is_some() {
-        //     attrs.check_used();
-        //     continue;
-        // }
+        if attrs.skip().is_some() {
+            // attrs.check_used();
+            continue;
+        }
 
         let js_field_name = match attrs.js_name() {
             Some((name, _)) => name.to_string(),

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -8,9 +8,11 @@ use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream, Result as SynResult};
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
-use syn::Token;
+use syn::Type;
+use syn::{parenthesized, Token};
 use syn::{ItemFn, Lit, MacroDelimiter, ReturnType};
 use wasm_bindgen_shared::identifier::{is_js_keyword, is_non_value_js_keyword, is_valid_ident};
 
@@ -70,6 +72,71 @@ pub struct BindgenAttrs {
 #[derive(Clone)]
 pub struct JsNamespace(Vec<String>);
 
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
+#[derive(Clone)]
+pub struct GenericArg {
+    generics: Vec<Type>,
+    type_alias_name: Ident,
+}
+
+impl Parse for GenericArg {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        let kw_impl: Ident = input.parse()?;
+        if kw_impl != "new" {
+            return Err(syn::Error::new(kw_impl.span(), "expected `new`"));
+        }
+
+        let content;
+        parenthesized!(content in input);
+
+        let kw_generics: Ident = content.parse()?;
+        if kw_generics != "generics" {
+            return Err(syn::Error::new(kw_generics.span(), "expected `generics`"));
+        }
+
+        let generics_content;
+        parenthesized!(generics_content in content);
+
+        let generics: Punctuated<Type, Token![,]> =
+            generics_content.parse_terminated(Type::parse, Token![,])?;
+
+        content.parse::<Token![,]>()?;
+
+        let key: Ident = content.parse()?;
+        if key != "type_alias_name" {
+            return Err(syn::Error::new(key.span(), "expected `type_alias_name`"));
+        }
+
+        content.parse::<Token![=]>()?;
+        let type_alias_name = content.parse::<Ident>()?;
+
+        if !content.is_empty() {
+            let _ = content.parse::<Option<Token![,]>>()?;
+        }
+        Ok(GenericArg {
+            generics: generics.into_iter().collect(),
+            type_alias_name,
+        })
+    }
+}
+
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
+#[derive(Clone)]
+pub struct GenericArgs {
+    pub items: Vec<GenericArg>,
+}
+
+impl Parse for GenericArgs {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        let content;
+        parenthesized!(content in input);
+
+        let items = Punctuated::<GenericArg, Token![,]>::parse_terminated(&content)?;
+        Ok(GenericArgs {
+            items: items.into_iter().collect(),
+        })
+    }
+}
 macro_rules! attrgen {
     ($mac:ident) => {
         $mac! {
@@ -90,6 +157,7 @@ macro_rules! attrgen {
             (structural, false, Structural(Span)),
             (r#final, false, Final(Span)),
             (readonly, false, Readonly(Span)),
+            (generic, false, Generic(Span, GenericArgs)),
             (js_name, false, JsName(Span, String, Span)),
             (js_class, false, JsClass(Span, String, Span)),
             (reexport, false, Reexport(Span, Option<String>)),
@@ -338,6 +406,11 @@ impl Parse for BindgenAttr {
                 )*
             };
 
+            (@parser $variant:ident(Span, GenericArgs)) => ({
+                input.parse::<Token![=]>()?;
+                return Ok(BindgenAttr::$variant(attr_span, input.parse()?));
+            });
+
             (@parser $variant:ident(Span)) => ({
                 return Ok(BindgenAttr::$variant(attr_span));
             });
@@ -463,94 +536,208 @@ pub(crate) trait ConvertToAst<Ctx> {
     fn convert(self, context: Ctx) -> Result<Self::Target, Diagnostic>;
 }
 
+fn substitute_type(ty: &syn::Type, subs: &[(syn::Ident, syn::Type)]) -> syn::Type {
+    match ty {
+        syn::Type::Path(tp) => {
+            if tp.qself.is_none() && tp.path.segments.len() == 1 {
+                let seg = &tp.path.segments[0];
+                if let Some((_, repl)) = subs.iter().find(|(g, _)| *g == seg.ident) {
+                    return repl.clone();
+                }
+            }
+
+            let mut out = tp.clone();
+            for seg in &mut out.path.segments {
+                if let syn::PathArguments::AngleBracketed(args) = &mut seg.arguments {
+                    for arg in &mut args.args {
+                        if let syn::GenericArgument::Type(inner) = arg {
+                            *inner = substitute_type(inner, subs);
+                        }
+                    }
+                }
+            }
+            syn::Type::Path(out)
+        }
+
+        syn::Type::Tuple(tt) => {
+            let mut out = tt.clone();
+            for elem in &mut out.elems {
+                *elem = substitute_type(elem, subs);
+            }
+            syn::Type::Tuple(out)
+        }
+
+        syn::Type::Paren(tp) => {
+            let mut out = tp.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subs));
+            syn::Type::Paren(out)
+        }
+
+        syn::Type::Group(tg) => {
+            let mut out = tg.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subs));
+            syn::Type::Group(out)
+        }
+
+        syn::Type::Reference(tr) => {
+            let mut out = tr.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subs));
+            syn::Type::Reference(out)
+        }
+
+        syn::Type::Array(ta) => {
+            let mut out = ta.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subs));
+            syn::Type::Array(out)
+        }
+
+        syn::Type::Slice(ts) => {
+            let mut out = ts.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subs));
+            syn::Type::Slice(out)
+        }
+
+        _ => ty.clone(),
+    }
+}
+
+fn convert(
+    self_item_struct: &&mut syn::ItemStruct,
+    self_ident: Ident,
+    attrs: &BindgenAttrs,
+    generic_substitutions: Option<Vec<(Ident, Type)>>,
+    wasm_bindgen: &syn::Path,
+    gen_type_alias: bool,
+) -> Result<ast::Struct, Diagnostic> {
+    let mut fields = Vec::new();
+    let js_name = attrs
+        .js_name()
+        .map(|s| s.0.to_string())
+        .unwrap_or(self_ident.unraw().to_string());
+    if is_js_keyword(&js_name) && js_name != "default" {
+        bail_span!(
+            self_ident,
+            "struct cannot use the JS keyword `{}` as its name",
+            js_name
+        );
+    }
+
+    let is_inspectable = attrs.inspectable().is_some();
+    let getter_with_clone = attrs.getter_with_clone();
+
+    // We can clone here despite the itermut because fields themselves won't have
+    // bindgen args
+    for (i, field) in self_item_struct.fields.clone().iter_mut().enumerate() {
+        match field.vis {
+            syn::Visibility::Public(..) => {}
+            _ => continue,
+        }
+        let (js_field_name, member) = match &field.ident {
+            Some(ident) => (ident.unraw().to_string(), syn::Member::Named(ident.clone())),
+            None => (i.to_string(), syn::Member::Unnamed(i.into())),
+        };
+
+        let attrs = BindgenAttrs::find(&mut field.attrs)?;
+        // if attrs.skip().is_some() {
+        //     attrs.check_used();
+        //     continue;
+        // }
+
+        let js_field_name = match attrs.js_name() {
+            Some((name, _)) => name.to_string(),
+            None => js_field_name,
+        };
+
+        let comments = extract_doc_comments(&field.attrs);
+        let getter = wasm_bindgen_shared::struct_field_get(&js_name, &js_field_name);
+        let setter = wasm_bindgen_shared::struct_field_set(&js_name, &js_field_name);
+
+        let ty = if let Some(items) = &generic_substitutions {
+            substitute_type(&field.ty, items.as_slice())
+        } else {
+            field.ty.clone()
+        };
+
+        fields.push(ast::StructField {
+            rust_name: member,
+            js_name: js_field_name,
+            struct_name: self_ident.clone(),
+            readonly: attrs.readonly().is_some(),
+            ty,
+            getter: Ident::new(&getter, Span::call_site()),
+            setter: Ident::new(&setter, Span::call_site()),
+            comments,
+            generate_typescript: attrs.skip_typescript().is_none(),
+            generate_jsdoc: attrs.skip_jsdoc().is_none(),
+            getter_with_clone: attrs.getter_with_clone().or(getter_with_clone).copied(),
+            wasm_bindgen: wasm_bindgen.clone(),
+        });
+        // attrs.check_used();
+    }
+    let generate_typescript = attrs.skip_typescript().is_none();
+    let private = attrs.private().is_some();
+    let comments: Vec<String> = extract_doc_comments(&self_item_struct.attrs);
+    let js_namespace = attrs.js_namespace().map(|(ns, _)| ns.0);
+    // attrs.check_used();
+    Ok(ast::Struct {
+        rust_name: self_ident.clone(),
+        js_name,
+        fields,
+        comments,
+        is_inspectable,
+        generate_typescript,
+        private,
+        js_namespace,
+        wasm_bindgen: wasm_bindgen.clone(),
+        generate_type_alias: gen_type_alias.then_some(self_ident),
+    })
+}
+
 impl ConvertToAst<&ast::Program> for &mut syn::ItemStruct {
-    type Target = ast::Struct;
+    type Target = Vec<ast::Struct>;
 
     fn convert(self, program: &ast::Program) -> Result<Self::Target, Diagnostic> {
-        if !self.generics.params.is_empty() {
-            bail_span!(
-                self.generics,
-                "structs with #[wasm_bindgen] cannot have lifetime or \
-                 type parameters currently"
-            );
-        }
         let attrs = BindgenAttrs::find(&mut self.attrs)?;
 
-        // the `wasm_bindgen` option has been used before
-        let _ = attrs.wasm_bindgen();
+        if let Some(list) = attrs.generic() {
+            let tp = self
+                .generics
+                .type_params()
+                .cloned()
+                .map(|v| v.ident)
+                .collect::<Vec<_>>();
 
-        let mut fields = Vec::new();
-        let js_name = attrs
-            .js_name()
-            .map(|s| s.0.to_string())
-            .unwrap_or(self.ident.unraw().to_string());
-        if is_js_keyword(&js_name) && js_name != "default" {
-            bail_span!(
-                self.ident,
-                "struct cannot use the JS keyword `{}` as its name",
-                js_name
-            );
-        }
+            let mut ret = vec![];
 
-        let is_inspectable = attrs.inspectable().is_some();
-        let getter_with_clone = attrs.getter_with_clone();
-        for (i, field) in self.fields.iter_mut().enumerate() {
-            match field.vis {
-                syn::Visibility::Public(..) => {}
-                _ => continue,
-            }
-            let (js_field_name, member) = match &field.ident {
-                Some(ident) => (ident.unraw().to_string(), syn::Member::Named(ident.clone())),
-                None => (i.to_string(), syn::Member::Unnamed(i.into())),
-            };
+            for first_param in list.items.clone() {
+                let generic_substitutions = tp
+                    .clone()
+                    .into_iter()
+                    .zip(first_param.generics.into_iter())
+                    .collect::<Vec<(Ident, Type)>>();
 
-            let attrs = BindgenAttrs::find(&mut field.attrs)?;
-            if attrs.skip().is_some() {
-                attrs.check_used();
-                continue;
+                ret.push(convert(
+                    &self,
+                    first_param.type_alias_name,
+                    &attrs,
+                    Some(generic_substitutions),
+                    &program.wasm_bindgen,
+                    true,
+                )?);
             }
 
-            let js_field_name = match attrs.js_name() {
-                Some((name, _)) => name.to_string(),
-                None => js_field_name,
-            };
-
-            let comments = extract_doc_comments(&field.attrs);
-            let getter = wasm_bindgen_shared::struct_field_get(&js_name, &js_field_name);
-            let setter = wasm_bindgen_shared::struct_field_set(&js_name, &js_field_name);
-
-            fields.push(ast::StructField {
-                rust_name: member,
-                js_name: js_field_name,
-                struct_name: self.ident.clone(),
-                readonly: attrs.readonly().is_some(),
-                ty: field.ty.clone(),
-                getter: Ident::new(&getter, Span::call_site()),
-                setter: Ident::new(&setter, Span::call_site()),
-                comments,
-                generate_typescript: attrs.skip_typescript().is_none(),
-                generate_jsdoc: attrs.skip_jsdoc().is_none(),
-                getter_with_clone: attrs.getter_with_clone().or(getter_with_clone).copied(),
-                wasm_bindgen: program.wasm_bindgen.clone(),
-            });
-            attrs.check_used();
+            Ok(ret)
+        } else {
+            let ident = self.ident.clone();
+            Ok(vec![convert(
+                &self,
+                ident,
+                &attrs,
+                None,
+                &program.wasm_bindgen,
+                false,
+            )?])
         }
-        let generate_typescript = attrs.skip_typescript().is_none();
-        let private = attrs.private().is_some();
-        let comments: Vec<String> = extract_doc_comments(&self.attrs);
-        let js_namespace = attrs.js_namespace().map(|(ns, _)| ns.0);
-        attrs.check_used();
-        Ok(ast::Struct {
-            rust_name: self.ident.clone(),
-            js_name,
-            fields,
-            comments,
-            is_inspectable,
-            generate_typescript,
-            private,
-            js_namespace,
-            wasm_bindgen: program.wasm_bindgen.clone(),
-        })
     }
 }
 

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1880,15 +1880,15 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
         if self.variants.is_empty() {
             bail_span!(self, "cannot export empty enums to JS");
         }
-        for variant in self.variants.iter() {
-            match variant.fields {
-                syn::Fields::Unit => (),
-                _ => bail_span!(
-                    variant.fields,
-                    "enum variants with associated data are not supported with #[wasm_bindgen]"
-                ),
-            }
-        }
+        // for variant in self.variants.iter() {
+        //     match variant.fields {
+        //         syn::Fields::Unit => (),
+        //         _ => bail_span!(
+        //             variant.fields,
+        //             "enum variants with associated data are not supported with #[wasm_bindgen]"
+        //         ),
+        //     }
+        // }
 
         let generate_typescript = opts.skip_typescript().is_none();
         let private = opts.private().is_some();


### PR DESCRIPTION
So I was wondering what the difficulty was with implementing generics in wasm-bindgen actually was. It's not too difficult but it's not particularly useful either

As this is just an expirement it only supports structs and getting generic methods to play nice might be a bit of a pain in practice.

The downside to this approach is that you have to declare each generic upfront, kinda hamstringing their usefulness.  I appreciate that anything automatic would be nightmare fuel for the rust compiler as it'd require wasm-bindgen knowing about the instantiations of generic types requiring a monophisation step _after_ linking.

Here's an example API that creates multiple generic instantiations of a structure.



```
use wasm_bindgen::prelude::*;

#[wasm_bindgen(
    generic = (
        new(
            generics(usize, f64), 
            type_alias_name=MyTestStructGen1
        ),
        new(
            generics(f64, f64), 
            type_alias_name=MyTestStructGen2
        ),
    )
)]
pub struct MyTestStruct<T, R> {
    pub the_prop: T,
    pub other_prop: R,
}


type MyTestStructGen1 = MyTestStruct<usize, f64>;
type MyTestStructGen2 = MyTestStruct<f64, f64>;

#[wasm_bindgen]
pub fn example_use() -> MyTestStruct<f64, f64> {
    MyTestStruct { 
        the_prop: 0.1,
        other_prop: 5.5
    }
}
```

Not 100% sure if I'd use such an approach.  Generics aren't _hugely_ useful at the type boundary anyway, my _particular_ usecase is for interop with already existing code where destructing and recreating structures into new type would be a massive pain in already generic laden code. 