### PR TITLE
Improve ? support in JsError under no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Changed
 
+* Fix ? support for JsError under no_std
+  #5029[](https://github.com/wasm-bindgen/wasm-bindgen/pull/5029)
+
 * Replaced per-closure generic destructors with a single `__wbindgen_destroy_closure`
   export.
   [#5019](https://github.com/wasm-bindgen/wasm-bindgen/pull/5019)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1810,13 +1810,12 @@ impl JsError {
     }
 }
 
-#[cfg(feature = "std")]
 impl<E> From<E> for JsError
 where
-    E: std::error::Error,
+    E: core::error::Error,
 {
     fn from(error: E) -> Self {
-        use std::string::ToString;
+        use alloc::string::ToString;
 
         JsError::new(&error.to_string())
     }


### PR DESCRIPTION
Fixes https://github.com/wasm-bindgen/wasm-bindgen/issues/5025

### Description
Uses alloc::strict::ToString.  Uses core::error::Error because alloc:error does not exist.

### Checklist
- [x] Verified changelog requirement
