### PR TITLE
release: 0.2.121 - schema bump

### DIFF
--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -13,7 +13,7 @@ pub mod tys;
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same
 // SCHEMA_VERSION in order to work together.
-pub const SCHEMA_VERSION: &str = "0.2.120";
+pub const SCHEMA_VERSION: &str = "0.2.121";
 
 #[macro_export]
 macro_rules! shared_api {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "8371363225348701245";
+const APPROVED_SCHEMA_FILE_HASH: &str = "18105850795781353992";
 
 #[test]
 fn schema_version() {


### PR DESCRIPTION
Bumps `SCHEMA_VERSION` to 0.2.121 to match the crate version released in #5147, which I missed during the release. Same pattern as #5129 after the 0.2.119 release.