### PR TITLE
Fix CI for latest rustc nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
         components: rust-src
     - uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version: '20'
     - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
     - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
   test_wasm_bindgen_unwind_exnref_eh:
@@ -268,7 +268,7 @@ jobs:
         targets: wasm32-unknown-unknown
     - uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version: '20'
     - run: cargo test
     - run: cargo test -p wasm-bindgen-cli-support
     - run: cargo test -p wasm-bindgen-cli

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,11 +275,11 @@ jobs:
         targets: wasm32-unknown-unknown
     # The cli termination tests build with `-Cpanic=unwind` which since
     # rust-lang/rust#156061 produces modern (exnref) EH by default. That needs
-    # Node 22.22.3+ on the 22 LTS line (or 24+) to validate.
+    # Node 22.22.3+ on the 22 LTS line (or 24.15+) to validate.
     # TODO: drop back to Node 22 LTS once 22.22.3 ships (2026-05-13, modern EH backport).
     - uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '24.15'
     - run: cargo test
     - run: cargo test -p wasm-bindgen-cli-support
     - run: cargo test -p wasm-bindgen-cli

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-      RUSTFLAGS: -Cpanic=unwind
+      # rust-lang/rust#156061 flipped the wasm panic=unwind default to modern
+      # (exnref) EH, so legacy EH now requires an explicit opt-in via the LLVM
+      # flag below. Node 20 only supports legacy EH.
+      RUSTFLAGS: -Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh
     steps:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@nightly
@@ -185,13 +188,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-      RUSTFLAGS: -Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh=false
+      # Modern (exnref) EH is the default for panic=unwind on wasm since
+      # rust-lang/rust#156061. Modern EH requires Node 22.22.3+ on the 22 LTS
+      # line (or 24+).
+      RUSTFLAGS: -Cpanic=unwind
     steps:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@nightly
       with:
         targets: wasm32-unknown-unknown
         components: rust-src
+    # TODO: drop back to Node 22 LTS once 22.22.3 ships (2026-05-13, modern EH backport).
     - uses: actions/setup-node@v6
       with:
         node-version: '25'
@@ -266,9 +273,13 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         targets: wasm32-unknown-unknown
+    # The cli termination tests build with `-Cpanic=unwind` which since
+    # rust-lang/rust#156061 produces modern (exnref) EH by default. That needs
+    # Node 22.22.3+ on the 22 LTS line (or 24+) to validate.
+    # TODO: drop back to Node 22 LTS once 22.22.3 ships (2026-05-13, modern EH backport).
     - uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
     - run: cargo test
     - run: cargo test -p wasm-bindgen-cli-support
     - run: cargo test -p wasm-bindgen-cli

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
           - name: mvp
             rustflags: -Ctarget-cpu=mvp
           - name: atomics
-            rustflags: -Ctarget-feature=+atomics -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base
+            rustflags: -Ctarget-feature=+atomics -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__heap_base -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base
     name: "Run wasm-bindgen crate tests (${{ matrix.envs.name }})"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
       WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
       # Modern (exnref) EH is the default for panic=unwind on wasm since
       # rust-lang/rust#156061. Modern EH requires Node 22.22.3+ on the 22 LTS
-      # line (or 24+).
+      # line (or 24.15.0+).
       RUSTFLAGS: -Cpanic=unwind
     steps:
     - uses: actions/checkout@v6
@@ -275,7 +275,7 @@ jobs:
         targets: wasm32-unknown-unknown
     # The cli termination tests build with `-Cpanic=unwind` which since
     # rust-lang/rust#156061 produces modern (exnref) EH by default. That needs
-    # Node 22.22.3+ on the 22 LTS line (or 24.15+) to validate.
+    # Node 22.22.3+ on the 22 LTS line (or 24.15.0+) to validate.
     # TODO: drop back to Node 22 LTS once 22.22.3 ships (2026-05-13, modern EH backport).
     - uses: actions/setup-node@v6
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   handling by default after
   [rust-lang/rust#156061](https://github.com/rust-lang/rust/pull/156061),
   instead of the legacy try/catch EH. Modern EH requires Node.js
-  22.22.3+ or 24+, or a recent browser. If older runtime support is
+  22.22.3+ or 24.15.0+, or a recent browser. If older runtime support is
   needed (e.g. Node.js 20), pass `-Cllvm-args=-wasm-use-legacy-eh` to
   opt back into legacy EH — wasm-bindgen detects and supports both
   variants. The `catch-unwind` guide has been updated accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 
 ## Unreleased
 
+### Fixed
+
+* Threading support requires `-Clink-arg=--export=__heap_base` to be set
+  in `RUSTFLAGS` for nightly toolchains from 2026-05-06 onward, after
+  [rust-lang/rust#156174](https://github.com/rust-lang/rust/pull/156174)
+  removed the implicit `__heap_base`/`__data_end` exports on `wasm*`
+  targets. Atomics CI, CLI reference tests, and the `nodejs-threads`,
+  `raytrace-parallel`, and `wasm-audio-worklet` examples have been
+  updated to pass `--export=__heap_base` explicitly. The flag is
+  backward-compatible with older nightlies.
+
 --------------------------------------------------------------------------------
 
 ## [0.2.121](https://github.com/rustwasm/wasm-bindgen/compare/0.2.120...0.2.121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Unreleased
 
-### Fixed
+### Notices
 
 * Threading support requires `-Clink-arg=--export=__heap_base` to be set
   in `RUSTFLAGS` for nightly toolchains from 2026-05-06 onward, after
@@ -13,6 +13,15 @@
   `raytrace-parallel`, and `wasm-audio-worklet` examples have been
   updated to pass `--export=__heap_base` explicitly. The flag is
   backward-compatible with older nightlies.
+
+* `-Cpanic=unwind` on wasm targets now emits modern (exnref) exception
+  handling by default after
+  [rust-lang/rust#156061](https://github.com/rust-lang/rust/pull/156061),
+  instead of the legacy try/catch EH. Modern EH requires Node.js
+  22.22.3+ or 24+, or a recent browser. If older runtime support is
+  needed (e.g. Node.js 20), pass `-Cllvm-args=-wasm-use-legacy-eh` to
+  opt back into legacy EH — wasm-bindgen detects and supports both
+  variants. The `catch-unwind` guide has been updated accordingly.
 
 --------------------------------------------------------------------------------
 

--- a/crates/cli/tests/wasm-bindgen/reference.rs
+++ b/crates/cli/tests/wasm-bindgen/reference.rs
@@ -244,6 +244,7 @@ fn runtest_targets_atomics() -> Result<()> {
                 -Clink-args=--shared-memory \
                 -Clink-args=--max-memory=1073741824 \
                 -Clink-args=--import-memory \
+                -Clink-args=--export=__heap_base \
                 -Clink-args=--export=__wasm_init_tls \
                 -Clink-args=--export=__tls_size \
                 -Clink-args=--export=__tls_align \
@@ -271,6 +272,7 @@ fn no_duplicate_wasm_export_in_node_esm_atomics_debug() -> Result<()> {
             -Clink-args=--shared-memory \
             -Clink-args=--max-memory=1073741824 \
             -Clink-args=--import-memory \
+            -Clink-args=--export=__heap_base \
             -Clink-args=--export=__wasm_init_tls \
             -Clink-args=--export=__tls_size \
             -Clink-args=--export=__tls_align \

--- a/examples/nodejs-threads/package.json
+++ b/examples/nodejs-threads/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"prebuild": "cargo +nightly build -p nodejs-threads --target wasm32-unknown-unknown --release -Zbuild-std=std,panic_abort --config \"target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics,+bulk-memory -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base'\"",
+		"prebuild": "cargo +nightly build -p nodejs-threads --target wasm32-unknown-unknown --release -Zbuild-std=std,panic_abort --config \"target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics,+bulk-memory -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__heap_base -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base'\"",
 		"build:cjs": "wasm-bindgen --target nodejs --out-dir ../dist/nodejs-threads ../../target/wasm32-unknown-unknown/release/nodejs_threads.wasm",
 		"build:esm": "wasm-bindgen --target experimental-nodejs-module --out-dir ../dist/nodejs-threads-esm ../../target/wasm32-unknown-unknown/release/nodejs_threads.wasm",
 		"build": "npm run build:cjs && npm run build:esm",

--- a/examples/raytrace-parallel/package.json
+++ b/examples/raytrace-parallel/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"build": "wasm-pack build --target no-modules --out-dir ../dist/raytrace-parallel . -Zbuild-std=std,panic_abort --config \"target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base'\"",
+		"build": "wasm-pack build --target no-modules --out-dir ../dist/raytrace-parallel . -Zbuild-std=std,panic_abort --config \"target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__heap_base -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base'\"",
 		"postbuild": "node ../cp-dist.mjs index.html index.js worker.js"
 	}
 }

--- a/examples/wasm-audio-worklet/package.json
+++ b/examples/wasm-audio-worklet/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"build": "wasm-pack build --target web --out-dir ../dist/wasm-audio-worklet . -Zbuild-std=std,panic_abort --config \"target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base'\"",
+		"build": "wasm-pack build --target web --out-dir ../dist/wasm-audio-worklet . -Zbuild-std=std,panic_abort --config \"target.wasm32-unknown-unknown.rustflags='-Ctarget-feature=+atomics -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory -Clink-args=--export=__heap_base -Clink-args=--export=__wasm_init_tls -Clink-args=--export=__tls_size -Clink-args=--export=__tls_align -Clink-args=--export=__tls_base'\"",
 		"postbuild": "node ../cp-dist.mjs index.html"
 	}
 }

--- a/guide/src/reference/catch-unwind.md
+++ b/guide/src/reference/catch-unwind.md
@@ -19,7 +19,7 @@ is rejected with the `PanicError`.
 - **`std` feature** - `std` support is required to use
   `std::panic::catch_unwind`. to catch panics.
 - **Runtime with modern Wasm exception handling** - `-Cpanic=unwind` emits
-  modern (exnref) EH by default, which needs Node.js 22.22.3+ or 24+, or a
+  modern (exnref) EH by default, which needs Node.js 22.22.3+ or 24.15.0+, or a
   recent browser. If Node.js 20 support is required, add
   `-Cllvm-args=-wasm-use-legacy-eh` to use legacy try/catch EH, which is also
   supported by wasm-bindgen.

--- a/guide/src/reference/catch-unwind.md
+++ b/guide/src/reference/catch-unwind.md
@@ -18,6 +18,11 @@ is rejected with the `PanicError`.
 - **Rust nightly compiler** - `-Zbuild-std` is only available on nightly
 - **`std` feature** - `std` support is required to use
   `std::panic::catch_unwind`. to catch panics.
+- **Runtime with modern Wasm exception handling** - `-Cpanic=unwind` emits
+  modern (exnref) EH by default, which needs Node.js 22.22.3+ or 24+, or a
+  recent browser. If Node.js 20 support is required, add
+  `-Cllvm-args=-wasm-use-legacy-eh` to use legacy try/catch EH, which is also
+  supported by wasm-bindgen.
 
 ## Building
 

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ test-wasm64 *ARGS="":
         {{ARGS}}
 
 # Run wasm-bindgen tests with panic=unwind. Since rust-lang/rust#156061 this
-# uses modern (exnref) EH by default, which requires Node 22.22.3+ or Node 24+.
+# uses modern (exnref) EH by default, which requires Node 22.22.3+ or Node 24.15.0+.
 test-wasm-bindgen-unwind *ARGS="":
     RUSTFLAGS="-Cpanic=unwind" \
     RUSTDOCFLAGS="-Cpanic=unwind" \
@@ -68,7 +68,7 @@ test-wasm-bindgen-unwind *ARGS="":
         {{ARGS}}
 
 # Run wasm-bindgen tests with panic=unwind using legacy EH (try/catch). Useful
-# for testing compatibility with older runtimes (Node <22.22.3, older browsers).
+# for testing compatibility with older runtimes (Node 20, older browsers).
 test-wasm-bindgen-unwind-legacy-eh *ARGS="":
     RUSTFLAGS="-Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh" \
     RUSTDOCFLAGS="-Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh" \

--- a/justfile
+++ b/justfile
@@ -53,6 +53,8 @@ test-wasm64 *ARGS="":
         --target wasm64-unknown-unknown \
         {{ARGS}}
 
+# Run wasm-bindgen tests with panic=unwind. Since rust-lang/rust#156061 this
+# uses modern (exnref) EH by default, which requires Node 22.22.3+ or Node 24+.
 test-wasm-bindgen-unwind *ARGS="":
     RUSTFLAGS="-Cpanic=unwind" \
     RUSTDOCFLAGS="-Cpanic=unwind" \
@@ -65,9 +67,11 @@ test-wasm-bindgen-unwind *ARGS="":
         --target wasm32-unknown-unknown \
         {{ARGS}}
 
-test-wasm-bindgen-unwind-eh *ARGS="":
-    RUSTFLAGS="-Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh=false" \
-    RUSTDOCFLAGS="-Cpanic=unwind" \
+# Run wasm-bindgen tests with panic=unwind using legacy EH (try/catch). Useful
+# for testing compatibility with older runtimes (Node <22.22.3, older browsers).
+test-wasm-bindgen-unwind-legacy-eh *ARGS="":
+    RUSTFLAGS="-Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh" \
+    RUSTDOCFLAGS="-Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh" \
     NODE_ARGS="--stack-trace-limit=100" \
     RUST_BACKTRACE=1 \
     WASM_BINDGEN_TEST_ONLY_NODE=1 \

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ test:
     just test-webidl-tests-compat
 
 test-cli *ARGS="":
-    cargo test -p wasm-bindgen-cli {{ARGS}} > /tmp/test-cli.log 2>&1 || (cat /tmp/test-cli.log && exit 1)
+    cargo test -p wasm-bindgen-cli {{ARGS}}
 
 test-cli-overwrite:
     BLESS=1 cargo test -p wasm-bindgen-cli -- --skip headless_streaming_tests


### PR DESCRIPTION
This fixes CI on current nightly Rust (2026-05-06+) with two recent issues:

1. modern exception handling is now the default as of 
2. atomics-flagged builds fail with `failed to find \`__heap_base\` for injecting thread id`.

### Use Node.js 24.15+ 22.22.3+

Node.js modern exception handling requires 22.22.3+ OR 24.15+.

We change the tests to use this version, and then explicitly turn on legacy exception handling for those tests.

### Add --export=__heap_base for threading after rust-lang/rust#156174

[rust-lang/rust#156174](https://github.com/rust-lang/rust/pull/156174) (merged 2026-05-06) intentionally removed the implicit `__heap_base`/`__data_end` exports on `wasm*-unknown-unknown` and `wasm32v1-none`, requiring threading toolchains like wasm-bindgen to opt in explicitly. The PR description spells out the required link arg directly:

> After this PR the following would be required for multi-threading support in `wasm-bindgen`:
> `... -Clink-arg=--shared-memory ... -Clink-arg=--export=__heap_base -Clink-arg=--export=__wasm_init_tls ...`

`wasm-bindgen`'s threading post-processing needs `__heap_base` (see `crates/cli-support/src/transforms/threads/mod.rs:193`) to set up per-thread stacks, so without the new export it bails immediately.

This PR adds `-Clink-arg=--export=__heap_base` everywhere the existing TLS exports are listed:

* `.github/workflows/main.yml` — atomics CI rustflags
* `crates/cli/tests/wasm-bindgen/reference.rs` — `runtest_targets_atomics` and `no_duplicate_wasm_export_in_node_esm_atomics_debug`
* `examples/nodejs-threads/package.json`
* `examples/raytrace-parallel/package.json`
* `examples/wasm-audio-worklet/package.json`

Verified locally: the fix makes the failing `headless` test pass on `nightly-2026-05-07` (`365c0e1d7`), and remains backward-compatible with older nightlies (`nightly-2026-05-06` / `e95e73209`).