### PR TITLE
Loosen JsFuture<T> bound to support Promise<Union>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@
 
 ### Fixed
 
+* `From<Promise<T>> for JsFuture<T>` and `IntoFuture for Promise<T>` now
+  accept any `T: FromWasmAbi` (rather than `T: JsGeneric`), letting
+  imported `async fn`s return dynamic-union enums.
+
 * `TryFromJsValue` for C-style enums no longer accepts non-numeric values
   via JS unary `+` coercion. Previously calling `dyn_into::<MyEnum>()` on
   a string would silently coerce it via `+"foo"` (yielding `NaN`, then

--- a/crates/js-sys/src/futures/mod.rs
+++ b/crates/js-sys/src/futures/mod.rs
@@ -127,7 +127,11 @@ impl<T> fmt::Debug for JsFuture<T> {
     }
 }
 
-impl<T: JsGeneric + FromWasmAbi> From<Promise<T>> for JsFuture<T> {
+// `FromWasmAbi` is what the closure shim invokes on the resolved value;
+// no layout equivalence with `JsValue` is required at this seam — the
+// per-type `from_abi` does the conversion (e.g. for dynamic unions it
+// runs the variant dispatcher).
+impl<T: FromWasmAbi + 'static> From<Promise<T>> for JsFuture<T> {
     fn from(js: Promise<T>) -> JsFuture<T> {
         // Use the `then` method to schedule two callbacks, one for the
         // resolved value and one for the rejected value. We're currently
@@ -217,7 +221,7 @@ impl<T> Future for JsFuture<T> {
     }
 }
 
-impl<T: JsGeneric + FromWasmAbi> IntoFuture for Promise<T> {
+impl<T: FromWasmAbi + 'static> IntoFuture for Promise<T> {
     type Output = Result<T, JsValue>;
     type IntoFuture = JsFuture<T>;
 

--- a/tests/wasm/enums.js
+++ b/tests/wasm/enums.js
@@ -55,3 +55,12 @@ exports.js_string_enum_fallback_roundtrip = e => wasm.string_enum_fallback_round
 exports.js_nested_union_roundtrip = o => wasm.nested_union_roundtrip(o);
 exports.js_optional_union_roundtrip = o => wasm.optional_union_roundtrip(o);
 exports.js_fallback_union_roundtrip = u => wasm.fallback_union_roundtrip(u);
+
+// Async round-trip: returning from an `async function` produces a
+// `Promise<Union>` on the JS side; awaiting it on the Rust import side
+// requires `From<Promise<Union>> for JsFuture<Union>` to compile.
+exports.js_async_union_roundtrip = async o => wasm.async_union_roundtrip(o);
+
+// Same shape, `Result<Union, JsValue>` form (success-only here; reject
+// path is exercised by other catch tests in the suite).
+exports.js_async_union_result = async o => wasm.async_union_roundtrip(o);

--- a/tests/wasm/enums.rs
+++ b/tests/wasm/enums.rs
@@ -23,6 +23,15 @@ extern "C" {
     fn js_nested_union_roundtrip(o: OuterUnion) -> OuterUnion;
     fn js_optional_union_roundtrip(o: Option<OuterUnion>) -> Option<OuterUnion>;
     fn js_fallback_union_roundtrip(u: FallbackUnion) -> FallbackUnion;
+
+    // Async round-trip: imports an `async fn` returning a dynamic union,
+    // exercising `Promise<Union>` resolution across the `JsFuture` seam.
+    async fn js_async_union_roundtrip(o: OuterUnion) -> OuterUnion;
+
+    // Same but with `catch`: the resolved success type is still `Union`,
+    // wrapped in `Result<_, JsValue>` for the rejection path.
+    #[wasm_bindgen(catch)]
+    async fn js_async_union_result(o: OuterUnion) -> Result<OuterUnion, JsValue>;
 }
 
 #[wasm_bindgen]
@@ -315,5 +324,37 @@ fn test_fallback_union_roundtrip() {
     assert!(matches!(
         js_fallback_union_roundtrip(FallbackUnion::Anything(foo)),
         FallbackUnion::Anything(_)
+    ));
+}
+
+// Verifies that an imported `async fn` returning a dynamic union resolves
+// correctly: the JS-side `Promise<Union>` flows through `JsFuture` and the
+// closure-shim's `from_abi` runs the union dispatcher. This case was
+// missed when unions were originally added — the original
+// `From<Promise<T>> for JsFuture<T>` impl required `T: JsGeneric`, which
+// dynamic unions cannot satisfy because they are tagged Rust enums (not
+// `#[repr(transparent)]` wrappers around `JsValue`). The bound has been
+// loosened to `T: FromWasmAbi + 'static`, which is the actual minimum the
+// closure shim needs.
+#[wasm_bindgen]
+pub async fn async_union_roundtrip(o: OuterUnion) -> OuterUnion {
+    o
+}
+
+#[wasm_bindgen_test]
+async fn test_async_union_roundtrip() {
+    let bar = Bar::new(99);
+    let result = js_async_union_roundtrip(OuterUnion::Bare(bar)).await;
+    assert!(matches!(result, OuterUnion::Bare(b) if b.value() == 99));
+}
+
+// `catch` projects to `Result<Union, JsValue>` on the Rust side; the
+// success type still flows through the same `JsFuture` seam.
+#[wasm_bindgen_test]
+async fn test_async_union_result_catch() {
+    let res = js_async_union_result(OuterUnion::Wrapped(InnerUnion::Number(123))).await;
+    assert!(matches!(
+        res,
+        Ok(OuterUnion::Wrapped(InnerUnion::Number(123)))
     ));
 }


### PR DESCRIPTION
Minor patch on top of #4734. Imported `async fn` returning a dynamic-union enum (i.e. `Promise<Union>` resolution) failed to compile because `From<Promise<T>> for JsFuture<T>` required `T: JsGeneric`. `JsGeneric` demands `JsCast` + `AsRef<JsValue>` (layout equivalence with `JsValue`), which a tagged-enum union cannot satisfy.

The closure shim that materialises the resolved value calls `T::from_abi`, which is per-type ABI conversion — `T: FromWasmAbi` is the actual minimum needed at this seam. For union types `from_abi` runs the variant dispatcher.

```rs
impl<T: JsGeneric + FromWasmAbi> From<Promise<T>> for JsFuture<T> { ... }
```

becomes:

```rs
impl<T: FromWasmAbi + 'static> From<Promise<T>> for JsFuture<T> { ... }
```

Same change applied to `IntoFuture for Promise<T>`. No behaviour change for existing `JsGeneric` types (they all impl `FromWasmAbi`).

Adding to 0.2.121 as it has not yet gone out.

This intentionally does not address `Array<Union>` / `Map<K, Union>` and similar — those go through the `ErasableGeneric` macro check at a different layer and need a separate fix.