### PR TITLE
Fix slice_to_array erroring on non-slice args of slice_to_array fns

### DIFF
--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -2176,13 +2176,16 @@ impl TryToTokens for ast::ImportFunction {
             // Wire format is `WasmSlice` either way; the cli-support
             // side picks the right JS shim based on the element
             // `VectorKind` recovered from the descriptor.
-            if arg.slice_to_array {
-                let Some((elem_ty, is_option)) = detect_slice_or_option_slice(ty) else {
-                    bail_span!(
-                        ty,
-                        "`slice_to_array` only applies to `&[T]` or `Option<&[T]>` argument types"
-                    );
-                };
+            // `slice_to_array` is set per-fn or per-`extern "C"` block
+            // and applies to every `&[T]` / `Option<&[T]>` argument of
+            // every fn it covers. Args that aren't slice-shaped (e.g.
+            // the `this: &Foo` of a method, or any other non-slice
+            // argument of a slice_to_array fn) silently fall through to
+            // the default ABI path — there's no per-arg opt-out form
+            // in Rust attribute syntax to require, so silent no-op is
+            // the only sensible behaviour.
+            if arg.slice_to_array && detect_slice_or_option_slice(ty).is_some() {
+                let (elem_ty, is_option) = detect_slice_or_option_slice(ty).unwrap();
 
                 let abi = quote! { #wasm_bindgen::convert::WasmSlice };
                 let (prim_args, prim_names) = splat(wasm_bindgen, &name, &abi);
@@ -2816,6 +2819,10 @@ impl TryToTokens for DescribeImport<'_> {
                 // `Option<&Vec<T>>`) to match the ABI rewrite in
                 // `ImportFunction::try_to_tokens` — the descriptor shape is
                 // `Ref(Vector(T))`, which the cli-support side recognises.
+                // Non-slice args (e.g. `this: &Foo` of a method) under a
+                // fn- or block-level `slice_to_array` silently fall through
+                // to their default describe — slice_to_array is a mode that
+                // only acts on slice-shaped args.
                 if arg.slice_to_array {
                     if let Some((elem_ty, is_option)) = detect_slice_or_option_slice(&ty) {
                         if is_option {
@@ -2825,11 +2832,6 @@ impl TryToTokens for DescribeImport<'_> {
                         } else {
                             return Ok(parse_quote! { &::std::vec::Vec<#elem_ty> });
                         }
-                    } else {
-                        bail_span!(
-                            arg.pat_type.ty,
-                            "`slice_to_array` only applies to `&[T]` or `Option<&[T]>` argument types"
-                        );
                     }
                 }
                 Ok(ty)

--- a/guide/src/reference/attributes/on-js-imports/slice_to_array.md
+++ b/guide/src/reference/attributes/on-js-imports/slice_to_array.md
@@ -43,8 +43,12 @@ extern "C" {
 }
 ```
 
-Per-function and per-arg `slice_to_array` are additive — the attribute
-is opt-in at any level.
+Per-function and per-block `slice_to_array` combine additively — the
+attribute is opt-in at either level. The mode only acts on `&[T]` /
+`Option<&[T]>` arguments; any other argument shape (e.g. the `this`
+argument of a method, or unrelated scalar arguments) is left
+untouched, so it's safe to set the attribute on a method or on an
+entire `extern "C"` block of mixed-shape imports.
 
 ## Wire format
 

--- a/tests/wasm/slice_to_array.js
+++ b/tests/wasm/slice_to_array.js
@@ -8,6 +8,11 @@ exports.Tagged = class Tagged {
     get tag() {
         return this._tag;
     }
+    push_strings(v) {
+        const assert = require('assert');
+        assert.ok(Array.isArray(v));
+        return v.map(s => `${this._tag}-${s}`);
+    }
 };
 
 // Each handler asserts the incoming value is a plain `Array` (not a

--- a/tests/wasm/slice_to_array.rs
+++ b/tests/wasm/slice_to_array.rs
@@ -52,6 +52,12 @@ extern "C" {
     fn js_st2a_imported(v: &[Tagged]) -> Vec<String>;
     #[wasm_bindgen(slice_to_array)]
     fn js_st2a_optional_u16(v: Option<&[u16]>) -> Option<Vec<u16>>;
+
+    // Method form: the `this` argument is non-slice and must be left
+    // alone by `slice_to_array`. Mixed args (the slice gets the rewrite,
+    // `this` doesn't).
+    #[wasm_bindgen(method, slice_to_array)]
+    fn push_strings(this: &Tagged, v: &[String]) -> Vec<String>;
 }
 
 // Block-level `slice_to_array` propagates to every fn in the block.
@@ -115,6 +121,17 @@ fn optional() {
     assert_eq!(out, Some(vec![10u16, 12, 14]));
     assert_eq!(v, vec![5u16, 6, 7]);
     assert_eq!(js_st2a_optional_u16(None), None);
+}
+
+#[wasm_bindgen_test]
+fn method_with_slice_to_array() {
+    // `slice_to_array` on a method ignores the non-slice `this` arg
+    // and only rewrites the slice arg. Compiles + runs without
+    // complaint about `this: &Tagged`.
+    let t = Tagged::new("prefix");
+    let v = vec!["a".to_string(), "b".to_string()];
+    let out = t.push_strings(&v);
+    assert_eq!(out, vec!["prefix-a".to_string(), "prefix-b".to_string()]);
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
Fixes a regression introduced by #5145.

`slice_to_array` is a fn-level / block-level mode that should only act on `&[T]` and `Option<&[T]>` arguments. Today it errors out at macro-expansion time on any non-slice arg of a fn it covers — most notably the `this: &Foo` of a method:

```rust
#[wasm_bindgen(method, setter, js_name = "cc", slice_to_array)]
pub fn set_cc_with_array(this: &SendEmailBuilder, val: &[String]);
```

was rejected with `slice_to_array only applies to slice arguments` because the macro tried to apply the rewrite to `&SendEmailBuilder`.

There's no per-arg `slice_to_array` opt-in in Rust attribute syntax (macros can't decorate individual args), so the fix is to silently fall through to the default ABI / describe path for non-slice args. The rewrite still applies to every slice-shaped arg the mode covers.

Adds a method test exercising the fix (`#[wasm_bindgen(method, slice_to_array)] fn push_strings(this: &Tagged, v: &[String])`).