### PR TITLE
feat: Promise ergonomics for typed concurrent awaits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 
 ## Unreleased
 
+### Added
+
+* Promise ergonomics: `Promise::all_tuple` and `Promise::all_settled_tuple`
+  for heterogeneous concurrent awaits (arity 1..=8, destructure via
+  `.into_parts()`), typed `FromIterator` / `Extend` on `js_sys::Array<T>` so
+  the canonical `Promise::all_iterable(&iter.collect::<Array<_>>()).await`
+  one-liner infers element types without turbofish, and a new
+  `wasm_bindgen::IntoJsGeneric` trait underpinning the inference (with
+  codegen-emitted identity impls and a `#[wasm_bindgen(no_into_js_generic)]`
+  opt-out for types like `JsClosure`). Also re-exports `JsGeneric` from the
+  prelude. Fixes [#5042](https://github.com/wasm-bindgen/wasm-bindgen/issues/5042).
+  Callers that relied on `.collect::<Array>()` implicitly erasing typed
+  items into `Array<JsValue>` now need `.map(JsValue::from)`.
+  [#5113](https://github.com/wasm-bindgen/wasm-bindgen/pull/5113)
+
 ### Fixed
 
 * Fixed namespaced export identifiers in generated JS/TS to use qualified names
@@ -15,6 +30,7 @@
   no longer uses stderr output to determine if a driver has failed; instead a
   per-attempt timeout detects stuck drivers and retries on a new port.
   [#5111](https://github.com/wasm-bindgen/wasm-bindgen/pull/5111)
+
 ## [0.2.118](https://github.com/rustwasm/wasm-bindgen/compare/0.2.117...0.2.118)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * Promise ergonomics: `Promise::all_tuple` and `Promise::all_settled_tuple`
   for heterogeneous concurrent awaits (arity 1..=8, destructure via
-  `.into_parts()`), typed `FromIterator` / `Extend` on `js_sys::Array<T>` so
+  `.into_tuple()`), typed `FromIterator` / `Extend` on `js_sys::Array<T>` so
   the canonical `Promise::all_iterable(&iter.collect::<Array<_>>()).await`
   one-liner infers element types without turbofish, and a new
   `wasm_bindgen::IntoJsGeneric` trait underpinning the inference (with
@@ -16,7 +16,7 @@
   prelude. Fixes [#5042](https://github.com/wasm-bindgen/wasm-bindgen/issues/5042).
   Callers that relied on `.collect::<Array>()` implicitly erasing typed
   items into `Array<JsValue>` now need `.map(JsValue::from)`.
-  [#5113](https://github.com/wasm-bindgen/wasm-bindgen/pull/5113)
+  [#5121](https://github.com/wasm-bindgen/wasm-bindgen/pull/5121)
 
 * Added `wasm_bindgen::instance()` to return the current
   `WebAssembly.Instance`. The generated JS glue retains the 

--- a/crates/cli/tests/reference/async-number.bg.js
+++ b/crates/cli/tests/reference/async-number.bg.js
@@ -30,7 +30,7 @@ export function __wbg_call_a24592a6f349a97e() { return handleError(function (arg
     const ret = arg0.call(arg1, arg2);
     return ret;
 }, arguments); }
-export function __wbg_new_typed_323f37fd55ab048d(arg0, arg1) {
+export function __wbg_new_typed_f83251c19eb777b9(arg0, arg1) {
     try {
         var state0 = {a: arg0, b: arg1};
         var cb0 = (arg0, arg1) => {

--- a/crates/cli/tests/reference/async-number.wat
+++ b/crates/cli/tests/reference/async-number.wat
@@ -23,7 +23,7 @@
   (import "./reference_test_bg.js" "__wbg___wbindgen_throw_6b64449b9b9ed33c" (func (;3;) (type 4)))
   (import "./reference_test_bg.js" "__wbg__wbg_cb_unref_b46c9b5a9f08ec37" (func (;4;) (type 12)))
   (import "./reference_test_bg.js" "__wbg_call_a24592a6f349a97e" (func (;5;) (type 17)))
-  (import "./reference_test_bg.js" "__wbg_new_typed_323f37fd55ab048d" (func (;6;) (type 6)))
+  (import "./reference_test_bg.js" "__wbg_new_typed_f83251c19eb777b9" (func (;6;) (type 6)))
   (import "./reference_test_bg.js" "__wbg_queueMicrotask_5d15a957e6aa920e" (func (;7;) (type 12)))
   (import "./reference_test_bg.js" "__wbg_queueMicrotask_f8819e5ffc402f36" (func (;8;) (type 14)))
   (import "./reference_test_bg.js" "__wbg_resolve_e6c466bc1052f16c" (func (;9;) (type 14)))

--- a/crates/cli/tests/reference/async-void.bg.js
+++ b/crates/cli/tests/reference/async-void.bg.js
@@ -30,7 +30,7 @@ export function __wbg_call_a24592a6f349a97e() { return handleError(function (arg
     const ret = arg0.call(arg1, arg2);
     return ret;
 }, arguments); }
-export function __wbg_new_typed_323f37fd55ab048d(arg0, arg1) {
+export function __wbg_new_typed_f83251c19eb777b9(arg0, arg1) {
     try {
         var state0 = {a: arg0, b: arg1};
         var cb0 = (arg0, arg1) => {

--- a/crates/cli/tests/reference/async-void.wat
+++ b/crates/cli/tests/reference/async-void.wat
@@ -22,7 +22,7 @@
   (import "./reference_test_bg.js" "__wbg___wbindgen_throw_6b64449b9b9ed33c" (func (;3;) (type 4)))
   (import "./reference_test_bg.js" "__wbg__wbg_cb_unref_b46c9b5a9f08ec37" (func (;4;) (type 11)))
   (import "./reference_test_bg.js" "__wbg_call_a24592a6f349a97e" (func (;5;) (type 16)))
-  (import "./reference_test_bg.js" "__wbg_new_typed_323f37fd55ab048d" (func (;6;) (type 6)))
+  (import "./reference_test_bg.js" "__wbg_new_typed_f83251c19eb777b9" (func (;6;) (type 6)))
   (import "./reference_test_bg.js" "__wbg_queueMicrotask_5d15a957e6aa920e" (func (;7;) (type 11)))
   (import "./reference_test_bg.js" "__wbg_queueMicrotask_f8819e5ffc402f36" (func (;8;) (type 13)))
   (import "./reference_test_bg.js" "__wbg_resolve_e6c466bc1052f16c" (func (;9;) (type 13)))

--- a/crates/cli/tests/reference/function-attrs.bg.js
+++ b/crates/cli/tests/reference/function-attrs.bg.js
@@ -89,7 +89,7 @@ export function __wbg_call_a24592a6f349a97e() { return handleError(function (arg
     const ret = arg0.call(arg1, arg2);
     return ret;
 }, arguments); }
-export function __wbg_new_typed_323f37fd55ab048d(arg0, arg1) {
+export function __wbg_new_typed_f83251c19eb777b9(arg0, arg1) {
     try {
         var state0 = {a: arg0, b: arg1};
         var cb0 = (arg0, arg1) => {

--- a/crates/cli/tests/reference/function-attrs.wat
+++ b/crates/cli/tests/reference/function-attrs.wat
@@ -27,7 +27,7 @@
   (import "./reference_test_bg.js" "__wbg___wbindgen_throw_6b64449b9b9ed33c" (func (;4;) (type 4)))
   (import "./reference_test_bg.js" "__wbg__wbg_cb_unref_b46c9b5a9f08ec37" (func (;5;) (type 15)))
   (import "./reference_test_bg.js" "__wbg_call_a24592a6f349a97e" (func (;6;) (type 20)))
-  (import "./reference_test_bg.js" "__wbg_new_typed_323f37fd55ab048d" (func (;7;) (type 6)))
+  (import "./reference_test_bg.js" "__wbg_new_typed_f83251c19eb777b9" (func (;7;) (type 6)))
   (import "./reference_test_bg.js" "__wbg_queueMicrotask_5d15a957e6aa920e" (func (;8;) (type 15)))
   (import "./reference_test_bg.js" "__wbg_queueMicrotask_f8819e5ffc402f36" (func (;9;) (type 17)))
   (import "./reference_test_bg.js" "__wbg_resolve_e6c466bc1052f16c" (func (;10;) (type 17)))

--- a/crates/cli/tests/reference/wasm-export-colon.js
+++ b/crates/cli/tests/reference/wasm-export-colon.js
@@ -301,7 +301,7 @@ function __wbg_get_imports() {
             const ret = new Error();
             return ret;
         },
-        __wbg_new_typed_323f37fd55ab048d: function(arg0, arg1) {
+        __wbg_new_typed_f83251c19eb777b9: function(arg0, arg1) {
             try {
                 var state0 = {a: arg0, b: arg1};
                 var cb0 = (arg0, arg1) => {

--- a/crates/cli/tests/reference/wasm-export-colon.wat
+++ b/crates/cli/tests/reference/wasm-export-colon.wat
@@ -48,7 +48,7 @@
   (import "./reference_test_bg.js" "__wbg_name_4042d1d7bd3559e7" (func (;18;) (type 17)))
   (import "./reference_test_bg.js" "__wbg_name_d3c35622d14bb080" (func (;19;) (type 22)))
   (import "./reference_test_bg.js" "__wbg_new_cb2a314576635710" (func (;20;) (type 4)))
-  (import "./reference_test_bg.js" "__wbg_new_typed_323f37fd55ab048d" (func (;21;) (type 9)))
+  (import "./reference_test_bg.js" "__wbg_new_typed_f83251c19eb777b9" (func (;21;) (type 9)))
   (import "./reference_test_bg.js" "__wbg_now_f583f05f4ed894e2" (func (;22;) (type 21)))
   (import "./reference_test_bg.js" "__wbg_performance_ce6182246e03f6e4" (func (;23;) (type 22)))
   (import "./reference_test_bg.js" "__wbg_queueMicrotask_5d15a957e6aa920e" (func (;24;) (type 19)))

--- a/crates/js-sys/benches/promise_combinators.js
+++ b/crates/js-sys/benches/promise_combinators.js
@@ -1,0 +1,8 @@
+// Helper for the promise-combinator benchmark.
+//
+// Creates a promise that resolves to `value` after yielding once to the
+// event loop via `setTimeout(0)`. Each invocation returns a fresh promise,
+// so callers can build a batch for `Promise.all` / `join_all`.
+export function makeTimeoutPromise(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), 0));
+}

--- a/crates/js-sys/benches/promise_combinators.rs
+++ b/crates/js-sys/benches/promise_combinators.rs
@@ -1,0 +1,104 @@
+//! Apples-to-apples comparison of promise combinators.
+//!
+//! Both paths join the **exact same** JS `Promise`s — the only thing that
+//! differs is the combinator. This isolates combinator overhead from the
+//! underlying async work (which is identical on both sides: `setTimeout(0)`
+//! backed promises).
+//!
+//! Paths compared:
+//!
+//! * `futures_util::future::join_all` over `Vec<JsFuture<T>>` where each
+//!   `JsFuture` wraps one of the input `Promise`s. This is the
+//!   Rust-executor-cooperative path the PR claims is slower.
+//! * `Promise::all_iterable(&iter.collect()).await` — the canonical
+//!   one-liner. The iterator items are `Promise<T>`, so
+//!   `FromIterator<Promise<T>>` infers the target `Array<Promise<T>>`
+//!   annotation-free via `IntoJsGeneric`. Delegates to `Promise.all` on the
+//!   JS side. No intermediate `Vec`, no `js_sys::futures` wrapper in the hot
+//!   loop, no macros, no new combinator crate surface.
+//!
+//! Varying N exposes any scaling behaviour differences — in particular
+//! `futures_util::future::join_all`'s O(N) re-poll of every child on every
+//! wake, which becomes O(N^2) total poll work when wakes arrive one-by-one.
+
+use js_sys::{futures::JsFuture, Array, Number, Promise};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::{wasm_bindgen_bench, Criterion};
+
+// One setTimeout(0)-backed promise per invocation. Kept in JS so the
+// construction cost is equal on both sides of the comparison.
+#[wasm_bindgen(module = "/benches/promise_combinators.js")]
+extern "C" {
+    #[wasm_bindgen(js_name = makeTimeoutPromise)]
+    fn make_timeout_promise(value: f64) -> Promise<Number>;
+}
+
+fn make_timeout_promises(n: usize) -> Vec<Promise<Number>> {
+    (0..n).map(|i| make_timeout_promise(i as f64)).collect()
+}
+
+async fn bench_futures_join_all(n: usize) {
+    let promises = make_timeout_promises(n);
+    // Wrap every promise in a `JsFuture`, then join via the Rust executor.
+    let futs: Vec<JsFuture<Number>> = promises.into_iter().map(JsFuture::from).collect();
+    let results = futures_util::future::join_all(futs).await;
+    // Keep results live across the await so nothing is optimised away.
+    std::hint::black_box(results);
+}
+
+async fn bench_promise_all(n: usize) {
+    // Canonical one-liner: collect the promise-producing iterator straight
+    // into a typed `Array<Promise<Number>>` via `FromIterator` (inference
+    // pins the element type through `IntoJsGeneric::JsCanon`), then hand it
+    // to `Promise::all_iterable` and await. The `::<Array<_>>()` turbofish
+    // picks `Array` as the target container (`Promise::all_iterable` is
+    // generic over any `Iterable`, so something has to name the concrete
+    // container); `_` is inferred from the iterator's item type as
+    // `Promise<Number>`. One JS-side combinator, one wake, no intermediate
+    // `Vec`.
+    let results = Promise::all_iterable(
+        &(0..n)
+            .map(|i| make_timeout_promise(i as f64))
+            .collect::<Array<_>>(),
+    )
+    .await
+    .unwrap();
+    std::hint::black_box(results);
+}
+
+#[wasm_bindgen_bench]
+async fn bench_join_combinators(c: &mut Criterion) {
+    // N = 10 matches the PR claim's workload size.
+    // N = 100, 1000 expose any super-linear scaling of the Rust path.
+    for &n in &[10usize, 100, 1000] {
+        let label_futures = format!("futures_join_all_timeout_n{n}");
+        c.bench_async_function(&label_futures, |b| {
+            Box::pin(async move {
+                b.iter_custom_future(move |iters| async move {
+                    let start = wasm_bindgen_test::Instant::now();
+                    for _ in 0..iters {
+                        bench_futures_join_all(n).await;
+                    }
+                    start.elapsed()
+                })
+                .await;
+            })
+        })
+        .await;
+
+        let label_promise_all = format!("promise_all_timeout_n{n}");
+        c.bench_async_function(&label_promise_all, |b| {
+            Box::pin(async move {
+                b.iter_custom_future(move |iters| async move {
+                    let start = wasm_bindgen_test::Instant::now();
+                    for _ in 0..iters {
+                        bench_promise_all(n).await;
+                    }
+                    start.elapsed()
+                })
+                .await;
+            })
+        })
+        .await;
+    }
+}

--- a/crates/js-sys/src/futures/mod.rs
+++ b/crates/js-sys/src/futures/mod.rs
@@ -46,6 +46,7 @@ use wasm_bindgen::__rt::marker::ErasableGeneric;
 #[cfg(all(target_arch = "wasm32", feature = "std", panic = "unwind"))]
 use wasm_bindgen::__rt::panic_to_panic_error;
 use wasm_bindgen::convert::{FromWasmAbi, Upcast};
+use wasm_bindgen::sys::Promising;
 use wasm_bindgen::{prelude::*, JsError, JsGeneric};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "futures-core-03-stream")))]
@@ -126,7 +127,7 @@ impl<T> fmt::Debug for JsFuture<T> {
     }
 }
 
-impl<T: 'static + FromWasmAbi> From<Promise<T>> for JsFuture<T> {
+impl<T: JsGeneric + FromWasmAbi> From<Promise<T>> for JsFuture<T> {
     fn from(js: Promise<T>) -> JsFuture<T> {
         // Use the `then` method to schedule two callbacks, one for the
         // resolved value and one for the rejected value. We're currently
@@ -216,7 +217,7 @@ impl<T> Future for JsFuture<T> {
     }
 }
 
-impl<T: 'static + FromWasmAbi> IntoFuture for Promise<T> {
+impl<T: JsGeneric + FromWasmAbi> IntoFuture for Promise<T> {
     type Output = Result<T, JsValue>;
     type IntoFuture = JsFuture<T>;
 
@@ -254,10 +255,10 @@ where
         spawn_local(async move {
             match future.await {
                 Ok(val) => {
-                    resolve.call(&JsValue::undefined(), (&val,)).unwrap_throw();
+                    resolve.call(&JsValue::UNDEFINED, (&val,)).unwrap_throw();
                 }
                 Err(val) => {
-                    reject.call(&JsValue::undefined(), (&val,)).unwrap_throw();
+                    reject.call(&JsValue::UNDEFINED, (&val,)).unwrap_throw();
                 }
             }
         });
@@ -295,14 +296,14 @@ where
             let res = future.catch_unwind().await;
             match res {
                 Ok(Ok(val)) => {
-                    resolve.call(&JsValue::undefined(), (&val,)).unwrap_throw();
+                    resolve.call(&JsValue::UNDEFINED, (&val,)).unwrap_throw();
                 }
                 Ok(Err(val)) => {
-                    reject.call(&JsValue::undefined(), (&val,)).unwrap_throw();
+                    reject.call(&JsValue::UNDEFINED, (&val,)).unwrap_throw();
                 }
                 Err(val) => {
                     reject
-                        .call(&JsValue::undefined(), (&panic_to_panic_error(val),))
+                        .call(&JsValue::UNDEFINED, (&panic_to_panic_error(val),))
                         .unwrap_throw();
                 }
             }
@@ -331,10 +332,11 @@ where
 /// If the `future` provided panics then the returned `Promise` **will not
 /// resolve**. Instead it will be a leaked promise. This is an unfortunate
 /// limitation of Wasm currently that's hoped to be fixed one day!
-pub fn future_to_promise_typed<F, T>(future: F) -> Promise<T>
+pub fn future_to_promise_typed<T, F>(future: F) -> Promise<<T as Promising>::Resolution>
 where
     F: Future<Output = Result<T, JsValue>> + 'static,
-    T: FromWasmAbi + JsGeneric + Upcast<T> + 'static,
+    T: Promising + FromWasmAbi + JsGeneric,
+    <T as Promising>::Resolution: JsGeneric,
 {
     let mut future = Some(future);
 
@@ -343,10 +345,10 @@ where
         spawn_local(async move {
             match future.await {
                 Ok(val) => {
-                    resolve.call(&JsValue::undefined(), (&val,)).unwrap_throw();
+                    resolve.call(&JsValue::UNDEFINED, (&val,)).unwrap_throw();
                 }
                 Err(val) => {
-                    reject.call(&JsValue::undefined(), (&val,)).unwrap_throw();
+                    reject.call(&JsValue::UNDEFINED, (&val,)).unwrap_throw();
                 }
             }
         });

--- a/crates/js-sys/src/futures/stream.rs
+++ b/crates/js-sys/src/futures/stream.rs
@@ -21,7 +21,7 @@ pub struct JsStream<T = JsValue> {
     done: bool,
 }
 
-impl<T: 'static + FromWasmAbi> JsStream<T> {
+impl<T: JsGeneric + FromWasmAbi> JsStream<T> {
     fn next_future(&self) -> Result<JsFuture<IteratorNext<T>>, JsValue> {
         self.iter.next_iterator().map(JsFuture::from)
     }
@@ -37,7 +37,7 @@ impl<T> From<AsyncIterator<T>> for JsStream<T> {
     }
 }
 
-impl<T: 'static + JsGeneric + FromWasmAbi + Unpin> Stream for JsStream<T> {
+impl<T: JsGeneric + FromWasmAbi + Unpin> Stream for JsStream<T> {
     type Item = Result<T, JsValue>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -56,7 +56,7 @@ use wasm_bindgen::JsError;
 
 // Re-export sys types as js-sys types
 pub use wasm_bindgen::sys::{JsOption, Null, Promising, Undefined};
-pub use wasm_bindgen::JsGeneric;
+pub use wasm_bindgen::{IntoJsGeneric, JsGeneric};
 
 // When adding new imports:
 //
@@ -1944,73 +1944,44 @@ impl<T: JsGeneric> core::iter::IntoIterator for Array<T> {
     }
 }
 
-#[cfg(not(js_sys_unstable_apis))]
-impl<A> core::iter::FromIterator<A> for Array
-where
-    A: AsRef<JsValue>,
-{
-    fn from_iter<I>(iter: I) -> Array
+// `FromIterator` / `Extend` for `Array<T>` project every input value through
+// its canonical [`JsGeneric`] via [`IntoJsGeneric`].
+//
+// Using an associated type (`A::JsCanon`) rather than a free type parameter
+// bound by `AsRef<T>` is what lets inference pick `T` uniquely from the
+// iterator item — no turbofish, no intermediate `Vec`, no `AsRef<T>` ambiguity
+// across the auto-generated `AsRef<JsValue>` / `AsRef<Self>` /
+// `AsRef<Superclass>` impls on `#[wasm_bindgen]` types. This fixes the
+// `A: AsRef<T>` E0283 regression that the earlier unstable impl suffered
+// from (see #5042).
+//
+// The reference-iteration case (`Item = &T`) is handled transparently by the
+// `&T: IntoJsGeneric` blanket in `wasm-bindgen` core.
+//
+// Compared to the pre-existing stable impl `impl<A> FromIterator<A> for Array
+// where A: AsRef<JsValue>`, this changes the target type from the untyped
+// `Array<JsValue>` (implicit erasure) to the typed `Array<A::JsCanon>`.
+// Call sites that want erasure now opt in via `.map(JsValue::from)` at the
+// call site.
+
+impl<A: IntoJsGeneric> core::iter::FromIterator<A> for Array<A::JsCanon> {
+    fn from_iter<I>(iter: I) -> Array<A::JsCanon>
     where
         I: IntoIterator<Item = A>,
     {
-        let mut out = Array::new();
+        let mut out = Array::<A::JsCanon>::new_typed();
         out.extend(iter);
         out
     }
 }
 
-#[cfg(js_sys_unstable_apis)]
-impl<A, T: JsGeneric> core::iter::FromIterator<A> for Array<T>
-where
-    A: AsRef<T>,
-{
-    fn from_iter<I>(iter: I) -> Array<T>
-    where
-        I: IntoIterator<Item = A>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let out = Array::new_with_length_typed(capacity as u32);
-        let mut i = 0;
-        for value in iter {
-            out.set(i, value.as_ref());
-            i += 1;
-        }
-        // Trim to the actual number of items written, in case size_hint over-estimated.
-        if i < capacity as u32 {
-            out.set_length(i);
-        }
-        out
-    }
-}
-
-#[cfg(not(js_sys_unstable_apis))]
-impl<A> core::iter::Extend<A> for Array
-where
-    A: AsRef<JsValue>,
-{
+impl<A: IntoJsGeneric> core::iter::Extend<A> for Array<A::JsCanon> {
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = A>,
     {
         for value in iter {
-            self.push(value.as_ref());
-        }
-    }
-}
-
-#[cfg(js_sys_unstable_apis)]
-impl<A, T: JsGeneric> core::iter::Extend<A> for Array<T>
-where
-    A: AsRef<T>,
-{
-    fn extend<I>(&mut self, iter: I)
-    where
-        I: IntoIterator<Item = A>,
-    {
-        for value in iter {
-            self.push(value.as_ref());
+            self.push(&value.to_js());
         }
     }
 }
@@ -5167,6 +5138,7 @@ impl Iterator {
     fn looks_like_iterator(it: &JsValue) -> bool {
         #[wasm_bindgen]
         extern "C" {
+            #[derive(Clone, Debug)]
             type MaybeIterator;
 
             #[wasm_bindgen(method, getter)]
@@ -10551,6 +10523,7 @@ pub mod Intl {
     #[wasm_bindgen]
     extern "C" {
         #[wasm_bindgen(extends = CollatorOptions)]
+        #[derive(Clone, Debug)]
         pub type ResolvedCollatorOptions;
 
         #[wasm_bindgen(method, getter = locale)]
@@ -12869,9 +12842,9 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
     #[wasm_bindgen(constructor)]
-    pub fn new_typed<T: JsGeneric>(
+    pub fn new_typed<T: Promising + JsGeneric>(
         cb: &mut dyn FnMut(Function<fn(T) -> Undefined>, Function<fn(JsValue) -> Undefined>),
-    ) -> Promise<T>;
+    ) -> Promise<<T as Promising>::Resolution>;
 
     /// The `Promise.all(iterable)` method returns a single `Promise` that
     /// resolves when all of the promises in the iterable argument have resolved
@@ -12971,7 +12944,6 @@ extern "C" {
     /// `AggregateError` if all promises in the iterable rejected.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any)
-    #[cfg(not(js_sys_unstable_apis))]
     #[wasm_bindgen(static_method_of = Promise, js_name = any)]
     pub fn any_iterable<I: Iterable>(obj: &I) -> Promise<<I::Item as Promising>::Resolution>
     where
@@ -13144,6 +13116,129 @@ impl<T: JsGeneric> Promising for Promise<T> {
     type Resolution = T;
 }
 
+/// Internal: maps a tuple of `Promise<T_i>` to the result shapes of
+/// [`Promise::all_tuple`] and [`Promise::all_settled_tuple`].
+///
+/// Implemented for every tuple arity 1..=8 of `Promise<T: JsGeneric>`. The
+/// associated `Joined` / `Settled` types pin down the [`ArrayTuple`] shape
+/// of the result so the one [`JsCast::unchecked_into`] needed to reinterpret
+/// the [`Array<JsValue>`] returned by `Promise.all` / `Promise.allSettled`
+/// is encapsulated inside each impl — the caller sees a fully-typed
+/// `Promise<ArrayTuple<...>>`.
+///
+/// The soundness of the `unchecked_into`s here rests on `Promise.all` and
+/// `Promise.allSettled` preserving input order and arity, which they do by
+/// spec.
+///
+/// You normally call [`Promise::all_tuple`] / [`Promise::all_settled_tuple`]
+/// rather than using this trait directly.
+#[doc(hidden)]
+pub trait PromiseTuple {
+    /// The typed `ArrayTuple` shape the joined promise resolves to.
+    ///
+    /// For a tuple `(Promise<T1>, Promise<T2>, ...)` this is
+    /// `ArrayTuple<(T1, T2, ...)>`.
+    type Joined: JsGeneric;
+
+    /// The typed `ArrayTuple` shape the all-settled promise resolves to.
+    ///
+    /// For a tuple `(Promise<T1>, Promise<T2>, ...)` this is
+    /// `ArrayTuple<(PromiseState<T1>, PromiseState<T2>, ...)>`.
+    type Settled: JsGeneric;
+
+    /// Internal: join via `Promise.all`, returning a typed `Promise`.
+    #[doc(hidden)]
+    fn __all(self) -> Promise<Self::Joined>;
+
+    /// Internal: settle via `Promise.allSettled`, returning a typed `Promise`.
+    #[doc(hidden)]
+    fn __all_settled(self) -> Promise<Self::Settled>;
+}
+
+macro_rules! impl_promise_tuple {
+    ([$($T:ident)+] [$($idx:tt)+]) => {
+        impl<$($T: JsGeneric),+> PromiseTuple for ($(Promise<$T>,)+) {
+            type Joined = ArrayTuple<($($T,)+)>;
+            type Settled = ArrayTuple<($(PromiseState<$T>,)+)>;
+
+            fn __all(self) -> Promise<Self::Joined> {
+                // Build the heterogeneous `ArrayTuple` of promises via the
+                // existing `From<(...)>` impl (each element upcasts through
+                // `JsGeneric`), hand it to `Promise.all_iterable`, and
+                // reinterpret the result `Array<JsValue>` as the intended
+                // `ArrayTuple<(T1, T2, ...)>`. The reinterpret is safe
+                // because `Promise.all` preserves order and arity by spec.
+                let tuple: ArrayTuple<($(Promise<$T>,)+)> = ($(self.$idx,)+).into();
+                use wasm_bindgen::JsCast;
+                Promise::all_iterable(&tuple).unchecked_into()
+            }
+
+            fn __all_settled(self) -> Promise<Self::Settled> {
+                let tuple: ArrayTuple<($(Promise<$T>,)+)> = ($(self.$idx,)+).into();
+                use wasm_bindgen::JsCast;
+                Promise::all_settled_iterable(&tuple).unchecked_into()
+            }
+        }
+    };
+}
+
+impl_promise_tuple!([T1][0]);
+impl_promise_tuple!([T1 T2] [0 1]);
+impl_promise_tuple!([T1 T2 T3] [0 1 2]);
+impl_promise_tuple!([T1 T2 T3 T4] [0 1 2 3]);
+impl_promise_tuple!([T1 T2 T3 T4 T5] [0 1 2 3 4]);
+impl_promise_tuple!([T1 T2 T3 T4 T5 T6] [0 1 2 3 4 5]);
+impl_promise_tuple!([T1 T2 T3 T4 T5 T6 T7] [0 1 2 3 4 5 6]);
+impl_promise_tuple!([T1 T2 T3 T4 T5 T6 T7 T8] [0 1 2 3 4 5 6 7]);
+
+impl Promise {
+    /// Heterogeneous counterpart to [`Promise::all_iterable`]: accepts a Rust
+    /// tuple of `Promise<T_i>` and returns a single [`Promise`] resolving to a
+    /// typed [`ArrayTuple<(T_1, T_2, ..., T_n)>`].
+    ///
+    /// Destructure the awaited result via [`ArrayTuple::into_parts`] to get
+    /// the individual values back as a native Rust tuple. Implemented for
+    /// arity 1..=8.
+    ///
+    /// Rejects with the first rejection, matching `Promise.all` semantics.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use js_sys::Promise;
+    ///
+    /// let (response, buffer) = Promise::all_tuple((fetch_promise, buffer_promise))
+    ///     .await?
+    ///     .into_parts();
+    /// ```
+    #[inline]
+    pub fn all_tuple<T: PromiseTuple>(promises: T) -> Promise<T::Joined> {
+        promises.__all()
+    }
+
+    /// Heterogeneous counterpart to [`Promise::all_settled_iterable`]: accepts
+    /// a Rust tuple of `Promise<T_i>` and returns a single [`Promise`]
+    /// resolving to a typed
+    /// `ArrayTuple<(PromiseState<T_1>, ..., PromiseState<T_n>)>`.
+    ///
+    /// Unlike [`Promise::all_tuple`], this never rejects early: every input
+    /// settles (fulfills or rejects) and is reflected by its [`PromiseState`]
+    /// slot in the result tuple. Implemented for arity 1..=8.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use js_sys::Promise;
+    ///
+    /// let results = Promise::all_settled_tuple((fetch_promise, buffer_promise)).await?;
+    /// let (response_state, buffer_state) = results.into_parts();
+    /// ```
+    #[inline]
+    pub fn all_settled_tuple<T: PromiseTuple>(promises: T) -> Promise<T::Settled> {
+        promises.__all_settled()
+    }
+}
+
 /// Returns a handle to the global scope object.
 ///
 /// This allows access to the global properties and global names by accessing
@@ -13176,6 +13271,7 @@ pub fn global() -> Object {
         // the end which triggers CSP errors.
         #[wasm_bindgen]
         extern "C" {
+            #[derive(Clone, Debug)]
             type Global;
 
             #[wasm_bindgen(thread_local_v2, js_name = globalThis)]

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1680,9 +1680,15 @@ macro_rules! impl_tuple {
                 self.$last()
             }
 
-            /// Convert the ArrayTuple into its corresponding Rust tuple
-            pub fn into_parts(self) -> ($($T,)+) {
+            /// Convert the ArrayTuple into its corresponding Rust tuple.
+            pub fn into_tuple(self) -> ($($T,)+) {
                 ($(self.$vars(),)+)
+            }
+
+            /// Deprecated alias for [`ArrayTuple::into_tuple`].
+            #[deprecated(note = "renamed to `into_tuple`")]
+            pub fn into_parts(self) -> ($($T,)+) {
+                self.into_tuple()
             }
 
             /// Create a new ArrayTuple from the corresponding parts.
@@ -12783,6 +12789,19 @@ impl<T> PromiseState<T> {
     }
 }
 
+/// Converts a `PromiseState<T>` into a `Result<T, JsValue>`, matching the
+/// spec invariant that exactly one of the fulfilled value or the rejection
+/// reason is populated per slot.
+impl<T: JsGeneric + FromWasmAbi> From<PromiseState<T>> for Result<T, JsValue> {
+    fn from(state: PromiseState<T>) -> Result<T, JsValue> {
+        if state.is_fulfilled() {
+            Ok(state.get_value().unwrap())
+        } else {
+            Err(state.get_reason().unwrap())
+        }
+    }
+}
+
 // Promise
 #[wasm_bindgen]
 extern "C" {
@@ -13146,37 +13165,56 @@ pub trait PromiseTuple {
     /// `ArrayTuple<(PromiseState<T1>, PromiseState<T2>, ...)>`.
     type Settled: JsGeneric;
 
-    /// Internal: join via `Promise.all`, returning a typed `Promise`.
-    #[doc(hidden)]
-    fn __all(self) -> Promise<Self::Joined>;
+    /// Join via `Promise.all`, returning a typed `Promise`.
+    fn all(self) -> Promise<Self::Joined>;
 
-    /// Internal: settle via `Promise.allSettled`, returning a typed `Promise`.
-    #[doc(hidden)]
-    fn __all_settled(self) -> Promise<Self::Settled>;
+    /// Settle via `Promise.allSettled`, returning a typed `Promise`.
+    fn all_settled(self) -> Promise<Self::Settled>;
 }
 
 macro_rules! impl_promise_tuple {
     ([$($T:ident)+] [$($idx:tt)+]) => {
+        // Rust tuple of `Promise<T_i>`. Builds the heterogeneous
+        // `ArrayTuple` of promises via the existing `From<(...)>` impl
+        // (each element upcasts through `JsGeneric`), then delegates to
+        // the `ArrayTuple` impl below.
         impl<$($T: JsGeneric),+> PromiseTuple for ($(Promise<$T>,)+) {
             type Joined = ArrayTuple<($($T,)+)>;
             type Settled = ArrayTuple<($(PromiseState<$T>,)+)>;
 
-            fn __all(self) -> Promise<Self::Joined> {
-                // Build the heterogeneous `ArrayTuple` of promises via the
-                // existing `From<(...)>` impl (each element upcasts through
-                // `JsGeneric`), hand it to `Promise.all_iterable`, and
-                // reinterpret the result `Array<JsValue>` as the intended
-                // `ArrayTuple<(T1, T2, ...)>`. The reinterpret is safe
-                // because `Promise.all` preserves order and arity by spec.
+            fn all(self) -> Promise<Self::Joined> {
                 let tuple: ArrayTuple<($(Promise<$T>,)+)> = ($(self.$idx,)+).into();
-                use wasm_bindgen::JsCast;
-                Promise::all_iterable(&tuple).unchecked_into()
+                tuple.all()
             }
 
-            fn __all_settled(self) -> Promise<Self::Settled> {
+            fn all_settled(self) -> Promise<Self::Settled> {
                 let tuple: ArrayTuple<($(Promise<$T>,)+)> = ($(self.$idx,)+).into();
+                tuple.all_settled()
+            }
+        }
+
+        // `ArrayTuple<(Promise<T_1>, ..., Promise<T_n>)>` — callers who
+        // already have an `ArrayTuple` (e.g. from a binding that returns
+        // one, or built via `.into()` earlier in a pipeline) can pass it
+        // directly without unpacking into a Rust tuple.
+        //
+        // Hands the `ArrayTuple` straight to `Promise.all_iterable` /
+        // `Promise.allSettled_iterable` and reinterprets the result
+        // `Array<JsValue>` as the intended typed `ArrayTuple`. Safe because
+        // `Promise.all` / `Promise.allSettled` preserve input order and
+        // arity by spec.
+        impl<$($T: JsGeneric),+> PromiseTuple for ArrayTuple<($(Promise<$T>,)+)> {
+            type Joined = ArrayTuple<($($T,)+)>;
+            type Settled = ArrayTuple<($(PromiseState<$T>,)+)>;
+
+            fn all(self) -> Promise<Self::Joined> {
                 use wasm_bindgen::JsCast;
-                Promise::all_settled_iterable(&tuple).unchecked_into()
+                Promise::all_iterable(&self).unchecked_into()
+            }
+
+            fn all_settled(self) -> Promise<Self::Settled> {
+                use wasm_bindgen::JsCast;
+                Promise::all_settled_iterable(&self).unchecked_into()
             }
         }
     };
@@ -13196,7 +13234,7 @@ impl Promise {
     /// tuple of `Promise<T_i>` and returns a single [`Promise`] resolving to a
     /// typed [`ArrayTuple<(T_1, T_2, ..., T_n)>`].
     ///
-    /// Destructure the awaited result via [`ArrayTuple::into_parts`] to get
+    /// Destructure the awaited result via [`ArrayTuple::into_tuple`] to get
     /// the individual values back as a native Rust tuple. Implemented for
     /// arity 1..=8.
     ///
@@ -13209,11 +13247,11 @@ impl Promise {
     ///
     /// let (response, buffer) = Promise::all_tuple((fetch_promise, buffer_promise))
     ///     .await?
-    ///     .into_parts();
+    ///     .into_tuple();
     /// ```
     #[inline]
     pub fn all_tuple<T: PromiseTuple>(promises: T) -> Promise<T::Joined> {
-        promises.__all()
+        promises.all()
     }
 
     /// Heterogeneous counterpart to [`Promise::all_settled_iterable`]: accepts
@@ -13231,11 +13269,11 @@ impl Promise {
     /// use js_sys::Promise;
     ///
     /// let results = Promise::all_settled_tuple((fetch_promise, buffer_promise)).await?;
-    /// let (response_state, buffer_state) = results.into_parts();
+    /// let (response_state, buffer_state) = results.into_tuple();
     /// ```
     #[inline]
     pub fn all_settled_tuple<T: PromiseTuple>(promises: T) -> Promise<T::Settled> {
-        promises.__all_settled()
+        promises.all_settled()
     }
 }
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1955,9 +1955,7 @@ impl<T: JsGeneric> core::iter::IntoIterator for Array<T> {
 //
 // Using an associated type (`A::JsCanon`) rather than a free type parameter
 // bound by `AsRef<T>` is what lets inference pick `T` uniquely from the
-// iterator item — no turbofish, no intermediate `Vec`, no `AsRef<T>` ambiguity
-// across the auto-generated `AsRef<JsValue>` / `AsRef<Self>` /
-// `AsRef<Superclass>` impls on `#[wasm_bindgen]` types. This fixes the
+// iterator item. This fixes the
 // `A: AsRef<T>` E0283 regression that the earlier unstable impl suffered
 // from (see #5042).
 //

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -84,28 +84,68 @@ fn from_iter() {
 }
 
 // Regression test for https://github.com/wasm-bindgen/wasm-bindgen/issues/5042:
-// collecting a wasm_bindgen type without explicit type annotations must not cause E0283.
-#[cfg(not(js_sys_unstable_apis))]
+// collecting a `#[wasm_bindgen]` type without explicit type annotations must
+// not cause E0283. Under the `IntoJsGeneric`-based `FromIterator` impl the
+// result type is the typed `Array<JsString>` (projected via
+// `JsString::JsCanon = JsString`), not the erased `Array<JsValue>` the
+// pre-`IntoJsGeneric` stable impl produced.
 #[wasm_bindgen_test]
 fn from_iter_wasm_bindgen_type() {
-    // JsString implements AsRef<JsValue> and AsRef<JsString>; before the fix this
-    // caused "cannot infer type for type parameter T" on the stable FromIterator impl.
     let arr = Array::from_iter([JsString::from("a"), JsString::from("b")]);
     assert_eq!(arr.length(), 2);
 
-    let arr = [JsString::from("x"), JsString::from("y")]
-        .iter()
-        .collect::<Array>();
+    // Reference iteration: `Item = &JsString`, the `&T: IntoJsGeneric`
+    // blanket delegates through to `JsString::JsCanon = JsString`, so
+    // `.collect::<Array<_>>()` infers `Array<JsString>`.
+    let arr: Array<JsString> = [JsString::from("x"), JsString::from("y")].iter().collect();
+    assert_eq!(arr.length(), 2);
+
+    // Explicit erasure — opt in via `.map(JsValue::from)` if you still want
+    // the untyped shape.
+    let arr: Array<JsValue> = [JsString::from("p"), JsString::from("q")]
+        .into_iter()
+        .map(JsValue::from)
+        .collect();
     assert_eq!(arr.length(), 2);
 }
 
-#[cfg(not(js_sys_unstable_apis))]
+// Regression shape from the flutter_rust_bridge report (fzyzcjy/flutter_rust_bridge#3009):
+//
+//     worker.post_message(&Array::from_iter([wasm_init_object]))?;
+//
+// The important property is that `Array::from_iter([owned_value])` — where
+// the iterator item is an owned `#[wasm_bindgen]` type — must infer to the
+// **typed** `Array<T>` without any turbofish or type annotation. On the old
+// `FromIterator<A> for Array<T> where A: AsRef<T>` impl this triggered
+// E0283 because `A: AsRef<T>` had multiple solutions for `T`.
+#[wasm_bindgen_test]
+fn from_iter_owned_wasm_bindgen_type_infers() {
+    // No annotation, single owned item: must infer `Array<Object>`, and the
+    // inference must propagate through a `&Array<Object>` argument without
+    // re-triggering ambiguity.
+    fn take_object_array(arr: &Array<Object>) {
+        assert_eq!(arr.length(), 1);
+    }
+
+    let obj = Object::new();
+    let arr = Array::from_iter([obj]);
+    take_object_array(&arr);
+}
+
 #[wasm_bindgen_test]
 fn extend() {
-    let mut array = Array::new();
+    // Starting from a typed `Array<JsString>`: `.extend` with matching items
+    // works without any erasure.
+    let mut array: Array<JsString> = Array::new_typed();
     array.extend([JsString::from("a"), JsString::from("b")]);
     array.extend([JsString::from("c"), JsString::from("d")]);
     assert_eq!(array.length(), 4);
+
+    // Starting from an untyped `Array<JsValue>`: callers extend with
+    // `JsValue` items (or explicitly erase typed ones via `.map`).
+    let mut array: Array<JsValue> = Array::new();
+    array.extend([JsString::from("e"), JsString::from("f")].map(JsValue::from));
+    assert_eq!(array.length(), 2);
 }
 
 #[wasm_bindgen_test]
@@ -1362,7 +1402,6 @@ fn test_array_to_vec() {
     assert_eq!(second.id(), 2);
 }
 
-#[cfg(js_sys_unstable_apis)]
 #[wasm_bindgen_test]
 fn test_array_from_iter() {
     let items = vec![
@@ -1378,7 +1417,6 @@ fn test_array_from_iter() {
     assert_eq!(first.id(), 1);
 }
 
-#[cfg(js_sys_unstable_apis)]
 #[wasm_bindgen_test]
 fn test_array_extend() {
     let mut arr: Array<TestItem> = Array::new_typed();

--- a/crates/js-sys/tests/wasm/ArrayTuple.rs
+++ b/crates/js-sys/tests/wasm/ArrayTuple.rs
@@ -166,14 +166,14 @@ fn last_method() {
 }
 
 #[wasm_bindgen_test]
-fn into_parts_method() {
+fn into_tuple_method() {
     let tuple1: ArrayTuple<(JsString,)> = ArrayTuple::new1(&JsString::from("single"));
-    let (a,) = tuple1.into_parts();
+    let (a,) = tuple1.into_tuple();
     assert_eq!(a, "single");
 
     let tuple2: ArrayTuple<(JsString, Number)> =
         ArrayTuple::new2(&JsString::from("hello"), &Number::from(42));
-    let (first, second) = tuple2.into_parts();
+    let (first, second) = tuple2.into_tuple();
     assert_eq!(first, "hello");
     assert_eq!(second, 42);
 
@@ -182,7 +182,7 @@ fn into_parts_method() {
         &JsString::from("middle"),
         &Number::from(3),
     );
-    let (a, b, c) = tuple3.into_parts();
+    let (a, b, c) = tuple3.into_tuple();
     assert_eq!(a, 1);
     assert_eq!(b, "middle");
     assert_eq!(c, 3);
@@ -194,12 +194,24 @@ fn into_parts_method() {
         &JsString::from("d"),
         &JsString::from("e"),
     );
-    let (v1, v2, v3, v4, v5) = tuple5.into_parts();
+    let (v1, v2, v3, v4, v5) = tuple5.into_tuple();
     assert_eq!(v1, "a");
     assert_eq!(v2, "b");
     assert_eq!(v3, "c");
     assert_eq!(v4, "d");
     assert_eq!(v5, "e");
+}
+
+// The deprecated `into_parts` alias still works.
+#[wasm_bindgen_test]
+fn into_parts_alias_still_works() {
+    #[allow(deprecated)]
+    let tuple: ArrayTuple<(JsString, Number)> =
+        ArrayTuple::new2(&JsString::from("hello"), &Number::from(42));
+    #[allow(deprecated)]
+    let (first, second) = tuple.into_parts();
+    assert_eq!(first, "hello");
+    assert_eq!(second, 42);
 }
 
 #[wasm_bindgen_test]

--- a/crates/js-sys/tests/wasm/Promise.rs
+++ b/crates/js-sys/tests/wasm/Promise.rs
@@ -253,7 +253,7 @@ async fn test_future_to_promise_success() {
 #[wasm_bindgen_test]
 async fn test_future_to_promise_error() {
     let future = async { Err(JsValue::from("future failed")) };
-    let promise: Promise<TestValue> = future_to_promise_typed(future);
+    let promise = future_to_promise_typed::<TestValue, _>(future);
 
     let result = JsFuture::from(promise).await;
     assert!(result.is_err());
@@ -265,10 +265,10 @@ async fn test_future_to_promise_error() {
 async fn test_future_to_promise_chaining_with_closure() {
     let future = async {
         let val = TestValue::new(&JsString::from("chained"));
-        Ok(val.into())
+        Ok(val)
     };
 
-    let promise: Promise<TestValue> = future_to_promise_typed(future);
+    let promise = future_to_promise_typed(future);
     let closure = Closure::new(|val: TestValue| {
         val.transform(&JsString::from("_then"))
             .map_err(|e| JsError::new(&e.as_string().unwrap_or_default()))
@@ -284,10 +284,10 @@ async fn test_future_to_promise_async_computation() {
     let future = async {
         let base = TestValue::new(&JsString::from("computed"));
         let transformed = base.transform(&JsString::from("_async"))?;
-        Ok(transformed.into())
+        Ok(transformed)
     };
 
-    let promise: Promise<TestValue> = future_to_promise_typed(future);
+    let promise = future_to_promise_typed(future);
     let result = JsFuture::from(promise).await.unwrap();
     assert_eq!(result.value(), "computed_async");
 }

--- a/crates/js-sys/tests/wasm/futures.rs
+++ b/crates/js-sys/tests/wasm/futures.rs
@@ -153,7 +153,7 @@ async fn all_tuple_two() {
 
     let p1 = Promise::resolve(&Number::from(1));
     let p2 = Promise::resolve(&JsString::from("hello"));
-    let (a, b) = Promise::all_tuple((p1, p2)).await.unwrap().into_parts();
+    let (a, b) = Promise::all_tuple((p1, p2)).await.unwrap().into_tuple();
     assert_eq!(a.value_of(), 1.0);
     assert_eq!(b, "hello");
 }
@@ -165,7 +165,7 @@ async fn all_tuple_three() {
     let p1 = Promise::resolve(&Number::from(1));
     let p2 = Promise::resolve(&Number::from(2));
     let p3 = Promise::resolve(&Number::from(3));
-    let (a, b, c) = Promise::all_tuple((p1, p2, p3)).await.unwrap().into_parts();
+    let (a, b, c) = Promise::all_tuple((p1, p2, p3)).await.unwrap().into_tuple();
     assert_eq!(a.value_of(), 1.0);
     assert_eq!(b.value_of(), 2.0);
     assert_eq!(c.value_of(), 3.0);
@@ -176,7 +176,7 @@ async fn all_tuple_single() {
     use js_sys::Number;
 
     let p1 = Promise::resolve(&Number::from(42));
-    let (a,) = Promise::all_tuple((p1,)).await.unwrap().into_parts();
+    let (a,) = Promise::all_tuple((p1,)).await.unwrap().into_tuple();
     assert_eq!(a.value_of(), 42.0);
 }
 
@@ -200,7 +200,7 @@ async fn all_tuple_accepts_future_via_future_to_promise_typed() {
 
     let p1 = Promise::resolve(&Number::from(7));
     let p2 = future_to_promise_typed(async { Ok(JsString::from("world")) });
-    let (a, b) = Promise::all_tuple((p1, p2)).await.unwrap().into_parts();
+    let (a, b) = Promise::all_tuple((p1, p2)).await.unwrap().into_tuple();
     assert_eq!(a.value_of(), 7.0);
     assert_eq!(b, "world");
 }
@@ -214,11 +214,59 @@ async fn all_settled_tuple_mixed() {
     let p1 = Promise::resolve(&Number::from(1));
     let p2 = Promise::<JsString>::reject_typed(&JsValue::from("err"));
     let results = Promise::all_settled_tuple((p1, p2)).await.unwrap();
-    let (s1, s2) = results.into_parts();
+    let (s1, s2) = results.into_tuple();
     assert!(s1.is_fulfilled());
     assert_eq!(s1.get_value().unwrap().value_of(), 1.0);
     assert!(s2.is_rejected());
     assert_eq!(s2.get_reason().unwrap(), "err");
+}
+
+// `Promise::all_tuple` also accepts an `ArrayTuple<(Promise<T_1>, ...)>`
+// directly, without first unpacking it into a Rust tuple. Same semantics,
+// same destructuring.
+#[wasm_bindgen_test]
+async fn all_tuple_accepts_array_tuple() {
+    use js_sys::{ArrayTuple, JsString, Number, Promise};
+
+    let p1 = Promise::resolve(&Number::from(1));
+    let p2 = Promise::resolve(&JsString::from("hello"));
+    let tuple: ArrayTuple<(Promise<Number>, Promise<JsString>)> = (p1, p2).into();
+    let (a, b) = Promise::all_tuple(tuple).await.unwrap().into_tuple();
+    assert_eq!(a.value_of(), 1.0);
+    assert_eq!(b, "hello");
+}
+
+#[wasm_bindgen_test]
+async fn all_settled_tuple_accepts_array_tuple() {
+    use js_sys::{ArrayTuple, JsString, Number, Promise};
+
+    let p1 = Promise::resolve(&Number::from(1));
+    let p2 = Promise::<JsString>::reject_typed(&JsValue::from("err"));
+    let tuple: ArrayTuple<(Promise<Number>, Promise<JsString>)> = (p1, p2).into();
+    let results = Promise::all_settled_tuple(tuple).await.unwrap();
+    let (s1, s2) = results.into_tuple();
+    assert!(s1.is_fulfilled());
+    assert_eq!(s1.get_value().unwrap().value_of(), 1.0);
+    assert!(s2.is_rejected());
+    assert_eq!(s2.get_reason().unwrap(), "err");
+}
+
+// `PromiseState<T>` converts to `Result<T, JsValue>` directly, matching the
+// `allSettled` spec invariant that exactly one of `value` / `reason` is
+// populated per slot.
+#[wasm_bindgen_test]
+async fn promise_state_into_result() {
+    use js_sys::{JsString, Number, Promise};
+
+    let p1 = Promise::resolve(&Number::from(1));
+    let p2 = Promise::<JsString>::reject_typed(&JsValue::from("err"));
+    let results = Promise::all_settled_tuple((p1, p2)).await.unwrap();
+    let (s1, s2) = results.into_tuple();
+
+    let r1: Result<Number, JsValue> = s1.into();
+    let r2: Result<JsString, JsValue> = s2.into();
+    assert_eq!(r1.unwrap().value_of(), 1.0);
+    assert_eq!(r2.unwrap_err(), "err");
 }
 
 // Atomics / multithread-specific tests

--- a/crates/js-sys/tests/wasm/futures.rs
+++ b/crates/js-sys/tests/wasm/futures.rs
@@ -4,10 +4,7 @@ use std::ops::FnMut;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
-// ---------------------------------------------------------------------------
 // IntoFuture — direct promise.await
-// ---------------------------------------------------------------------------
-
 #[wasm_bindgen_test]
 async fn promise_await_resolve() {
     let p = Promise::resolve(&JsValue::from(42));
@@ -30,10 +27,7 @@ async fn typed_promise_await() {
     assert_eq!(n.value_of(), 99.0);
 }
 
-// ---------------------------------------------------------------------------
 // JsFuture
-// ---------------------------------------------------------------------------
-
 #[wasm_bindgen_test]
 async fn promise_resolve_is_ok_future() {
     let p = Promise::resolve(&JsValue::from(42));
@@ -64,10 +58,7 @@ async fn can_create_multiple_futures_from_same_promise() {
     b.await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
 // future_to_promise
-// ---------------------------------------------------------------------------
-
 #[wasm_bindgen_test]
 async fn ok_future_is_resolved_promise() {
     let p = future_to_promise(async { Ok(JsValue::from(42)) });
@@ -82,10 +73,7 @@ async fn error_future_is_rejected_promise() {
     assert_eq!(e, 42);
 }
 
-// ---------------------------------------------------------------------------
 // spawn_local
-// ---------------------------------------------------------------------------
-
 #[wasm_bindgen]
 extern "C" {
     fn setTimeout(c: &Closure<dyn FnMut()>);
@@ -157,10 +145,83 @@ async fn spawn_local_err_no_exception() {
     assert_eq!(rx.await.unwrap(), 42);
 }
 
-// ---------------------------------------------------------------------------
-// Atomics / multithread-specific tests
-// ---------------------------------------------------------------------------
+// Heterogeneous `Promise::all_tuple` — the tuple method resolves a
+// tuple of `Promise<T_i>` into a typed `ArrayTuple<(T_1, T_2, ...)>`.
+#[wasm_bindgen_test]
+async fn all_tuple_two() {
+    use js_sys::{JsString, Number};
 
+    let p1 = Promise::resolve(&Number::from(1));
+    let p2 = Promise::resolve(&JsString::from("hello"));
+    let (a, b) = Promise::all_tuple((p1, p2)).await.unwrap().into_parts();
+    assert_eq!(a.value_of(), 1.0);
+    assert_eq!(b, "hello");
+}
+
+#[wasm_bindgen_test]
+async fn all_tuple_three() {
+    use js_sys::Number;
+
+    let p1 = Promise::resolve(&Number::from(1));
+    let p2 = Promise::resolve(&Number::from(2));
+    let p3 = Promise::resolve(&Number::from(3));
+    let (a, b, c) = Promise::all_tuple((p1, p2, p3)).await.unwrap().into_parts();
+    assert_eq!(a.value_of(), 1.0);
+    assert_eq!(b.value_of(), 2.0);
+    assert_eq!(c.value_of(), 3.0);
+}
+
+#[wasm_bindgen_test]
+async fn all_tuple_single() {
+    use js_sys::Number;
+
+    let p1 = Promise::resolve(&Number::from(42));
+    let (a,) = Promise::all_tuple((p1,)).await.unwrap().into_parts();
+    assert_eq!(a.value_of(), 42.0);
+}
+
+// Rejection propagation: `Promise::all_tuple` rejects with the first
+// rejection, matching `Promise.all` semantics.
+#[wasm_bindgen_test]
+async fn all_tuple_rejects_on_first_failure() {
+    use js_sys::{JsString, Number};
+
+    let p1 = Promise::resolve(&Number::from(1));
+    let p2 = Promise::<JsString>::reject_typed(&JsValue::from("fail"));
+    let err = Promise::all_tuple((p1, p2)).await.unwrap_err();
+    assert_eq!(err, "fail");
+}
+
+// Mixing a Rust `Future` with a `Promise` is handled at the call site via
+// `future_to_promise_typed` — explicit spawning, no trait magic.
+#[wasm_bindgen_test]
+async fn all_tuple_accepts_future_via_future_to_promise_typed() {
+    use js_sys::{futures::future_to_promise_typed, JsString, Number};
+
+    let p1 = Promise::resolve(&Number::from(7));
+    let p2 = future_to_promise_typed(async { Ok(JsString::from("world")) });
+    let (a, b) = Promise::all_tuple((p1, p2)).await.unwrap().into_parts();
+    assert_eq!(a.value_of(), 7.0);
+    assert_eq!(b, "world");
+}
+
+// Heterogeneous `Promise::all_settled_tuple` — never rejects early; every
+// slot settles and is reflected by a `PromiseState<T_i>` in the result.
+#[wasm_bindgen_test]
+async fn all_settled_tuple_mixed() {
+    use js_sys::{JsString, Number};
+
+    let p1 = Promise::resolve(&Number::from(1));
+    let p2 = Promise::<JsString>::reject_typed(&JsValue::from("err"));
+    let results = Promise::all_settled_tuple((p1, p2)).await.unwrap();
+    let (s1, s2) = results.into_parts();
+    assert!(s1.is_fulfilled());
+    assert_eq!(s1.get_value().unwrap().value_of(), 1.0);
+    assert!(s2.is_rejected());
+    assert_eq!(s2.get_reason().unwrap(), "err");
+}
+
+// Atomics / multithread-specific tests
 #[cfg(target_feature = "atomics")]
 use std::future::Future;
 #[cfg(target_feature = "atomics")]
@@ -229,10 +290,7 @@ async fn wait_async_promise_callback_runs_without_wake() {
     done_rx.await.expect("task finished");
 }
 
-// ---------------------------------------------------------------------------
 // JsStream (requires futures-core-03-stream feature)
-// ---------------------------------------------------------------------------
-
 #[cfg(feature = "futures-core-03-stream")]
 #[wasm_bindgen_test]
 async fn can_use_an_async_iterable_as_stream() {

--- a/crates/macro-support/src/ast.rs
+++ b/crates/macro-support/src/ast.rs
@@ -354,6 +354,8 @@ pub struct ImportType {
     pub no_upcast: bool,
     /// If present, don't generate a `Promising` impl
     pub no_promising: bool,
+    /// If present, don't generate an `IntoJsGeneric` impl
+    pub no_into_js_generic: bool,
     /// Path to wasm_bindgen
     pub wasm_bindgen: Path,
     /// Validated generics

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -992,6 +992,7 @@ impl TryToTokens for ast::ImportType {
 
         let no_deref = self.no_deref;
         let no_promising = self.no_promising;
+        let no_into_js_generic = self.no_into_js_generic;
 
         let doc = if doc_comment.is_empty() {
             quote! {}
@@ -1042,6 +1043,60 @@ impl TryToTokens for ast::ImportType {
             phantom = quote! {};
             phantom_init = quote! {};
         }
+
+        // Identity implementation of `IntoJsGeneric`. Declaring this per-type,
+        // rather than via a blanket over `T: JsGeneric`, preserves the option
+        // for future wrapper types to pick a non-identity `JsCanon`.
+        //
+        // The body goes through `JsValue` rather than `Clone::clone(self)`:
+        // every `#[wasm_bindgen]` type has an auto-generated
+        // `AsRef<JsValue>` impl, and `JsValue` is always refcount-cloneable.
+        // This lets the impl apply uniformly to types that do not implement
+        // Rust-level `Clone` (e.g. generic types whose parameters aren't
+        // `Clone`, or plain handle wrappers that simply don't derive
+        // `Clone`), while still performing the single boundary-crossing
+        // refcount op that any JS handle would require.
+        //
+        // Types whose Rust wrapper enforces owned-once destruction semantics
+        // (currently just `JsClosure`) opt out via the
+        // `#[wasm_bindgen(no_into_js_generic)]` attribute — producing a
+        // second wrapper over the same handle would violate those semantics.
+        //
+        // The extra `Self: JsGeneric` predicate propagates any generic
+        // type-parameter requirements the `JsGeneric` blanket imposes
+        // through `ErasableGeneric<Repr = JsValue>` etc.
+        let into_js_generic_impl = if no_into_js_generic {
+            quote! {}
+        } else {
+            let mut clause =
+                self.generics
+                    .where_clause
+                    .clone()
+                    .unwrap_or_else(|| syn::WhereClause {
+                        where_token: Default::default(),
+                        predicates: Default::default(),
+                    });
+            let self_ty_generics = &ty_generics;
+            let self_ty: syn::Type = syn::parse_quote!(#rust_name #self_ty_generics);
+            let wasm_bindgen_path: syn::Path = syn::parse_quote!(#wasm_bindgen);
+            clause.predicates.push(syn::parse_quote!(
+                #self_ty: #wasm_bindgen_path::JsGeneric
+            ));
+            quote! {
+                #[automatically_derived]
+                impl #impl_generics #wasm_bindgen::IntoJsGeneric
+                    for #rust_name #ty_generics
+                #clause
+                {
+                    type JsCanon = #rust_name #ty_generics;
+                    #[inline]
+                    fn to_js(&self) -> #rust_name #ty_generics {
+                        let js: JsValue = AsRef::<JsValue>::as_ref(self).clone();
+                        <#rust_name #ty_generics as JsCast>::unchecked_from_js(js)
+                    }
+                }
+            }
+        };
 
         (quote! {
             #(#attrs)*
@@ -1165,6 +1220,8 @@ impl TryToTokens for ast::ImportType {
                     #[inline]
                     fn as_ref(&self) -> &#rust_name #ty_generics { self }
                 }
+
+                #into_js_generic_impl
 
                 // TODO: remove this on the next major version
                 // Only include lifetime params here; type params use their
@@ -2230,29 +2287,28 @@ impl ast::ImportFunction {
             return None;
         }
 
-        // For static methods, only infer class hoisting when all type args are
-        // bare generic param idents — not associated types like `I::Item`.
-        if is_static {
-            if let syn::PathArguments::AngleBracketed(ref gen_args) = seg.arguments {
-                let fn_params: Vec<&Ident> = generics::generic_params(&self.generics)
-                    .iter()
-                    .map(|p| p.0)
-                    .collect();
-                for arg in &gen_args.args {
-                    match arg {
-                        syn::GenericArgument::Lifetime(_) => {}
-                        syn::GenericArgument::Type(syn::Type::Path(syn::TypePath {
-                            qself: None,
-                            path: arg_path,
-                        })) if arg_path.segments.len() == 1
-                            && matches!(
-                                arg_path.segments[0].arguments,
-                                syn::PathArguments::None
-                            )
-                            && fn_params.iter().any(|p| *p == &arg_path.segments[0].ident) => {}
-                        _ => return None,
-                    }
-                }
+        // Only hoist fn generics onto the class impl header when every fn
+        // generic mentioned in the return type's args appears in a
+        // *structurally constraining* position (per E0207 / RFC 0447).
+        //
+        // Non-constraining positions — projections (`<T as Trait>::Assoc`,
+        // `T::Item`), fn-ptr slots (`fn(T)` / `Fn(T)` sugar), associated-type
+        // binding RHS, etc. — would produce an `impl<T> Ret<...>` whose `T`
+        // is not determinable from `Self`, yielding a borrow-check-level
+        // compilation error. When we detect such a shape, bail so the
+        // parameter stays function-level.
+        //
+        // This replaces the earlier "static methods must have only bare
+        // idents" heuristic, which was both too strict (rejected valid
+        // shapes like `Array<Option<T>>`) and too narrow (didn't apply to
+        // constructors, leading to E0207 for `Promise<<T as Promising>::Resolution>`).
+        if let syn::PathArguments::AngleBracketed(ref gen_args) = seg.arguments {
+            let fn_params: Vec<&Ident> = generics::generic_params(&self.generics)
+                .iter()
+                .map(|p| p.0)
+                .collect();
+            if !generics::args_are_constraining_for(&gen_args.args, &fn_params) {
+                return None;
             }
         }
 

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -1048,19 +1048,16 @@ impl TryToTokens for ast::ImportType {
         // rather than via a blanket over `T: JsGeneric`, preserves the option
         // for future wrapper types to pick a non-identity `JsCanon`.
         //
-        // The body goes through `JsValue` rather than `Clone::clone(self)`:
-        // every `#[wasm_bindgen]` type has an auto-generated
-        // `AsRef<JsValue>` impl, and `JsValue` is always refcount-cloneable.
-        // This lets the impl apply uniformly to types that do not implement
-        // Rust-level `Clone` (e.g. generic types whose parameters aren't
-        // `Clone`, or plain handle wrappers that simply don't derive
-        // `Clone`), while still performing the single boundary-crossing
-        // refcount op that any JS handle would require.
+        // The body takes `self` by value and reinterprets the transparent JS
+        // handle wrapper into its canonical type. This lets the impl apply
+        // uniformly to types that do not implement Rust-level `Clone` (e.g.
+        // generic types whose parameters aren't `Clone`, or plain handle
+        // wrappers that simply don't derive `Clone`).
         //
         // Types whose Rust wrapper enforces owned-once destruction semantics
         // (currently just `JsClosure`) opt out via the
         // `#[wasm_bindgen(no_into_js_generic)]` attribute — producing a
-        // second wrapper over the same handle would violate those semantics.
+        // duplicate wrapper over the same handle would violate those semantics.
         //
         // The extra `Self: JsGeneric` predicate propagates any generic
         // type-parameter requirements the `JsGeneric` blanket imposes
@@ -1090,9 +1087,8 @@ impl TryToTokens for ast::ImportType {
                 {
                     type JsCanon = #rust_name #ty_generics;
                     #[inline]
-                    fn to_js(&self) -> #rust_name #ty_generics {
-                        let js: JsValue = AsRef::<JsValue>::as_ref(self).clone();
-                        <#rust_name #ty_generics as JsCast>::unchecked_from_js(js)
+                    fn to_js(self) -> #rust_name #ty_generics {
+            unsafe { core::mem::transmute_copy(&core::mem::ManuallyDrop::new(self)) }
                     }
                 }
             }

--- a/crates/macro-support/src/generics.rs
+++ b/crates/macro-support/src/generics.rs
@@ -316,6 +316,140 @@ pub(crate) fn used_generic_params<'a>(
     used_params
 }
 
+/// Checks whether every occurrence of each ident in `generic_names` that appears
+/// anywhere inside `args` is in a *structurally constraining* position —
+/// i.e. a position from which rustc can read the parameter off of the
+/// constructed type. This mirrors the E0207 rule for type parameters on
+/// `impl` blocks: a parameter must appear in `Self` (or a trait ref) in a
+/// structurally determined slot, otherwise Rust can't infer it at use sites.
+///
+/// Constraining positions (for a param appearing somewhere inside):
+///   - Bare: `T`
+///   - As a type argument of a nominal path `Foo<..., T, ...>` (recursive)
+///   - Under references, arrays, slices, tuples, parens (recursive)
+///
+/// Non-constraining positions:
+///   - Under a QSelf / projection: `<T as Trait>::X` or `T::X`
+///   - Inside a `fn(T) -> U` / `dyn Fn(T)` / `impl Fn(T)` — function-pointer
+///     and trait-object / `impl Trait` slots do not constrain.
+///   - Inside an associated-type binding's RHS (those project through the
+///     outer trait, so they are not injective).
+///
+/// Returns `true` if the args are safe to hoist (all occurrences constraining,
+/// or no occurrences at all), `false` if any occurrence is non-constraining.
+pub(crate) fn args_are_constraining_for(
+    args: &syn::punctuated::Punctuated<syn::GenericArgument, syn::Token![,]>,
+    generic_names: &[&Ident],
+) -> bool {
+    for arg in args {
+        match arg {
+            syn::GenericArgument::Type(ty) if !type_is_constraining(ty, generic_names) => {
+                return false;
+            }
+            // Associated type bindings (`Trait<Item = T>`) project through the
+            // outer trait, so any fn generics inside the RHS are behind a
+            // projection — not constraining.
+            syn::GenericArgument::AssocType(binding)
+                if type_mentions_any(&binding.ty, generic_names) =>
+            {
+                return false;
+            }
+            // Anything else (lifetimes, consts, already-constraining types,
+            // future arg kinds) doesn't disqualify the args.
+            _ => {}
+        }
+    }
+    true
+}
+
+/// A type is "constraining" for the fn generics it contains iff every
+/// occurrence of any `generic_names` ident within it is in a constraining
+/// position. See [`args_are_constraining_for`] for the rules.
+fn type_is_constraining(ty: &syn::Type, generic_names: &[&Ident]) -> bool {
+    match ty {
+        syn::Type::Path(type_path) => {
+            // QSelf -> projection like `<T as Trait>::Assoc`. Any fn generic
+            // appearing anywhere inside is behind a projection.
+            if type_path.qself.is_some() {
+                return !type_mentions_any(ty, generic_names);
+            }
+
+            // Bare `T` where T is a fn generic: constraining.
+            if type_path.path.segments.len() == 1 {
+                let seg = &type_path.path.segments[0];
+                if matches!(seg.arguments, syn::PathArguments::None)
+                    && generic_names.contains(&&seg.ident)
+                {
+                    return true;
+                }
+            }
+
+            // `T::Foo...` (multi-segment path whose head is a fn generic)
+            // is a projection through the head's implicit trait — any fn
+            // generic inside is non-constraining.
+            if type_path.path.segments.len() > 1 {
+                if let Some(first) = type_path.path.segments.first() {
+                    if generic_names.contains(&&first.ident) {
+                        return !type_mentions_any(ty, generic_names);
+                    }
+                }
+            }
+
+            // Nominal path `Foo<..args..>`: recurse into the last segment's
+            // args. Leading segments (module path) don't carry generics that
+            // mention fn params.
+            for seg in &type_path.path.segments {
+                match &seg.arguments {
+                    syn::PathArguments::None => {}
+                    syn::PathArguments::AngleBracketed(a) => {
+                        if !args_are_constraining_for(&a.args, generic_names) {
+                            return false;
+                        }
+                    }
+                    syn::PathArguments::Parenthesized(p) => {
+                        // `Fn(T) -> U` sugar: function-pointer-like,
+                        // non-constraining.
+                        for input in &p.inputs {
+                            if type_mentions_any(input, generic_names) {
+                                return false;
+                            }
+                        }
+                        if let syn::ReturnType::Type(_, ret) = &p.output {
+                            if type_mentions_any(ret, generic_names) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            true
+        }
+        syn::Type::Reference(r) => type_is_constraining(&r.elem, generic_names),
+        syn::Type::Array(a) => type_is_constraining(&a.elem, generic_names),
+        syn::Type::Slice(s) => type_is_constraining(&s.elem, generic_names),
+        syn::Type::Group(g) => type_is_constraining(&g.elem, generic_names),
+        syn::Type::Paren(p) => type_is_constraining(&p.elem, generic_names),
+        syn::Type::Tuple(t) => t
+            .elems
+            .iter()
+            .all(|e| type_is_constraining(e, generic_names)),
+        // Pointer / BareFn / TraitObject / ImplTrait / Infer / Never / Macro:
+        // any fn-generic mention here is non-constraining (fn-ptr, dyn, impl
+        // Trait are explicitly non-constraining per RFC 0447; the rest are
+        // handled conservatively).
+        _ => !type_mentions_any(ty, generic_names),
+    }
+}
+
+/// Whether `ty` mentions any of the given idents anywhere (constraining or not).
+fn type_mentions_any(ty: &syn::Type, generic_names: &[&Ident]) -> bool {
+    let vec: Vec<&Ident> = generic_names.to_vec();
+    let mut found = BTreeSet::new();
+    let mut visitor = GenericNameVisitor::new(&vec, &mut found);
+    visitor.visit_type(ty);
+    !found.is_empty()
+}
+
 /// Usage visitor for generic bounds
 pub(crate) fn generics_predicate_uses(
     predicate: &syn::WherePredicate,
@@ -801,5 +935,97 @@ mod tests {
             quote::quote!(#result).to_string(),
             quote::quote!(#expected).to_string()
         );
+    }
+
+    /// Parse a type whose last path segment carries generic args and hand them
+    /// to `args_are_constraining_for`. This mirrors how `class_return_path()`
+    /// feeds the gate.
+    fn args_are_constraining(ty_src: &str, params: &[&str]) -> bool {
+        let ty: syn::Type = syn::parse_str(ty_src).expect("valid type");
+        let path = match ty {
+            syn::Type::Path(syn::TypePath { qself: None, path }) => path,
+            _ => panic!("test helper expects a bare path type"),
+        };
+        let seg = path.segments.last().expect("at least one segment");
+        let args = match &seg.arguments {
+            syn::PathArguments::AngleBracketed(a) => a.args.clone(),
+            syn::PathArguments::None => Default::default(),
+            syn::PathArguments::Parenthesized(_) => {
+                panic!("test helper doesn't handle paren-style args at the top")
+            }
+        };
+        let idents: Vec<syn::Ident> = params
+            .iter()
+            .map(|p| syn::Ident::new(p, proc_macro2::Span::call_site()))
+            .collect();
+        let refs: Vec<&syn::Ident> = idents.iter().collect();
+        crate::generics::args_are_constraining_for(&args, &refs)
+    }
+
+    #[test]
+    fn hoist_gate_accepts_bare_idents() {
+        // `Array<T>` — bare param, trivially constraining.
+        assert!(args_are_constraining("Array<T>", &["T"]));
+        // Multiple bare params.
+        assert!(args_are_constraining("Map<K, V>", &["K", "V"]));
+    }
+
+    #[test]
+    fn hoist_gate_accepts_nested_nominal() {
+        // `Array<Option<T>>` — T is nested inside a nominal path, still
+        // constraining. This was wrongly rejected by the old bare-ident gate.
+        assert!(args_are_constraining("Array<Option<T>>", &["T"]));
+        // Deeply nested.
+        assert!(args_are_constraining("Array<Vec<Box<T>>>", &["T"]));
+        // References, arrays, tuples preserve constraining-ness.
+        assert!(args_are_constraining("Foo<&T>", &["T"]));
+        assert!(args_are_constraining("Foo<[T; 4]>", &["T"]));
+        assert!(args_are_constraining("Foo<(T, U)>", &["T", "U"]));
+    }
+
+    #[test]
+    fn hoist_gate_accepts_when_param_absent() {
+        // T doesn't appear at all → nothing to hoist → vacuously safe.
+        assert!(args_are_constraining("Array<i32>", &["T"]));
+        assert!(args_are_constraining("Promise<JsValue>", &["T"]));
+    }
+
+    #[test]
+    fn hoist_gate_rejects_qself_projection() {
+        // `Promise<<T as Promising>::Resolution>` — T only appears behind a
+        // projection, which is NOT constraining. This is the shape that
+        // produced E0207 before the fix.
+        assert!(!args_are_constraining(
+            "Promise<<T as Promising>::Resolution>",
+            &["T"]
+        ));
+    }
+
+    #[test]
+    fn hoist_gate_rejects_bare_projection() {
+        // `Array<T::Item>` — T appears as the head of a multi-segment path,
+        // which Rust resolves through an implicit projection. Non-constraining.
+        assert!(!args_are_constraining("Array<T::Item>", &["T"]));
+        // Even if U is constraining, T's non-constraining presence disqualifies
+        // the whole return path (partial hoisting would still be ill-formed).
+        assert!(!args_are_constraining("Foo<T::Item, U>", &["T", "U"]));
+    }
+
+    #[test]
+    fn hoist_gate_rejects_fn_ptr_and_fn_sugar() {
+        // `fn(T) -> U` and `Fn(T) -> U` sugar are both non-constraining slots.
+        assert!(!args_are_constraining("Foo<fn(T) -> i32>", &["T"]));
+        assert!(!args_are_constraining("Foo<Box<dyn Fn(T) -> i32>>", &["T"]));
+        // Return-position of the parenthesized sugar also counts.
+        assert!(!args_are_constraining("Foo<Box<dyn Fn(i32) -> T>>", &["T"]));
+    }
+
+    #[test]
+    fn hoist_gate_rejects_assoc_type_binding_rhs() {
+        // `Trait<Item = T>` — T sits behind the outer trait's projection.
+        assert!(!args_are_constraining(
+            "Foo<Box<dyn Iterator<Item = T>>>",
+            &["T"]
+        ));
     }
 }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -99,6 +99,7 @@ macro_rules! attrgen {
             (no_deref, false, NoDeref(Span)),
             (no_upcast, false, NoUpcast(Span)),
             (no_promising, false, NoPromising(Span)),
+            (no_into_js_generic, false, NoIntoJsGeneric(Span)),
             (vendor_prefix, false, VendorPrefix(Span, Ident)),
             (variadic, false, Variadic(Span)),
             (typescript_custom_section, false, TypescriptCustomSection(Span)),
@@ -828,6 +829,7 @@ impl ConvertToAst<(&ast::Program, BindgenAttrs)> for syn::ForeignItemType {
         let no_deref = attrs.no_deref().is_some();
         let no_upcast = attrs.no_upcast().is_some();
         let no_promising = attrs.no_promising().is_some();
+        let no_into_js_generic = attrs.no_into_js_generic().is_some();
         for (used, attr) in attrs.attrs.iter() {
             match attr {
                 BindgenAttr::Extends(_, e) => {
@@ -870,6 +872,7 @@ impl ConvertToAst<(&ast::Program, BindgenAttrs)> for syn::ForeignItemType {
             no_deref,
             no_upcast,
             no_promising,
+            no_into_js_generic,
             wasm_bindgen: program.wasm_bindgen.clone(),
             generics: generics.unwrap_or(self.generics),
         }))

--- a/crates/macro/ui-tests/missing-catch.stderr
+++ b/crates/macro/ui-tests/missing-catch.stderr
@@ -14,8 +14,8 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             AssertUnwindSafe<T>
             Box<[T]>
             Clamped<T>
+            JsError
             JsOption<T>
-            NonNull<T>
           and $N others
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -32,8 +32,8 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             AssertUnwindSafe<T>
             Box<[T]>
             Clamped<T>
+            JsError
             JsOption<T>
-            NonNull<T>
           and $N others
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,6 +50,6 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             AssertUnwindSafe<T>
             Box<[T]>
             Clamped<T>
+            JsError
             JsOption<T>
-            NonNull<T>
           and $N others

--- a/crates/test/sample/src/lib.rs
+++ b/crates/test/sample/src/lib.rs
@@ -30,7 +30,7 @@ impl Timeout {
             .unwrap() as f64; // TODO: checked cast
 
         let mut id = None;
-        let promise = Promise::new_typed(&mut |resolve, _reject| {
+        let promise = Promise::new_typed::<JsValue>(&mut |resolve, _reject| {
             id = Some(set_timeout(resolve.into(), millis));
         });
 

--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -262,7 +262,7 @@ If you already have a `Vec<Promise<T>>`, use [`Array::of`] to lift it:
 
 When the promises resolve to *different* types, collect them into a Rust
 tuple and pass to [`Promise::all_tuple`]. The result is a typed
-[`ArrayTuple<(T1, T2, ..., Tn)>`] you can destructure via `.into_parts()`
+[`ArrayTuple<(T1, T2, ..., Tn)>`] you can destructure via `.into_tuple()`
 back into a native Rust tuple. Implemented for arity 1..=8.
 
 ```rust
@@ -272,7 +272,7 @@ use js_sys::Promise;
 // buffer_promise: Promise<ArrayBuffer>
 let (response, buffer) = Promise::all_tuple((fetch_promise, buffer_promise))
     .await?
-    .into_parts();
+    .into_tuple();
 ```
 
 Rejects with the first rejection, matching `Promise.all` semantics.
@@ -285,7 +285,7 @@ never rejects early:
 use js_sys::Promise;
 
 let results = Promise::all_settled_tuple((fetch_promise, buffer_promise)).await?;
-let (response_state, buffer_state) = results.into_parts();
+let (response_state, buffer_state) = results.into_tuple();
 if response_state.is_fulfilled() {
     let response = response_state.get_value().unwrap();
     // ...
@@ -324,7 +324,7 @@ let (response, buffer) = Promise::all_tuple((
     future_to_promise_typed(async { Ok(buffer_from_rust().await?) }),
 ))
 .await?
-.into_parts();
+.into_tuple();
 ```
 
 `future_to_promise_typed` spawns the `Future` on the current thread and

--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -186,6 +186,160 @@ Both functions are also re-exported from `wasm_bindgen_futures` unchanged.
 [`spawn_local`]: https://docs.rs/js-sys/*/js_sys/futures/fn.spawn_local.html
 [`future_to_promise`]: https://docs.rs/js-sys/*/js_sys/futures/fn.future_to_promise.html
 
+## Combining JS Promises Concurrently
+
+Rust's async ecosystem and JavaScript's promise ecosystem interoperate
+cleanly: awaiting a [`Promise<T>`][`js_sys::Promise`] yields to the JS
+event loop, so in-flight JS-side work (fetches, timers, I/O) continues in
+parallel while Rust futures are pending. `futures_util`'s `join_all` /
+`select` / `try_join_all` work correctly over `JsFuture`s and deliver
+proper parallelism.
+
+When your inputs are already JS `Promise<T>` values, the native
+`Promise.all` / `Promise.allSettled` / `Promise.race` bindings on
+[`js_sys::Promise`] are the idiomatic choice — they match JS semantics
+exactly and avoid the Rust executor polling each child on every wake.
+
+The canonical recipe collects the promise-producing iterator straight into a
+typed [`Array<Promise<T>>`] and hands it to the combinator — no turbofish
+on the elements, no intermediate `Vec`:
+
+### `Promise.all` — all must succeed
+
+```rust
+use js_sys::{Array, Promise};
+
+// responses: Array<Response>
+let responses = Promise::all_iterable(
+    &(0..10)
+        .map(|_| worker.fetch_with_str_and_init(&url, &init))
+        .collect::<Array<_>>(),
+)
+.await?;
+```
+
+Rejects with the first rejection, matching `Promise.all` semantics.
+
+### `Promise.allSettled` — wait for all, never reject early
+
+```rust
+use js_sys::{Array, Promise};
+
+// results: Array<PromiseState<Response>>
+let results = Promise::all_settled_iterable(
+    &(0..10)
+        .map(|_| worker.fetch_with_str_and_init(&url, &init))
+        .collect::<Array<_>>(),
+)
+.await?;
+for state in results.iter() {
+    if state.is_fulfilled() {
+        let value = state.get_value().unwrap();
+    } else {
+        let reason = state.get_reason().unwrap();
+    }
+}
+```
+
+### `Promise.race` — first to settle
+
+```rust
+use js_sys::{Array, Promise};
+
+// first: Response
+let first = Promise::race_iterable(
+    &(0..10)
+        .map(|_| worker.fetch_with_str_and_init(&url, &init))
+        .collect::<Array<_>>(),
+)
+.await?;
+```
+
+If you already have a `Vec<Promise<T>>`, use [`Array::of`] to lift it:
+`Promise::all_iterable(&Array::of(&promises))`.
+
+### Heterogeneous `Promise.all` over a tuple
+
+When the promises resolve to *different* types, collect them into a Rust
+tuple and pass to [`Promise::all_tuple`]. The result is a typed
+[`ArrayTuple<(T1, T2, ..., Tn)>`] you can destructure via `.into_parts()`
+back into a native Rust tuple. Implemented for arity 1..=8.
+
+```rust
+use js_sys::Promise;
+
+// fetch_promise:  Promise<Response>
+// buffer_promise: Promise<ArrayBuffer>
+let (response, buffer) = Promise::all_tuple((fetch_promise, buffer_promise))
+    .await?
+    .into_parts();
+```
+
+Rejects with the first rejection, matching `Promise.all` semantics.
+
+For the `Promise.allSettled` analogue use [`Promise::all_settled_tuple`]; it
+resolves to an `ArrayTuple<(PromiseState<T1>, ..., PromiseState<Tn>)>` and
+never rejects early:
+
+```rust
+use js_sys::Promise;
+
+let results = Promise::all_settled_tuple((fetch_promise, buffer_promise)).await?;
+let (response_state, buffer_state) = results.into_parts();
+if response_state.is_fulfilled() {
+    let response = response_state.get_value().unwrap();
+    // ...
+}
+```
+
+There is no `race_tuple` equivalent — `Promise.race` returns whichever input
+settles first, whose type would be a union `T1 | T2 | ... | Tn` that Rust
+can't express. For heterogeneous race, collect into an `Array<JsValue>` and
+use [`Promise::race_iterable`] explicitly, then narrow with `dyn_into` at
+the inspection site.
+
+### Mixing Rust `Future`s with JS `Promise`s
+
+If some of your inputs are Rust `Future<Output = Result<T, JsValue>>` values
+rather than JS `Promise<T>`, lift each one explicitly with
+[`future_to_promise_typed`] at the call site:
+
+```rust
+use js_sys::{futures::future_to_promise_typed, Array, Promise};
+
+// For homogeneous batches, mix both shapes into one `Array<Promise<T>>`:
+let responses = Promise::all_iterable(
+    &[
+        fetch_promise,
+        future_to_promise_typed(async { Ok(fetch_via_rust().await?) }),
+    ]
+    .into_iter()
+    .collect::<Array<_>>(),
+)
+.await?;
+
+// For heterogeneous tuples, lift each future before passing the tuple:
+let (response, buffer) = Promise::all_tuple((
+    fetch_promise,
+    future_to_promise_typed(async { Ok(buffer_from_rust().await?) }),
+))
+.await?
+.into_parts();
+```
+
+`future_to_promise_typed` spawns the `Future` on the current thread and
+returns a JS `Promise<T>` that settles with its result — from that point on
+the two shapes are interchangeable.
+
+[`js_sys::Promise`]: https://docs.rs/js-sys/*/js_sys/struct.Promise.html
+[`Array<Promise<T>>`]: https://docs.rs/js-sys/*/js_sys/struct.Array.html
+[`Array::of`]: https://docs.rs/js-sys/*/js_sys/struct.Array.html#method.of
+[`future_to_promise_typed`]: https://docs.rs/js-sys/*/js_sys/futures/fn.future_to_promise_typed.html
+[`Promise::all_tuple`]: https://docs.rs/js-sys/*/js_sys/struct.Promise.html#method.all_tuple
+[`Promise::all_settled_tuple`]: https://docs.rs/js-sys/*/js_sys/struct.Promise.html#method.all_settled_tuple
+[`Promise::race_iterable`]: https://docs.rs/js-sys/*/js_sys/struct.Promise.html#method.race_iterable
+[`ArrayTuple<(T1, T2, ..., Tn)>`]: https://docs.rs/js-sys/*/js_sys/struct.ArrayTuple.html
+
 ## Using Generic Promise Types
 
 Promises support [erasable generic type parameters](./types/js-sys.md). With

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -59,6 +59,11 @@ use core::panic::AssertUnwindSafe;
 
 #[wasm_bindgen_macro::wasm_bindgen(wasm_bindgen = crate)]
 extern "C" {
+    // `no_into_js_generic` is required because closures are deliberately
+    // not `Clone`: duplicating the Rust wrapper over a JS callback would
+    // break the "owned once" destruction semantics the type is designed
+    // to enforce.
+    #[wasm_bindgen(no_into_js_generic)]
     type JsClosure;
 
     #[wasm_bindgen(method)]

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -788,11 +788,7 @@ impl IntoWasmAbi for JsError {
     }
 }
 
-// `JsError` is `#[repr(transparent)]` over `JsValue`, so this is the same
-// wire format as `JsValue` — we just rewrap the resulting `JsValue` into
-// `JsError` on the way out. Required so `JsError` can be used in positions
-// that cross the ABI (e.g. `Promising`'s supertrait bound, promise
-// resolutions, async return types).
+// `JsError` is `#[repr(transparent)]` over `JsValue`
 impl FromWasmAbi for JsError {
     type Abi = <JsValue as FromWasmAbi>::Abi;
 

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -788,6 +788,22 @@ impl IntoWasmAbi for JsError {
     }
 }
 
+// `JsError` is `#[repr(transparent)]` over `JsValue`, so this is the same
+// wire format as `JsValue` — we just rewrap the resulting `JsValue` into
+// `JsError` on the way out. Required so `JsError` can be used in positions
+// that cross the ABI (e.g. `Promising`'s supertrait bound, promise
+// resolutions, async return types).
+impl FromWasmAbi for JsError {
+    type Abi = <JsValue as FromWasmAbi>::Abi;
+
+    #[inline]
+    unsafe fn from_abi(js: Self::Abi) -> Self {
+        JsError {
+            value: JsValue::from_abi(js),
+        }
+    }
+}
+
 impl Promising for JsError {
     type Resolution = JsError;
 }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -479,7 +479,10 @@ impl<T: ErasableGeneric<Repr = JsValue> + WasmDescribe> VectorIntoWasmAbi for T 
 // JsValue-like slice support (Rust-to-JS only)
 // JsValue-like are repr(transparent) over u32, so &[JsValue] is a contiguous array of heap indices
 
-unsafe impl<T: ErasableGeneric> ErasableGeneric for &[T] {
+unsafe impl<T: ErasableGeneric> ErasableGeneric for &[T]
+where
+    <T as ErasableGeneric>::Repr: Sized,
+{
     type Repr = &'static [T::Repr];
 }
 

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -479,10 +479,7 @@ impl<T: ErasableGeneric<Repr = JsValue> + WasmDescribe> VectorIntoWasmAbi for T 
 // JsValue-like slice support (Rust-to-JS only)
 // JsValue-like are repr(transparent) over u32, so &[JsValue] is a contiguous array of heap indices
 
-unsafe impl<T: ErasableGeneric> ErasableGeneric for &[T]
-where
-    <T as ErasableGeneric>::Repr: Sized,
-{
+unsafe impl<T: ErasableGeneric> ErasableGeneric for &[T] {
     type Repr = &'static [T::Repr];
 }
 

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -573,8 +573,6 @@ impl<T: ErasableGeneric<Repr = JsValue> + UpcastFrom<T> + Upcast<JsValue> + JsCa
 /// ```ignore
 /// use js_sys::{Array, Number};
 ///
-/// // No intermediate `Vec`, no annotations: the iterator's item type pins
-/// // `Array<A::JsCanon>` uniquely.
 /// let arr: Array<Number> = (0..10).map(Number::from).collect();
 /// ```
 pub trait IntoJsGeneric {

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -593,7 +593,7 @@ impl IntoJsGeneric for JsValue {
 
 // Reference iteration clones the borrowed wrapper to produce an owned value,
 // then delegates to that type's canonical conversion.
-impl<T: IntoJsGeneric + ?Sized + Clone> IntoJsGeneric for &T {
+impl<T: IntoJsGeneric + Clone> IntoJsGeneric for &T {
     type JsCanon = T::JsCanon;
     #[inline]
     fn to_js(self) -> T::JsCanon {

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -556,11 +556,13 @@ impl<T: ErasableGeneric<Repr = JsValue> + UpcastFrom<T> + Upcast<JsValue> + JsCa
 ///
 /// # Implementations
 ///
-/// Provided impls (all by-value, no `Clone`):
+/// Provided impls:
 /// - [`JsValue`] in this crate.
 /// - Every `#[wasm_bindgen]`-imported type (identity — emitted by the macro).
 /// - Every generic `js_sys` container (`Array<T>`, `Promise<T>`, `Set<T>`, …)
 ///   provides its own identity impl owned by `js_sys`.
+/// - References to cloneable implementors, so borrowed iteration can still
+///   produce owned JS-generic values.
 ///
 /// This trait is deliberately *not* blanket-implemented over all [`JsGeneric`]
 /// types: each implementor explicitly opts in, which leaves room for future
@@ -578,25 +580,24 @@ pub trait IntoJsGeneric {
     type JsCanon: JsGeneric;
 
     /// Produce the canonical [`JsGeneric`] value for `self`.
-    fn to_js(&self) -> Self::JsCanon;
+    fn to_js(self) -> Self::JsCanon;
 }
 
 impl IntoJsGeneric for JsValue {
     type JsCanon = JsValue;
     #[inline]
-    fn to_js(&self) -> JsValue {
-        self.clone()
+    fn to_js(self) -> JsValue {
+        self
     }
 }
 
-// Reference blanket delegates through deref — no extra clone, the underlying
-// `T` impl already performs the one refcount op that boundary-crossing
-// requires.
-impl<T: IntoJsGeneric + ?Sized> IntoJsGeneric for &T {
+// Reference iteration clones the borrowed wrapper to produce an owned value,
+// then delegates to that type's canonical conversion.
+impl<T: IntoJsGeneric + ?Sized + Clone> IntoJsGeneric for &T {
     type JsCanon = T::JsCanon;
     #[inline]
-    fn to_js(&self) -> T::JsCanon {
-        (**self).to_js()
+    fn to_js(self) -> T::JsCanon {
+        self.clone().to_js()
     }
 }
 

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -543,3 +543,77 @@ impl<T: ErasableGeneric<Repr = JsValue> + UpcastFrom<T> + Upcast<JsValue> + JsCa
     JsGeneric for T
 {
 }
+
+/// Value conversion from a type into its canonical [`JsGeneric`] form.
+///
+/// This trait lets APIs that operate over a generic JavaScript element type
+/// (for example [`js_sys::Array<T>`], [`js_sys::Set<T>`], combinators like
+/// `Promise.all`, etc.) project every input value through a single,
+/// functionally-determined target [`JsGeneric`].
+///
+/// The single associated type — rather than a free type parameter bounded by
+/// `AsRef<T>` — is what makes collection-style APIs infer annotation-free.
+/// Given an input `A`, there is exactly one `A::JsCanon`, so rustc never has
+/// to search across multiple `AsRef` impls to pick a target element type.
+///
+/// # Implementations
+///
+/// Provided impls (all by-value, no `Clone`):
+/// - [`JsValue`] in this crate.
+/// - Every `#[wasm_bindgen]`-imported type (identity — emitted by the macro).
+/// - Every generic `js_sys` container (`Array<T>`, `Promise<T>`, `Set<T>`, …)
+///   provides its own identity impl owned by `js_sys`.
+///
+/// This trait is deliberately *not* blanket-implemented over all [`JsGeneric`]
+/// types: each implementor explicitly opts in, which leaves room for future
+/// wrapper types to pick a non-identity [`Self::JsCanon`].
+///
+/// # Example
+///
+/// ```ignore
+/// use js_sys::{Array, Number};
+///
+/// // No intermediate `Vec`, no annotations: the iterator's item type pins
+/// // `Array<A::JsCanon>` uniquely.
+/// let arr: Array<Number> = (0..10).map(Number::from).collect();
+/// ```
+pub trait IntoJsGeneric {
+    /// The canonical [`JsGeneric`] form of this type.
+    type JsCanon: JsGeneric;
+
+    /// Produce the canonical [`JsGeneric`] value for `self`.
+    ///
+    /// Takes `&self` because crossing into a JS-side handle is already a
+    /// refcount-level operation (every [`JsGeneric`] is an `Rc`-backed
+    /// externref handle). The "clone" that happens inside each impl body is
+    /// the boundary-crossing refcount, not an extra copy — this is the
+    /// `to_js` (borrow → owned) shape rather than `into_js` (consume → owned),
+    /// matching Rust's naming conventions for value conversion from a
+    /// reference.
+    fn to_js(&self) -> Self::JsCanon;
+}
+
+impl IntoJsGeneric for JsValue {
+    type JsCanon = JsValue;
+    #[inline]
+    fn to_js(&self) -> JsValue {
+        self.clone()
+    }
+}
+
+// Reference blanket delegates through deref — no extra clone, the underlying
+// `T` impl already performs the one refcount op that boundary-crossing
+// requires.
+impl<T: IntoJsGeneric + ?Sized> IntoJsGeneric for &T {
+    type JsCanon = T::JsCanon;
+    #[inline]
+    fn to_js(&self) -> T::JsCanon {
+        (**self).to_js()
+    }
+}
+
+// Intentionally not a blanket `impl<T: JsGeneric> IntoJsGeneric for T`:
+// that would lock in identity for every current and future `JsGeneric` type
+// and prevent wrapper types from canonicalising to a different target.
+// Instead, implementations are provided explicitly by each owning crate
+// (macro-generated for user types; hand-written for `js_sys` containers).

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -546,10 +546,8 @@ impl<T: ErasableGeneric<Repr = JsValue> + UpcastFrom<T> + Upcast<JsValue> + JsCa
 
 /// Value conversion from a type into its canonical [`JsGeneric`] form.
 ///
-/// This trait lets APIs that operate over a generic JavaScript element type
-/// (for example [`js_sys::Array<T>`], [`js_sys::Set<T>`], combinators like
-/// `Promise.all`, etc.) project every input value through a single,
-/// functionally-determined target [`JsGeneric`].
+/// This trait allows types to be converted into JsGeneric supported types, which
+/// are required to be erasably generic with JsValue.
 ///
 /// The single associated type — rather than a free type parameter bounded by
 /// `AsRef<T>` — is what makes collection-style APIs infer annotation-free.

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -582,14 +582,6 @@ pub trait IntoJsGeneric {
     type JsCanon: JsGeneric;
 
     /// Produce the canonical [`JsGeneric`] value for `self`.
-    ///
-    /// Takes `&self` because crossing into a JS-side handle is already a
-    /// refcount-level operation (every [`JsGeneric`] is an `Rc`-backed
-    /// externref handle). The "clone" that happens inside each impl body is
-    /// the boundary-crossing refcount, not an extra copy — this is the
-    /// `to_js` (borrow → owned) shape rather than `into_js` (consume → owned),
-    /// matching Rust's naming conventions for value conversion from a
-    /// reference.
     fn to_js(&self) -> Self::JsCanon;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ mod externref;
 use externref::__wbindgen_externref_heap_live_count;
 
 pub use crate::__rt::marker::ErasableGeneric;
-pub use crate::convert::JsGeneric;
+pub use crate::convert::{IntoJsGeneric, JsGeneric};
 
 #[doc(hidden)]
 pub mod handler;
@@ -1771,6 +1771,7 @@ impl<T> DerefMut for Clamped<T> {
 ///
 /// ```
 #[derive(Clone, Debug)]
+#[repr(transparent)]
 pub struct JsError {
     value: JsValue,
 }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -2,7 +2,6 @@
 //!
 //! These types represent fundamental JavaScript values and are designed to be
 //! used as generic type parameters in typed JavaScript collections and APIs.
-
 use crate::convert::UpcastFrom;
 use crate::JsCast;
 use crate::JsGeneric;


### PR DESCRIPTION
This is a follow-on to the work originally attempted in #5113 to provide better ergonomics for working with multiple combinators on `Promise<T>` generics.

Previously, that PR attempted to provide `js_sys::futures::utils` with the standard Rust futures utils variants in a way that could work with typed Promises.

Instead, this PR leans into the existing `Promise::` functions to ensure they fully handle the ergonomic edge cases required for the type inference through the standard combinators.

In particular:

- To construct an `Array<Promise<T>>` to use `Promise::all_iterable` required multiple steps. Instead, by resolving the `FromIterator` trait issues from before for the generic `Array<T>`, we can now support `rust_iter.collect::<Array<_>>` as providing an ergonomic route without an intermediate `Vec` having to be constructed. The same applies to `all_settled_iterable` and `race_iterable`.

- For the heterogeneous case previously covered by the `join!` macro, this PR adds `Promise::all_tuple((p1, p2, ...))` as an inherent method. It takes a Rust tuple of `Promise<T_i>` with different types and returns a typed `Promise<ArrayTuple<(T_1, ..., T_n)>>` that destructures via `.into_tuple()` into a native Rust tuple. Implemented for arity 1 through 8. In the process conversion from `ArrayTuple -> ()` has been renamed to be `into_tuple()` instead of the former `into_parts()` which is now deprecated from the original generics version.

- For the heterogeneous case previously covered by the `all_settled!` macro, `Promise::all_settled_tuple` follows the same shape and returns `Promise<ArrayTuple<(PromiseState<T_1>, ..., PromiseState<T_n>)>>`. Same arity range.

- For mixing Rust futures with JS promises in these combinators, users should just lift futures with `future_to_promise_typed(fut)` at the call site. This replaces the implicit `IntoPromise` trait from the previous PR and keeps the spawning visible in user code. This way we don't need to worry about mixing or supporting a shared trait.

- There is no `race_tuple` because `Promise.race` returns a value of type `T_1 | T_2 | ... | T_n`, which Rust can't express. For heterogeneous race, users should rather collect into an `Array<JsValue>` and use `Promise::race_iterable`, narrowing with `dyn_into` at the inspection site.

There are also some minor trait cleanups where this work touches them.

The async guide is updated based on the above guidance now.

### FromIterator

To support `FromIterator` for `Array<T>` without creating a breaking change (as previously encountered and fixed in https://github.com/wasm-bindgen/wasm-bindgen/pull/5052), this problem is now resolved with a new `wasm_bindgen::IntoJsGeneric` trait in the core crate. It has an associated type `JsCanon: JsGeneric` that pins the target element type from the input alone, which avoids the `AsRef<T>` inference ambiguity that was the root cause of the #5042 regression. The codegen emits an identity impl for every `#[wasm_bindgen]` type. The impl takes `self` by value and reinterprets the transparent JS handle wrapper into its canonical type, so it applies uniformly to types that aren't Rust-level `Clone`, including generic types whose parameters aren't `Clone`. Types whose wrapper enforces owned-once destruction semantics opt out with `#[wasm_bindgen(no_into_js_generic)]`, which is currently only `JsClosure`. A reference blanket covers `&T` for cloneable `T`, so borrowed iteration works for cloneable JS wrapper types.

That we now support `iter.collect::<Array>()` with typed items is formally breaking - but only against code that is already using generics. That is, it does not affect historical usage. Following up and fixing the former issue now that we have the technique to do that makes sense, and we are within the two months window of generics shipping still to do this therefore I think the benefit of supporting `FromIterator` outweighs the cost here. And if there are adoption issues we can always revert if necessary.

### Promise Tuple Trait

To support the heterogenous `Promise::all_tuple` and `Promise::all_settled_tuple`, these new tuple methods are implemented on a wrapper using an internal doc-hidden `PromiseTuple` trait with one impl per arity. Each impl builds an `ArrayTuple<(Promise<T_1>, ..., Promise<T_n>)>` from the input tuple using the existing `From<(T_1, ..., T_n)>` conversion, hands it to `Promise::all_iterable` or `Promise::all_settled_iterable`, and reinterprets the result. The single `unchecked_into` that reinterprets the returned `Array<JsValue>` as the typed `ArrayTuple<(T_1, ..., T_n)>` is encapsulated inside the trait, so no unchecked casts leak to the call site. Soundness rests on `Promise.all` and `Promise.allSettled` preserving input order and arity, which they do by spec.