### PR TITLE
js-sys: implement TypedArray for DataView, note future rename to ArrayBufferView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Changed
 
+* `js_sys::DataView` now implements the `js_sys::TypedArray` trait. A
+  `FIXME` notes that the trait should be renamed to `ArrayBufferView` in
+  the next major release to better reflect the WebIDL spec name covering
+  both `DataView` and the typed-array types.
+
 --------------------------------------------------------------------------------
 
 ## [0.2.119](https://github.com/rustwasm/wasm-bindgen/compare/0.2.118...0.2.119)

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2430,7 +2430,13 @@ extern "C" {
     pub fn values<T>(this: &Array<T>) -> Iterator<T>;
 }
 
+// FIXME(next-major): rename this trait to `ArrayBufferView`. The DOM/WebIDL
+// spec name `ArrayBufferView` covers both `DataView` and the typed-array
+// types, which more accurately reflects the set of types that implement this
+// trait. The `TypedArray` name is kept for now to avoid a breaking change.
 pub trait TypedArray: JsGeneric {}
+
+impl TypedArray for DataView {}
 
 // Next major: use usize/isize for indices
 /// The `Atomics` object provides atomic operations as static methods.


### PR DESCRIPTION
This implements `TypedArray` for `js_sys::DataView` and notes a future rename of the trait to `ArrayBufferView`.

The existing `TypedArray` trait in `js-sys` only covered the typed-array types (`Int8Array`, `Uint8Array`, `Float16Array`, etc.), but the natural superset in the WebIDL/DOM spec — `ArrayBufferView` — also includes `DataView`. This PR adds the missing impl so `DataView` participates in that trait and leaves a `FIXME` noting that the trait itself should be renamed in the next major release.

* add `impl TypedArray for DataView`
* add a `FIXME(next-major)` comment on the trait declaration explaining the intended rename to `ArrayBufferView` and why the current name is kept for now (avoiding a breaking change)

Before:

```rs
pub trait TypedArray: JsGeneric {}
```

After:

```rs
// FIXME(next-major): rename this trait to `ArrayBufferView`. ...
pub trait TypedArray: JsGeneric {}

impl TypedArray for DataView {}
```

No existing call sites change behavior; this is purely additive. `cargo check -p js-sys` passes locally. The `Atomics::*` functions remain bounded by `T: TypedArray` and were never intended to accept `DataView` at runtime — that semantic stays unchanged here, and is something the eventual rename to `ArrayBufferView` (with a narrower bound on `Atomics`) can clean up as part of the next major.