### PR TITLE
Restore stable AsRef<JsValue>-based FromIterator/Extend for Array; expose typed collection via Array::from_iter_typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,18 @@
 
 * Promise ergonomics: `Promise::all_tuple` and `Promise::all_settled_tuple`
   for heterogeneous concurrent awaits (arity 1..=8, destructure via
-  `.into_tuple()`), typed `FromIterator` / `Extend` on `js_sys::Array<T>` so
-  the canonical `Promise::all_iterable(&iter.collect::<Array<_>>()).await`
-  one-liner infers element types without turbofish, and a new
-  `wasm_bindgen::IntoJsGeneric` trait underpinning the inference (with
-  codegen-emitted identity impls and a `#[wasm_bindgen(no_into_js_generic)]`
-  opt-out for types like `JsClosure`). Also re-exports `JsGeneric` from the
-  prelude. Fixes [#5042](https://github.com/wasm-bindgen/wasm-bindgen/issues/5042).
-  Callers that relied on `.collect::<Array>()` implicitly erasing typed
-  items into `Array<JsValue>` now need `.map(JsValue::from)`.
-  [#5121](https://github.com/wasm-bindgen/wasm-bindgen/pull/5121)
+  `.into_tuple()`), and a new `wasm_bindgen::IntoJsGeneric` trait underpinning
+  typed-`Array` inference (with codegen-emitted identity impls and a
+  `#[wasm_bindgen(no_into_js_generic)]` opt-out for types like `JsClosure`).
+  Also re-exports `JsGeneric` from the prelude. Typed collection on
+  `js_sys::Array<T>` is exposed as the inherent constructor
+  `Array::<T>::from_iter_typed` (and companion `extend_typed`), inferring `T`
+  from the iterator item via `IntoJsGeneric`. The stable `FromIterator` /
+  `Extend` impls on `Array` (= `Array<JsValue>`) bound by `AsRef<JsValue>`
+  are preserved, so existing `.collect::<Array>()` call sites keep compiling
+  unchanged. Fixes [#5042](https://github.com/wasm-bindgen/wasm-bindgen/issues/5042).
+  [#5121](https://github.com/wasm-bindgen/wasm-bindgen/pull/5121),
+  [#5128](https://github.com/wasm-bindgen/wasm-bindgen/pull/5128)
 
 * Added `wasm_bindgen::instance()` to return the current
   `WebAssembly.Instance`. The generated JS glue retains the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,12 @@
   are preserved, so existing `.collect::<Array>()` call sites keep compiling
   unchanged. Fixes [#5042](https://github.com/wasm-bindgen/wasm-bindgen/issues/5042).
   [#5121](https://github.com/wasm-bindgen/wasm-bindgen/pull/5121),
-  [#5128](https://github.com/wasm-bindgen/wasm-bindgen/pull/5128)
+  [#5125](https://github.com/wasm-bindgen/wasm-bindgen/pull/5125)
 
 * Added `wasm_bindgen::instance()` to return the current
   `WebAssembly.Instance`. The generated JS glue retains the 
   instantiated `WebAssembly.Instance`.
   [#5118](https://github.com/wasm-bindgen/wasm-bindgen/pull/5118)
-
-### Added
 
 * Added an explicit opt-in `js-sys` feature to `wasm-bindgen` that makes async
   macro codegen use `js_sys::futures` instead of `wasm_bindgen_futures`,

--- a/crates/js-sys/benches/promise_combinators.rs
+++ b/crates/js-sys/benches/promise_combinators.rs
@@ -10,9 +10,9 @@
 //! * `futures_util::future::join_all` over `Vec<JsFuture<T>>` where each
 //!   `JsFuture` wraps one of the input `Promise`s. This is the
 //!   Rust-executor-cooperative path the PR claims is slower.
-//! * `Promise::all_iterable(&iter.collect()).await` — the canonical
-//!   one-liner. The iterator items are `Promise<T>`, so
-//!   `FromIterator<Promise<T>>` infers the target `Array<Promise<T>>`
+//! * `Promise::all_iterable(&Array::from_iter_typed(iter)).await` — the
+//!   canonical one-liner. The iterator items are `Promise<T>`, so
+//!   `Array::from_iter_typed` infers the target `Array<Promise<T>>`
 //!   annotation-free via `IntoJsGeneric`. Delegates to `Promise.all` on the
 //!   JS side. No intermediate `Vec`, no `js_sys::futures` wrapper in the hot
 //!   loop, no macros, no new combinator crate surface.
@@ -48,19 +48,13 @@ async fn bench_futures_join_all(n: usize) {
 
 async fn bench_promise_all(n: usize) {
     // Canonical one-liner: collect the promise-producing iterator straight
-    // into a typed `Array<Promise<Number>>` via `FromIterator` (inference
-    // pins the element type through `IntoJsGeneric::JsCanon`), then hand it
-    // to `Promise::all_iterable` and await. The `::<Array<_>>()` turbofish
-    // picks `Array` as the target container (`Promise::all_iterable` is
-    // generic over any `Iterable`, so something has to name the concrete
-    // container); `_` is inferred from the iterator's item type as
-    // `Promise<Number>`. One JS-side combinator, one wake, no intermediate
-    // `Vec`.
-    let results = Promise::all_iterable(
-        &(0..n)
-            .map(|i| make_timeout_promise(i as f64))
-            .collect::<Array<_>>(),
-    )
+    // into a typed `Array<Promise<Number>>` via `Array::from_iter_typed`
+    // (inference pins the element type through `IntoJsGeneric::JsCanon`),
+    // then hand it to `Promise::all_iterable` and await. One JS-side
+    // combinator, one wake, no intermediate `Vec`.
+    let results = Promise::all_iterable(&Array::from_iter_typed(
+        (0..n).map(|i| make_timeout_promise(i as f64)),
+    ))
     .await
     .unwrap();
     std::hint::black_box(results);

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1947,38 +1947,90 @@ impl<T: JsGeneric> core::iter::IntoIterator for Array<T> {
     }
 }
 
-// `FromIterator` / `Extend` for `Array<T>` project every input value through
-// its canonical [`JsGeneric`] via [`IntoJsGeneric`].
+// `FromIterator` / `Extend` for `Array` (= `Array<JsValue>` via the default
+// type parameter) preserve the long-standing stable behaviour: any iterator
+// of items convertible to `&JsValue` collects into an erased `Array<JsValue>`.
 //
-// Using an associated type (`A::JsCanon`) rather than a free type parameter
-// bound by `AsRef<T>` is what lets inference pick `T` uniquely from the
-// iterator item. This fixes the
-// `A: AsRef<T>` E0283 regression that the earlier unstable impl suffered
-// from (see #5042).
+// Typed collection (where the element type is inferred from the iterator
+// item via [`IntoJsGeneric`]) is exposed as the inherent constructor
+// [`Array::from_iter_typed`] rather than a second `FromIterator` impl. A
+// blanket `impl<A: IntoJsGeneric> FromIterator<A> for Array<A::JsCanon>`
+// would overlap with the stable `AsRef<JsValue>` impl on `Array<JsValue>`
+// (since `JsValue: IntoJsGeneric` with `JsCanon = JsValue`), so the two
+// cannot coexist as `FromIterator` impls without coherence violations.
 //
-// The reference-iteration case (`Item = &T`) is handled transparently by the
-// `&T: IntoJsGeneric` blanket in `wasm-bindgen` core.
-//
-// Compared to the pre-existing stable impl `impl<A> FromIterator<A> for Array
-// where A: AsRef<JsValue>`, this changes the target type from the untyped
-// `Array<JsValue>` (implicit erasure) to the typed `Array<A::JsCanon>`.
-// Call sites that want erasure now opt in via `.map(JsValue::from)` at the
-// call site.
+// TODO(next major): deprecate this `FromIterator`/`Extend` pair in favour
+// of a single `IntoJsGeneric`-based impl, and rename `from_iter_typed` to
+// take its place. That migration is source-breaking for callers relying on
+// `.collect::<Array>()` implicit erasure of typed items, so it is deferred.
 
-impl<A: IntoJsGeneric> core::iter::FromIterator<A> for Array<A::JsCanon> {
-    fn from_iter<I>(iter: I) -> Array<A::JsCanon>
+impl<A> core::iter::FromIterator<A> for Array
+where
+    A: AsRef<JsValue>,
+{
+    fn from_iter<I>(iter: I) -> Array
     where
         I: IntoIterator<Item = A>,
     {
-        let mut out = Array::<A::JsCanon>::new_typed();
+        let mut out = Array::new();
         out.extend(iter);
         out
     }
 }
 
-impl<A: IntoJsGeneric> core::iter::Extend<A> for Array<A::JsCanon> {
+impl<A> core::iter::Extend<A> for Array
+where
+    A: AsRef<JsValue>,
+{
     fn extend<I>(&mut self, iter: I)
     where
+        I: IntoIterator<Item = A>,
+    {
+        for value in iter {
+            self.push(value.as_ref());
+        }
+    }
+}
+
+impl<T: JsGeneric> Array<T> {
+    /// Collect an iterator into a typed `Array<T>`, projecting each item
+    /// through its canonical [`JsGeneric`] via [`IntoJsGeneric`].
+    ///
+    /// This is the typed counterpart to the stable
+    /// `impl FromIterator<A> for Array where A: AsRef<JsValue>`, which always
+    /// produces an erased `Array<JsValue>`. Use `from_iter_typed` when you
+    /// want the element type inferred from the iterator item:
+    ///
+    /// ```ignore
+    /// use js_sys::{Array, Number};
+    ///
+    /// let arr = Array::from_iter_typed((0..10).map(Number::from));
+    /// // arr: Array<Number>
+    /// ```
+    ///
+    /// Reference iteration (`Item = &U`) is supported transparently via the
+    /// `&U: IntoJsGeneric` blanket in `wasm-bindgen` core.
+    //
+    // TODO(next major): replace the stable `FromIterator` impl above with
+    // this behaviour and remove `from_iter_typed`.
+    pub fn from_iter_typed<A, I>(iter: I) -> Array<T>
+    where
+        A: IntoJsGeneric<JsCanon = T>,
+        I: IntoIterator<Item = A>,
+    {
+        let mut out = Array::<T>::new_typed();
+        out.extend_typed(iter);
+        out
+    }
+
+    /// Extend a typed `Array<T>` with an iterator of items convertible to
+    /// `T` via [`IntoJsGeneric`]. Companion to [`Array::from_iter_typed`].
+    //
+    // TODO(next major): replace the stable `Extend` impl above with this
+    // behaviour and remove `extend_typed`.
+    pub fn extend_typed<A, I>(&mut self, iter: I)
+    where
+        A: IntoJsGeneric<JsCanon = T>,
         I: IntoIterator<Item = A>,
     {
         for value in iter {

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -96,8 +96,7 @@ fn from_iter_wasm_bindgen_type() {
     assert_eq!(arr.length(), 2);
 
     // Typed form: inference picks `Array<JsString>` via `IntoJsGeneric`.
-    let arr: Array<JsString> =
-        Array::from_iter_typed([JsString::from("x"), JsString::from("y")]);
+    let arr: Array<JsString> = Array::from_iter_typed([JsString::from("x"), JsString::from("y")]);
     assert_eq!(arr.length(), 2);
 
     // Reference iteration: `Item = &JsString`, the `&T: IntoJsGeneric`

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -85,27 +85,25 @@ fn from_iter() {
 
 // Regression test for https://github.com/wasm-bindgen/wasm-bindgen/issues/5042:
 // collecting a `#[wasm_bindgen]` type without explicit type annotations must
-// not cause E0283. Under the `IntoJsGeneric`-based `FromIterator` impl the
-// result type is the typed `Array<JsString>` (projected via
-// `JsString::JsCanon = JsString`), not the erased `Array<JsValue>` the
-// pre-`IntoJsGeneric` stable impl produced.
+// not cause E0283. The stable `FromIterator` impl on `Array` (= `Array<JsValue>`)
+// is bound by `AsRef<JsValue>`, which `JsString` satisfies, so the result is
+// the erased `Array<JsValue>`. To preserve the element type, use
+// `Array::<T>::from_iter_typed`, which is typed via `IntoJsGeneric`.
 #[wasm_bindgen_test]
 fn from_iter_wasm_bindgen_type() {
+    // Stable form: erased `Array<JsValue>`, no turbofish needed.
     let arr = Array::from_iter([JsString::from("a"), JsString::from("b")]);
     assert_eq!(arr.length(), 2);
 
-    // Reference iteration: `Item = &JsString`, the `&T: IntoJsGeneric`
-    // blanket delegates through to `JsString::JsCanon = JsString`, so
-    // `.collect::<Array<_>>()` infers `Array<JsString>`.
-    let arr: Array<JsString> = [JsString::from("x"), JsString::from("y")].iter().collect();
+    // Typed form: inference picks `Array<JsString>` via `IntoJsGeneric`.
+    let arr: Array<JsString> =
+        Array::from_iter_typed([JsString::from("x"), JsString::from("y")]);
     assert_eq!(arr.length(), 2);
 
-    // Explicit erasure — opt in via `.map(JsValue::from)` if you still want
-    // the untyped shape.
-    let arr: Array<JsValue> = [JsString::from("p"), JsString::from("q")]
-        .into_iter()
-        .map(JsValue::from)
-        .collect();
+    // Reference iteration: `Item = &JsString`, the `&T: IntoJsGeneric`
+    // blanket delegates through to `JsString::JsCanon = JsString`.
+    let arr: Array<JsString> =
+        Array::from_iter_typed([JsString::from("p"), JsString::from("q")].iter());
     assert_eq!(arr.length(), 2);
 }
 
@@ -114,37 +112,43 @@ fn from_iter_wasm_bindgen_type() {
 //     worker.post_message(&Array::from_iter([wasm_init_object]))?;
 //
 // The important property is that `Array::from_iter([owned_value])` — where
-// the iterator item is an owned `#[wasm_bindgen]` type — must infer to the
-// **typed** `Array<T>` without any turbofish or type annotation. On the old
-// `FromIterator<A> for Array<T> where A: AsRef<T>` impl this triggered
-// E0283 because `A: AsRef<T>` had multiple solutions for `T`.
+// the iterator item is an owned `#[wasm_bindgen]` type — must compile
+// without any turbofish or type annotation. The stable `FromIterator` returns
+// erased `Array<JsValue>`; `Array::<T>::from_iter_typed` infers the typed
+// `Array<T>` for callers who want it.
 #[wasm_bindgen_test]
 fn from_iter_owned_wasm_bindgen_type_infers() {
-    // No annotation, single owned item: must infer `Array<Object>`, and the
-    // inference must propagate through a `&Array<Object>` argument without
-    // re-triggering ambiguity.
     fn take_object_array(arr: &Array<Object>) {
         assert_eq!(arr.length(), 1);
     }
+    fn take_value_array(arr: &Array) {
+        assert_eq!(arr.length(), 1);
+    }
 
+    // Stable: erased `Array<JsValue>` (= `Array`).
     let obj = Object::new();
     let arr = Array::from_iter([obj]);
+    take_value_array(&arr);
+
+    // Typed: `Array<Object>` via `IntoJsGeneric` inference.
+    let obj = Object::new();
+    let arr = Array::from_iter_typed([obj]);
     take_object_array(&arr);
 }
 
 #[wasm_bindgen_test]
 fn extend() {
-    // Starting from a typed `Array<JsString>`: `.extend` with matching items
-    // works without any erasure.
-    let mut array: Array<JsString> = Array::new_typed();
+    // Stable `Extend` on `Array` (= `Array<JsValue>`) is bound by
+    // `AsRef<JsValue>`, so typed items extend an erased array directly.
+    let mut array = Array::new();
     array.extend([JsString::from("a"), JsString::from("b")]);
     array.extend([JsString::from("c"), JsString::from("d")]);
     assert_eq!(array.length(), 4);
 
-    // Starting from an untyped `Array<JsValue>`: callers extend with
-    // `JsValue` items (or explicitly erase typed ones via `.map`).
-    let mut array: Array<JsValue> = Array::new();
-    array.extend([JsString::from("e"), JsString::from("f")].map(JsValue::from));
+    // Typed companion: `extend_typed` on `Array<T>` projects items through
+    // `IntoJsGeneric` and preserves the element type.
+    let mut array: Array<JsString> = Array::new_typed();
+    array.extend_typed([JsString::from("e"), JsString::from("f")]);
     assert_eq!(array.length(), 2);
 }
 
@@ -1403,14 +1407,14 @@ fn test_array_to_vec() {
 }
 
 #[wasm_bindgen_test]
-fn test_array_from_iter() {
+fn test_array_from_iter_typed() {
     let items = vec![
         TestItem::new(1, &JsString::from("a")),
         TestItem::new(2, &JsString::from("b")),
         TestItem::new(3, &JsString::from("c")),
     ];
 
-    let arr: Array<TestItem> = items.iter().map(|i| i).collect();
+    let arr: Array<TestItem> = Array::from_iter_typed(items.iter());
 
     assert_eq!(arr.length(), 3);
     let first: TestItem = unwrap_get!(arr, 0);
@@ -1418,7 +1422,7 @@ fn test_array_from_iter() {
 }
 
 #[wasm_bindgen_test]
-fn test_array_extend() {
+fn test_array_extend_typed() {
     let mut arr: Array<TestItem> = Array::new_typed();
     arr.push(&TestItem::new(1, &JsString::from("a")));
 
@@ -1426,7 +1430,7 @@ fn test_array_extend() {
         TestItem::new(2, &JsString::from("b")),
         TestItem::new(3, &JsString::from("c")),
     ];
-    arr.extend(more);
+    arr.extend_typed(more);
 
     assert_eq!(arr.length(), 3);
 }

--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -193,8 +193,11 @@ When your inputs are already JS `Promise<T>` values, the native
 exactly and avoid the Rust executor polling each child on every wake.
 
 The canonical recipe collects the promise-producing iterator straight into a
-typed [`Array<Promise<T>>`] and hands it to the combinator — no turbofish
-on the elements, no intermediate `Vec`:
+typed [`Array<Promise<T>>`] via [`Array::from_iter_typed`] and hands it to
+the combinator — no turbofish on the elements, no intermediate `Vec`. The
+typed-collection helper infers the element type from the iterator item via
+[`IntoJsGeneric`]; the stable `.collect::<Array>()` form keeps producing an
+erased `Array<JsValue>` for callers that want erasure.
 
 ### `Promise.all` — all must succeed
 
@@ -203,9 +206,9 @@ use js_sys::{Array, Promise};
 
 // responses: Array<Response>
 let responses = Promise::all_iterable(
-    &(0..10)
-        .map(|_| worker.fetch_with_str_and_init(&url, &init))
-        .collect::<Array<_>>(),
+    &Array::from_iter_typed(
+        (0..10).map(|_| worker.fetch_with_str_and_init(&url, &init)),
+    ),
 )
 .await?;
 ```
@@ -219,9 +222,9 @@ use js_sys::{Array, Promise};
 
 // results: Array<PromiseState<Response>>
 let results = Promise::all_settled_iterable(
-    &(0..10)
-        .map(|_| worker.fetch_with_str_and_init(&url, &init))
-        .collect::<Array<_>>(),
+    &Array::from_iter_typed(
+        (0..10).map(|_| worker.fetch_with_str_and_init(&url, &init)),
+    ),
 )
 .await?;
 for state in results.iter() {
@@ -240,9 +243,9 @@ use js_sys::{Array, Promise};
 
 // first: Response
 let first = Promise::race_iterable(
-    &(0..10)
-        .map(|_| worker.fetch_with_str_and_init(&url, &init))
-        .collect::<Array<_>>(),
+    &Array::from_iter_typed(
+        (0..10).map(|_| worker.fetch_with_str_and_init(&url, &init)),
+    ),
 )
 .await?;
 ```
@@ -301,12 +304,10 @@ use js_sys::{futures::future_to_promise_typed, Array, Promise};
 
 // For homogeneous batches, mix both shapes into one `Array<Promise<T>>`:
 let responses = Promise::all_iterable(
-    &[
+    &Array::from_iter_typed([
         fetch_promise,
         future_to_promise_typed(async { Ok(fetch_via_rust().await?) }),
-    ]
-    .into_iter()
-    .collect::<Array<_>>(),
+    ]),
 )
 .await?;
 


### PR DESCRIPTION
PR #5121 broke downstream crates by replacing the long-standing stable

```rust
impl<A: AsRef<JsValue>> FromIterator<A> for Array
```

with a typed

```rust
impl<A: IntoJsGeneric> FromIterator<A> for Array<A::JsCanon>
```

The motivating regression is workers-rs, where `D1Argument::js_value` returns `impl AsRef<JsValue>` and call sites collect via `.collect::<Array>()`:

```rust
pub trait D1Argument {
    fn js_value(&self) -> impl AsRef<JsValue>;
}

let array: Array = values.into_iter().map(|t| t.js_value()).collect();
```

`impl AsRef<JsValue>` does not implement `IntoJsGeneric` — and can't be made to, because `IntoJsGeneric` is a borrow-to-owned conversion with a single canonical `JsCanon` per type, while `AsRef<JsValue>` is a structurally weaker borrow trait. After PR #5121 the call site fails with E0277 (\`the trait \`IntoJsGeneric\` is not implemented for \`impl AsRef<JsValue>\`\`). The CHANGELOG entry for #5121 acknowledged the break (\"Callers that relied on \`.collect::<Array>()\` implicitly erasing typed items into \`Array<JsValue>\` now need \`.map(JsValue::from)\`\"), but the workaround is bad ergonomics for any helper trait shaped this way and the break is gratuitous: the stable impl and the typed-inference goal can coexist if the latter is exposed as an inherent method instead of a second `FromIterator` impl.

## API changes

* **Restored** stable `impl<A: AsRef<JsValue>> FromIterator<A> for Array` and matching `Extend` impl — `Array` (= `Array<JsValue>`) collects from any `AsRef<JsValue>` iterator, just like before #5121. No source change for any pre-#5121 caller.
* **New** `Array::<T>::from_iter_typed` inherent constructor — typed counterpart, infers `T` from the iterator item via `IntoJsGeneric`.
* **New** `Array::<T>::extend_typed` inherent method — companion to `from_iter_typed`.
* `IntoJsGeneric` trait, `JsGeneric` re-export, `Promise::all_tuple` / `Promise::all_settled_tuple` from #5121 are unaffected.

## Effect on the Promise iterable APIs

The Promise iterable combinators (`Promise::all_iterable` / `all_settled_iterable` / `race_iterable`) take any `&Iterable`, so the canonical recipe just changes the collection step. Old form (#5121, broken for `AsRef<JsValue>` callers):

```rust
Promise::all_iterable(
    &(0..10)
        .map(|i| make_promise(i))
        .collect::<Array<_>>(),
).await?;
```

New form, non-breaking:

```rust
Promise::all_iterable(
    &Array::from_iter_typed((0..10).map(|i| make_promise(i))),
).await?;
```

Same element-type inference (`Array<Promise<T>>`), no turbofish on items, no intermediate `Vec` — just an explicit constructor name in place of `iter.collect::<Array<_>>()`.

## Coherence

A blanket `impl<A: IntoJsGeneric> FromIterator<A> for Array<A::JsCanon>` cannot coexist with the stable `AsRef<JsValue>` impl: `JsValue` implements both (with `JsCanon = JsValue`), so `Array<JsValue>` would have two applicable impls for `A = JsValue`. The inherent-method form sidesteps this — inherent methods don't compete with `FromIterator` for coherence — and explicit naming (`Array::from_iter_typed(...)`) is only marginally less ergonomic than `iter.collect::<Array<_>>()` while being non-breaking.

## Test, bench, guide, CHANGELOG

* `crates/js-sys/tests/wasm/Array.rs` covers both forms (stable `from_iter` → erased `Array<JsValue>`; `from_iter_typed` → `Array<T>` via `IntoJsGeneric`), including reference iteration and the flutter_rust_bridge regression shape.
* `crates/js-sys/benches/promise_combinators.rs` updated to use `Array::from_iter_typed` in the canonical recipe.
* `guide/src/reference/js-promises-and-rust-futures.md` Promise-combinator examples updated.
* `CHANGELOG.md` entry for the unreleased 0.2.119 (which has not shipped #5121 yet) updated in place to describe the final behaviour and reference both PR numbers.
* TODOs in source mark a future-major migration: deprecate the stable `FromIterator` / `Extend` impls and rename `from_iter_typed` to take their place.

`cargo check -p js-sys -p wasm-bindgen -p wasm-bindgen-futures --tests --benches --target wasm32-unknown-unknown` passes. With this submodule patched, workers-rs builds cleanly without any source change to the `D1Argument` trait or its call sites.