### PR TITLE
release: 0.2.119 - schema bump

### DIFF
--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -13,7 +13,7 @@ pub mod tys;
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same
 // SCHEMA_VERSION in order to work together.
-pub const SCHEMA_VERSION: &str = "0.2.118";
+pub const SCHEMA_VERSION: &str = "0.2.119";
 
 #[macro_export]
 macro_rules! shared_api {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "5165210117105331182";
+const APPROVED_SCHEMA_FILE_HASH: &str = "7600785207908696146";
 
 #[test]
 fn schema_version() {


### PR DESCRIPTION
This adds the schema bump for release 0.2.119 which was missed in https://github.com/wasm-bindgen/wasm-bindgen/pull/5126.

The reason for this is that memory64 is a schema change, which was not picked up by the hasher.