### PR TITLE
Switch js-sys macro codegen opt-in from Cargo feature to cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,13 @@
   instantiated `WebAssembly.Instance`.
   [#5118](https://github.com/wasm-bindgen/wasm-bindgen/pull/5118)
 
-* Added an explicit opt-in `js-sys` feature to `wasm-bindgen` that makes async
-  macro codegen use `js_sys::futures` instead of `wasm_bindgen_futures`,
-  removing the need for `wasm-bindgen-futures` as a separate dependency when the
-  crate also depends directly on `js-sys`. This is not enabled automatically by
-  transitive `js-sys` dependencies, since the crate using `#[wasm_bindgen]` must
-  be able to resolve the generated `::js_sys` path.
+* Added a `--cfg=wasm_bindgen_use_js_sys` opt-in that makes async macro codegen
+  use `js_sys::futures` instead of `wasm_bindgen_futures`, dropping the need
+  for `wasm-bindgen-futures` when the crate already depends on `js-sys`. A cfg
+  is used rather than a Cargo feature so the choice stays scoped to the crate
+  that opts in.
   [#5112](https://github.com/wasm-bindgen/wasm-bindgen/pull/5112)
+  [#5127](https://github.com/wasm-bindgen/wasm-bindgen/pull/5127)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ test = false
 [features]
 default = ["std"]
 enable-interning = ["std"]
-js-sys = ["wasm-bindgen-macro/js-sys"]
 serde-serialize = ["serde", "serde_json", "std"]
 spans = []
 std = []
@@ -80,6 +79,7 @@ workspace = true
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(wasm_bindgen_unstable_test_coverage)',
+  'cfg(wasm_bindgen_use_js_sys)',
   'cfg(xxx_debug_only_print_generated_code)',
 ] }
 unused_lifetimes = "warn"

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.2.118"
 
 [features]
 extra-traits = ["syn/extra-traits"]
-js-sys = []
 strict-macro = []
 
 [dependencies]

--- a/crates/macro-support/src/ast.rs
+++ b/crates/macro-support/src/ast.rs
@@ -9,7 +9,7 @@ use syn::Path;
 use wasm_bindgen_shared as shared;
 
 pub fn use_js_sys_futures() -> bool {
-    cfg!(feature = "js-sys")
+    cfg!(wasm_bindgen_use_js_sys)
 }
 
 /// Whether a function is a start function, and if so, whether it

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -17,7 +17,6 @@ version = "0.2.118"
 proc-macro = true
 
 [features]
-js-sys = ["wasm-bindgen-macro-support/js-sys"]
 strict-macro = ["wasm-bindgen-macro-support/strict-macro"]
 
 [dependencies]

--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -360,34 +360,13 @@ async fn process_numbers() -> Result<f64, JsValue> {
 
 ## Using `js_sys` directly without `wasm-bindgen-futures`
 
-By default the `#[wasm_bindgen]` macro continues to generate async glue that
-references `wasm_bindgen_futures`. If you want to depend only on `js-sys` and
-avoid pulling in `wasm-bindgen-futures`, depend directly on `js-sys` and enable
-the `js-sys` feature on `wasm-bindgen`:
+To make `#[wasm_bindgen]` emit `js_sys::futures` directly and drop the
+`wasm-bindgen-futures` dependency, depend on `js-sys` and build with
+`--cfg=wasm_bindgen_use_js_sys` (e.g. via `RUSTFLAGS` or `.cargo/config.toml`).
 
-```toml
-[dependencies]
-js-sys = "..."
-wasm-bindgen = { version = "...", features = ["js-sys"] }
-```
-
-```rust
-#[wasm_bindgen]
-pub async fn foo() {
-    // codegen uses js_sys::futures::future_to_promise / spawn_local
-}
-
-#[wasm_bindgen]
-extern "C" {
-    async fn fetch(url: &str) -> JsValue;
-}
-```
-
-This feature is not enabled automatically by transitive `js-sys` dependencies:
-the crate using `#[wasm_bindgen]` must be able to resolve the generated
-`::js_sys` path. The existing `js_sys = my_crate::js_sys` attribute remains
-available as a path override for re-export crates, but it does not enable
-`js_sys::futures` codegen by itself.
+A cfg is used rather than a Cargo feature so the choice stays scoped to the
+crate that opts in — Cargo features union across the dep graph, which would
+flip codegen for every `#[wasm_bindgen]` user in the build.
 
 ## Compatibility note
 


### PR DESCRIPTION
Follow-up to #5112.

#5112 added a `js-sys` Cargo feature on `wasm-bindgen` that flipped async macro codegen to emit `js_sys::futures::*` instead of `wasm_bindgen_futures::*`. Cargo features are unioned across the dependency graph, so a transitive dep enabling that feature would change codegen for every `#[wasm_bindgen]` user in the build — including crates that don't depend on `js-sys` directly and can't resolve the generated `::js_sys` path. That's a transitive-breakage pattern we want to avoid for a knob this surgical.

Replace the feature with a `--cfg=wasm_bindgen_use_js_sys` cfg flag, which stays scoped to the crate that opts in.

Before:

```toml
[dependencies]
wasm-bindgen = { version = "...", features = ["js-sys"] }
```

After:

```toml
# .cargo/config.toml
[build]
rustflags = ["--cfg=wasm_bindgen_use_js_sys"]
```

* Drops the `js-sys` feature from `wasm-bindgen`, `wasm-bindgen-macro`, and `wasm-bindgen-macro-support`.
* `ast::use_js_sys_futures()` now reads `cfg!(wasm_bindgen_use_js_sys)`.
* Registers the cfg in the workspace `check-cfg` list alongside the existing `wasm_bindgen_unstable_test_coverage` entry.
* Trims the guide section and CHANGELOG entry to match the smaller surface area.

Verified `cargo check` builds cleanly for `wasm-bindgen`, `wasm-bindgen-macro`, and `wasm-bindgen-macro-support` both with and without `RUSTFLAGS='--cfg=wasm_bindgen_use_js_sys'`.