### PR TITLE
feat: expose `WebAssembly.Instance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## Unreleased
 
+### Added
+
+* Added `wasm_bindgen::instance()` to return the current
+  `WebAssembly.Instance`. The generated JS glue retains the 
+  instantiated `WebAssembly.Instance`.
+  [#5118](https://github.com/wasm-bindgen/wasm-bindgen/pull/5118)
+
 ### Fixed
 
 * Fixed namespaced export identifiers in generated JS/TS to use qualified names

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -81,6 +81,7 @@ intrinsics! {
         Memory = "__wbindgen_memory",
         Exports = "__wbindgen_exports",
         Module = "__wbindgen_module",
+        Instance = "__wbindgen_instance",
         FunctionTable = "__wbindgen_function_table",
         DebugString = "__wbindgen_debug_string",
         CopyToTypedArray = "__wbindgen_copy_to_typed_array",

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1102,8 +1102,9 @@ export const __wbg_memory: WebAssembly.Memory;
             }
         }
         format!(
-            "let wasmModule, wasm;
+            "let wasmModule, wasmInstance, wasm;
             function __wbg_finalize_init(instance, module{init_stack_size_arg}) {{
+                wasmInstance = instance;
                 wasm = instance.exports;
                 wasmModule = module;
                 {init_memviews}{init_stack_size_check}{start}return wasm;
@@ -1238,7 +1239,8 @@ export const __wbg_memory: WebAssembly.Memory;
         format!(
             "const wasmUrl = new URL('{module_name}_bg.wasm', import.meta.url);
             const wasmInstantiated = await WebAssembly.instantiateStreaming(fetch(wasmUrl), __wbg_get_imports());
-            const wasm = wasmInstantiated.instance.exports;
+            const wasmInstance = wasmInstantiated.instance;
+            const wasm = wasmInstance.exports;
             {start}",
             start = if needs_manual_start {
                 "wasm.__wbindgen_start();\n"
@@ -1275,9 +1277,7 @@ export const __wbg_memory: WebAssembly.Memory;
             };
 
             format!(
-                r#"let wasm;
-let wasmModule;
-let memory;
+                r#"let wasm, wasmInstance, wasmModule, memory;
 let __initialized = false;
 
 export function initSync(opts = {{}}) {{
@@ -1297,8 +1297,8 @@ export function initSync(opts = {{}}) {{
     }}
 
     const wasmImports = __wbg_get_imports(mem);
-    const instance = new WebAssembly.Instance(wasmModule, wasmImports);
-    wasm = instance.exports;
+    wasmInstance = new WebAssembly.Instance(wasmModule, wasmImports);
+    wasm = wasmInstance.exports;
     memory = wasmImports['./{module_name}_bg.js'].memory;
 {start_call}
     __initialized = true;
@@ -1320,7 +1320,8 @@ export {{ wasm as __wasm, wasmModule as __wbg_wasm_module, memory as __wbg_memor
                 const wasmUrl = new URL('{module_name}_bg.wasm', import.meta.url);\n\
                 const wasmBytes = readFileSync(wasmUrl);\n\
                 const wasmModule = new WebAssembly.Module(wasmBytes);\n\
-                let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;\n\
+                let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());\n\
+                let wasm = wasmInstance.exports;\n\
                 {start}",
                 start = if needs_manual_start {
                     "wasm.__wbindgen_start();\n"
@@ -1353,9 +1354,7 @@ export {{ wasm as __wasm, wasmModule as __wbg_wasm_module, memory as __wbg_memor
             };
 
             format!(
-                r#"let wasm;
-let wasmModule;
-let memory;
+                r#"let wasm, wasmInstance, wasmModule;
 let __initialized = false;
 
 // Export __wbg_get_imports for workers to use
@@ -1381,8 +1380,8 @@ exports.initSync = function(opts) {{
     }}
 
     const wasmImports = __wbg_get_imports(mem);
-    const instance = new WebAssembly.Instance(wasmModule, wasmImports);
-    wasm = instance.exports;
+    wasmInstance = new WebAssembly.Instance(wasmModule, wasmImports);
+    wasm = wasmInstance.exports;
     memory = wasmImports['./{module_name}_bg.js'].memory;
     exports.__wasm = wasm;
     exports.__wbg_wasm_module = wasmModule;
@@ -1404,7 +1403,8 @@ if (require('worker_threads').isMainThread) {{
                 r#"const wasmPath = `${{__dirname}}/{module_name}_bg.wasm`;
             const wasmBytes = require('fs').readFileSync(wasmPath);
             const wasmModule = new WebAssembly.Module(wasmBytes);
-            let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+            let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+            let wasm = wasmInstance.exports;
             {start}"#,
                 start = if needs_manual_start {
                     "wasm.__wbindgen_start();\n"
@@ -3465,7 +3465,7 @@ if (require('worker_threads').isMainThread) {{
         };
         reset_statements.push(format!(
             "{abort_reset}
-            const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+            wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
             wasm = wasmInstance.exports;
             wasm.__wbindgen_start();
             "
@@ -5059,11 +5059,32 @@ addToLibrary({
                 assert_eq!(args.len(), 0);
 
                 match self.config.mode {
-                    OutputMode::Web | OutputMode::NoModules { .. } |
-                    OutputMode::Node { .. } | OutputMode::Module => "wasmModule",
+                    OutputMode::Web
+                    | OutputMode::NoModules { .. }
+                    | OutputMode::Node { .. }
+                    | OutputMode::Module => "wasmModule",
                     _ => bail!(
                         "`wasm_bindgen::module` is currently only supported with \
-                         `--target no-modules`, `--target web`, `--target module` and `--target nodejs`"
+                         `--target no-modules`, `--target web`, `--target module`, \
+                         `--target nodejs` and `--target experimental-nodejs-module`"
+                    ),
+                }
+                .to_string()
+            }
+
+            Intrinsic::Instance => {
+                assert_eq!(args.len(), 0);
+                match self.config.mode {
+                    OutputMode::Web
+                    | OutputMode::NoModules { .. }
+                    | OutputMode::Node { .. }
+                    | OutputMode::Module
+                    | OutputMode::Deno => "wasmInstance",
+                    _ => bail!(
+                        "`wasm_bindgen::instance` is currently only supported with \
+                         `--target no-modules`, `--target web`, `--target deno`, \
+                         `--target module`, `--target nodejs` and \
+                         `--target experimental-nodejs-module`"
                     ),
                 }
                 .to_string()

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1014,7 +1014,7 @@ export const __wbg_memory: WebAssembly.Memory;
             "import source wasmModule from \"./{module_name}_bg.wasm\";\n"
         ));
         format!(
-            "const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());\n\
+            "let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());\n\
              let wasm = wasmInstance.exports;\n\
              {start}",
             start = if needs_manual_start {
@@ -1354,7 +1354,7 @@ export {{ wasm as __wasm, wasmModule as __wbg_wasm_module, memory as __wbg_memor
             };
 
             format!(
-                r#"let wasm, wasmInstance, wasmModule;
+                r#"let wasm, wasmInstance, wasmModule, memory;
 let __initialized = false;
 
 // Export __wbg_get_imports for workers to use

--- a/crates/cli/tests/reference/import-target-deno.js
+++ b/crates/cli/tests/reference/import-target-deno.js
@@ -107,5 +107,6 @@ function decodeText(ptr, len) {
 
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmInstantiated = await WebAssembly.instantiateStreaming(fetch(wasmUrl), __wbg_get_imports());
-const wasm = wasmInstantiated.instance.exports;
+const wasmInstance = wasmInstantiated.instance;
+const wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/import-target-experimental-nodejs-module.js
+++ b/crates/cli/tests/reference/import-target-experimental-nodejs-module.js
@@ -109,5 +109,6 @@ function decodeText(ptr, len) {
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmBytes = readFileSync(wasmUrl);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
@@ -12,7 +12,7 @@ export function __wbg_reset_state () {
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -130,6 +130,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/import-target-module.js
+++ b/crates/cli/tests/reference/import-target-module.js
@@ -106,6 +106,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/import-target-nodejs.js
+++ b/crates/cli/tests/reference/import-target-nodejs.js
@@ -109,5 +109,6 @@ function decodeText(ptr, len) {
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/import-target-web.js
+++ b/crates/cli/tests/reference/import-target-web.js
@@ -113,8 +113,9 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     cachedUint8ArrayMemory0 = null;

--- a/crates/cli/tests/reference/targets-target-deno-atomics.js
+++ b/crates/cli/tests/reference/targets-target-deno-atomics.js
@@ -58,5 +58,6 @@ function decodeText(ptr, len) {
 
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmInstantiated = await WebAssembly.instantiateStreaming(fetch(wasmUrl), __wbg_get_imports());
-const wasm = wasmInstantiated.instance.exports;
+const wasmInstance = wasmInstantiated.instance;
+const wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-deno-mvp.js
+++ b/crates/cli/tests/reference/targets-target-deno-mvp.js
@@ -25,4 +25,5 @@ function __wbg_get_imports() {
 
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmInstantiated = await WebAssembly.instantiateStreaming(fetch(wasmUrl), __wbg_get_imports());
-const wasm = wasmInstantiated.instance.exports;
+const wasmInstance = wasmInstantiated.instance;
+const wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-deno.js
+++ b/crates/cli/tests/reference/targets-target-deno.js
@@ -34,5 +34,6 @@ function __wbg_get_imports() {
 
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmInstantiated = await WebAssembly.instantiateStreaming(fetch(wasmUrl), __wbg_get_imports());
-const wasm = wasmInstantiated.instance.exports;
+const wasmInstance = wasmInstantiated.instance;
+const wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.js
@@ -59,9 +59,7 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-let wasm;
-let wasmModule;
-let memory;
+let wasm, wasmInstance, wasmModule, memory;
 let __initialized = false;
 
 export function initSync(opts = {}) {
@@ -81,8 +79,8 @@ export function initSync(opts = {}) {
     }
 
     const wasmImports = __wbg_get_imports(mem);
-    const instance = new WebAssembly.Instance(wasmModule, wasmImports);
-    wasm = instance.exports;
+    wasmInstance = new WebAssembly.Instance(wasmModule, wasmImports);
+    wasm = wasmInstance.exports;
     memory = wasmImports['./reference_test_bg.js'].memory;
 
     if (typeof thread_stack_size !== 'undefined' && (typeof thread_stack_size !== 'number' || thread_stack_size === 0 || thread_stack_size % 65536 !== 0)) {

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module-mvp.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module-mvp.js
@@ -28,4 +28,5 @@ function __wbg_get_imports() {
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmBytes = readFileSync(wasmUrl);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module.js
@@ -37,5 +37,6 @@ function __wbg_get_imports() {
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmBytes = readFileSync(wasmUrl);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-module-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-atomics.js
@@ -58,6 +58,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
@@ -7,7 +7,7 @@ export function __wbg_reset_state () {
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -82,6 +82,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
@@ -5,7 +5,7 @@ import source wasmModule from "./reference_test_bg.wasm";
 export function __wbg_reset_state () {
     __wbg_instance_id++;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -47,5 +47,5 @@ let __wbg_instance_id = 0;
 
 let __wbg_reinit_scheduled = false;
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
@@ -5,7 +5,7 @@ import source wasmModule from "./reference_test_bg.wasm";
 export function __wbg_reset_state () {
     __wbg_instance_id++;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -56,6 +56,6 @@ let __wbg_instance_id = 0;
 
 let __wbg_reinit_scheduled = false;
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-module-mvp.js
+++ b/crates/cli/tests/reference/targets-target-module-mvp.js
@@ -25,5 +25,5 @@ function __wbg_get_imports() {
     };
 }
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-module.js
+++ b/crates/cli/tests/reference/targets-target-module.js
@@ -34,6 +34,6 @@ function __wbg_get_imports() {
     };
 }
 
-const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-no-modules-atomics.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-atomics.js
@@ -61,8 +61,9 @@ let wasm_bindgen = (function(exports) {
         return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
     }
 
-    let wasmModule, wasm;
+    let wasmModule, wasmInstance, wasm;
     function __wbg_finalize_init(instance, module, thread_stack_size) {
+        wasmInstance = instance;
         wasm = instance.exports;
         wasmModule = module;
         cachedUint8ArrayMemory0 = null;

--- a/crates/cli/tests/reference/targets-target-no-modules-mvp.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-mvp.js
@@ -28,8 +28,9 @@ let wasm_bindgen = (function(exports) {
         };
     }
 
-    let wasmModule, wasm;
+    let wasmModule, wasmInstance, wasm;
     function __wbg_finalize_init(instance, module) {
+        wasmInstance = instance;
         wasm = instance.exports;
         wasmModule = module;
         return wasm;

--- a/crates/cli/tests/reference/targets-target-no-modules.js
+++ b/crates/cli/tests/reference/targets-target-no-modules.js
@@ -37,8 +37,9 @@ let wasm_bindgen = (function(exports) {
         };
     }
 
-    let wasmModule, wasm;
+    let wasmModule, wasmInstance, wasm;
     function __wbg_finalize_init(instance, module) {
+        wasmInstance = instance;
         wasm = instance.exports;
         wasmModule = module;
         wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-nodejs-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-atomics.js
@@ -57,9 +57,7 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-let wasm;
-let wasmModule;
-let memory;
+let wasm, wasmInstance, wasmModule, memory;
 let __initialized = false;
 
 // Export __wbg_get_imports for workers to use
@@ -85,8 +83,8 @@ exports.initSync = function(opts) {
     }
 
     const wasmImports = __wbg_get_imports(mem);
-    const instance = new WebAssembly.Instance(wasmModule, wasmImports);
-    wasm = instance.exports;
+    wasmInstance = new WebAssembly.Instance(wasmModule, wasmImports);
+    wasm = wasmInstance.exports;
     memory = wasmImports['./reference_test_bg.js'].memory;
     exports.__wasm = wasm;
     exports.__wbg_wasm_module = wasmModule;

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
@@ -5,7 +5,7 @@ function __wbg_reset_state () {
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -82,9 +82,7 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-let wasm;
-let wasmModule;
-let memory;
+let wasm, wasmInstance, wasmModule, memory;
 let __initialized = false;
 
 // Export __wbg_get_imports for workers to use
@@ -110,8 +108,8 @@ exports.initSync = function(opts) {
     }
 
     const wasmImports = __wbg_get_imports(mem);
-    const instance = new WebAssembly.Instance(wasmModule, wasmImports);
-    wasm = instance.exports;
+    wasmInstance = new WebAssembly.Instance(wasmModule, wasmImports);
+    wasm = wasmInstance.exports;
     memory = wasmImports['./reference_test_bg.js'].memory;
     exports.__wasm = wasm;
     exports.__wbg_wasm_module = wasmModule;

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
@@ -3,7 +3,7 @@
 function __wbg_reset_state () {
     __wbg_instance_id++;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -50,4 +50,5 @@ let __wbg_reinit_scheduled = false;
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
@@ -3,7 +3,7 @@
 function __wbg_reset_state () {
     __wbg_instance_id++;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -59,5 +59,6 @@ let __wbg_reinit_scheduled = false;
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-nodejs-mvp.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-mvp.js
@@ -27,4 +27,5 @@ function __wbg_get_imports() {
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-nodejs.js
+++ b/crates/cli/tests/reference/targets-target-nodejs.js
@@ -36,5 +36,6 @@ function __wbg_get_imports() {
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);
 const wasmModule = new WebAssembly.Module(wasmBytes);
-let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-web-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-atomics.js
@@ -64,8 +64,9 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module, thread_stack_size) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     cachedUint8ArrayMemory0 = null;

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
@@ -5,7 +5,7 @@ export function __wbg_reset_state () {
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -88,8 +88,9 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module, thread_stack_size) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     cachedUint8ArrayMemory0 = null;

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
@@ -3,7 +3,7 @@
 export function __wbg_reset_state () {
     __wbg_instance_id++;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -45,8 +45,9 @@ let __wbg_instance_id = 0;
 
 let __wbg_reinit_scheduled = false;
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     return wasm;

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
@@ -3,7 +3,7 @@
 export function __wbg_reset_state () {
     __wbg_instance_id++;
     __wbg_reinit_scheduled = false;
-    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
@@ -54,8 +54,9 @@ let __wbg_instance_id = 0;
 
 let __wbg_reinit_scheduled = false;
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-web-mvp.js
+++ b/crates/cli/tests/reference/targets-target-web-mvp.js
@@ -23,8 +23,9 @@ function __wbg_get_imports() {
     };
 }
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     return wasm;

--- a/crates/cli/tests/reference/targets-target-web.js
+++ b/crates/cli/tests/reference/targets-target-web.js
@@ -32,8 +32,9 @@ function __wbg_get_imports() {
     };
 }
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/wasm-export-colon.js
+++ b/crates/cli/tests/reference/wasm-export-colon.js
@@ -717,8 +717,9 @@ if (!('encodeInto' in cachedTextEncoder)) {
 
 let WASM_VECTOR_LEN = 0;
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     cachedDataViewMemory0 = null;

--- a/crates/cli/tests/reference/wasm-export-types.js
+++ b/crates/cli/tests/reference/wasm-export-types.js
@@ -131,8 +131,9 @@ if (!('encodeInto' in cachedTextEncoder)) {
 
 let WASM_VECTOR_LEN = 0;
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
     wasm = instance.exports;
     wasmModule = module;
     cachedUint8ArrayMemory0 = null;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1678,6 +1678,7 @@ pub fn instance() -> JsValue {
     __wbindgen_instance()
 }
 
+// TODO: deprecate next major
 /// Returns a handle to this Wasm instance's `WebAssembly.Instance.prototype.exports`
 pub fn exports() -> JsValue {
     __wbindgen_exports()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1272,6 +1272,7 @@ extern "C" {
     fn __wbindgen_exports() -> JsValue;
     fn __wbindgen_memory() -> JsValue;
     fn __wbindgen_module() -> JsValue;
+    fn __wbindgen_instance() -> JsValue;
     fn __wbindgen_function_table() -> JsValue;
 
     fn __wbindgen_reinit();
@@ -1667,6 +1668,14 @@ where
 /// It is unavailable for `--target bundler`.
 pub fn module() -> JsValue {
     __wbindgen_module()
+}
+
+/// Returns a handle to this Wasm instance's `WebAssembly.Instance`.
+/// This is only available when the final Wasm app is built with
+/// `--target no-modules`, `--target web`, `--target deno` or `--target nodejs`.
+/// It is unavailable for `--target bundler`.
+pub fn instance() -> JsValue {
+    __wbindgen_instance()
 }
 
 /// Returns a handle to this Wasm instance's `WebAssembly.Instance.prototype.exports`

--- a/tests/wasm/api.js
+++ b/tests/wasm/api.js
@@ -73,3 +73,8 @@ exports.assert_function_table = (x, i) => {
     assert.ok(x instanceof WebAssembly.Table);
     assert.strictEqual(x.get(i), rawWasm.function_table_lookup);
 };
+
+exports.assert_instance = (instance, wasmExports) => {
+    assert.ok(instance instanceof WebAssembly.Instance);
+    assert.strictEqual(instance.exports, wasmExports);
+};

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -9,6 +9,7 @@ extern "C" {
     fn assert_null(v: JsValue);
     fn debug_values() -> JsValue;
     fn assert_function_table(a: JsValue, b: usize);
+    fn assert_instance(a: JsValue, b: JsValue);
 }
 
 #[wasm_bindgen_test]
@@ -212,6 +213,11 @@ fn memory_accessor_appears_to_work() {
         move |val, _, _| v.push(val)
     });
     assert_eq!(v, [3, 0, 0, 0]);
+}
+
+#[wasm_bindgen_test]
+fn instance_accessor_appears_to_work() {
+    assert_instance(wasm_bindgen::instance(), wasm_bindgen::exports());
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
### Description

Just like `wasm_bindgen::module`, `wasm_bindgen::memory`, `wasm_bindgen::exports`, this pr adds `wasm_bindgen::instance` to get current wasm instance.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
