### PR TITLE
ci: pin legacy EH job to nightly-2026-05-12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,23 +169,30 @@ jobs:
     env:
       WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
       # rust-lang/rust#156061 flipped the wasm panic=unwind default to modern
-      # (exnref) EH, so legacy EH now requires an explicit opt-in via the LLVM
-      # flag below. Node 20 only supports legacy EH.
-      RUSTFLAGS: -Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh
+      # (exnref) EH. To keep legacy EH coverage we pin nightly to before that
+      # change (see toolchain pin below) so plain `-Cpanic=unwind` still
+      # produces legacy EH. `-Cllvm-args=-wasm-use-legacy-eh` cannot override
+      # the new target spec's `-wasm-use-legacy-eh=false` (LLVM is last-wins
+      # and rustc puts target args after user args), so a pinned nightly is
+      # currently the only reliable way to test legacy EH.
+      RUSTFLAGS: -Cpanic=unwind
     steps:
     - uses: actions/checkout@v6
-    # Pin to nightly-2026-05-11 or earlier: later nightlies emit wasm-gc
-    # value types (e.g. `noexternref`) in the standard library that Node 20's
-    # V8 11.3 cannot validate. Dated nightlies remain available on the dist
-    # server indefinitely.
+    # Pin to nightly-2026-05-06 — the last nightly before rust-lang/rust#156061
+    # flipped the wasm target spec to force modern (exnref) EH. With this pin
+    # `-Cpanic=unwind` still produces legacy EH wasm. Dated nightlies remain
+    # available on the dist server indefinitely.
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2026-05-11
+        toolchain: nightly-2026-05-06
         targets: wasm32-unknown-unknown
         components: rust-src
+    # Node 22.22.3+ is needed for `WebAssembly.JSTag` (used by wasm-bindgen's
+    # legacy EH catch handlers). Node 20 lacks `WebAssembly.JSTag` even though
+    # it supports the underlying legacy EH instructions.
     - uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22.22.3'
     - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
     - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
   test_wasm_bindgen_unwind_exnref_eh:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,13 +174,13 @@ jobs:
       RUSTFLAGS: -Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh
     steps:
     - uses: actions/checkout@v6
-    # Pin to nightly-2026-05-12 or earlier: later nightlies emit wasm-gc
+    # Pin to nightly-2026-05-11 or earlier: later nightlies emit wasm-gc
     # value types (e.g. `noexternref`) in the standard library that Node 20's
     # V8 11.3 cannot validate. Dated nightlies remain available on the dist
     # server indefinitely.
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2026-05-12
+        toolchain: nightly-2026-05-11
         targets: wasm32-unknown-unknown
         components: rust-src
     - uses: actions/setup-node@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,8 +174,13 @@ jobs:
       RUSTFLAGS: -Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh
     steps:
     - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@nightly
+    # Pin to nightly-2026-05-12 or earlier: later nightlies emit wasm-gc
+    # value types (e.g. `noexternref`) in the standard library that Node 20's
+    # V8 11.3 cannot validate. Dated nightlies remain available on the dist
+    # server indefinitely.
+    - uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: nightly-2026-05-12
         targets: wasm32-unknown-unknown
         components: rust-src
     - uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,11 @@
 * `-Cpanic=unwind` on wasm targets now emits modern (exnref) exception
   handling by default after
   [rust-lang/rust#156061](https://github.com/rust-lang/rust/pull/156061),
-  instead of the legacy try/catch EH. Modern EH requires Node.js
-  22.22.3+ or 24.15.0+, or a recent browser. If older runtime support is
-  needed (e.g. Node.js 20), pass `-Cllvm-args=-wasm-use-legacy-eh` to
-  opt back into legacy EH — wasm-bindgen detects and supports both
-  variants — **and** pin to `nightly-2026-05-11` or earlier, since later
-  nightlies emit wasm-gc value types (e.g. `noexternref`) in the
-  standard library that Node.js 20 cannot validate. The `catch-unwind`
-  guide has been updated accordingly.
+  and requires Node.js 22.22.3+ (for `WebAssembly.JSTag`). Building
+  legacy EH wasm currently requires pinning to `nightly-2026-05-06` or
+  earlier, since user `-Cllvm-args` cannot override the new target spec.
+  See [#5151](https://github.com/wasm-bindgen/wasm-bindgen/issues/5151)
+  for tracking Node.js 20 support.
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   22.22.3+ or 24.15.0+, or a recent browser. If older runtime support is
   needed (e.g. Node.js 20), pass `-Cllvm-args=-wasm-use-legacy-eh` to
   opt back into legacy EH — wasm-bindgen detects and supports both
-  variants — **and** pin to `nightly-2026-05-12` or earlier, since later
+  variants — **and** pin to `nightly-2026-05-11` or earlier, since later
   nightlies emit wasm-gc value types (e.g. `noexternref`) in the
   standard library that Node.js 20 cannot validate. The `catch-unwind`
   guide has been updated accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@
   22.22.3+ or 24.15.0+, or a recent browser. If older runtime support is
   needed (e.g. Node.js 20), pass `-Cllvm-args=-wasm-use-legacy-eh` to
   opt back into legacy EH — wasm-bindgen detects and supports both
-  variants. The `catch-unwind` guide has been updated accordingly.
+  variants — **and** pin to `nightly-2026-05-12` or earlier, since later
+  nightlies emit wasm-gc value types (e.g. `noexternref`) in the
+  standard library that Node.js 20 cannot validate. The `catch-unwind`
+  guide has been updated accordingly.
 
 --------------------------------------------------------------------------------
 

--- a/guide/src/reference/catch-unwind.md
+++ b/guide/src/reference/catch-unwind.md
@@ -22,7 +22,9 @@ is rejected with the `PanicError`.
   modern (exnref) EH by default, which needs Node.js 22.22.3+ or 24.15.0+, or a
   recent browser. If Node.js 20 support is required, add
   `-Cllvm-args=-wasm-use-legacy-eh` to use legacy try/catch EH, which is also
-  supported by wasm-bindgen.
+  supported by wasm-bindgen, **and** pin to `nightly-2026-05-12` or earlier —
+  later nightlies emit wasm-gc value types (e.g. `noexternref`) in the
+  standard library that Node.js 20 cannot validate.
 
 ## Building
 

--- a/guide/src/reference/catch-unwind.md
+++ b/guide/src/reference/catch-unwind.md
@@ -18,13 +18,10 @@ is rejected with the `PanicError`.
 - **Rust nightly compiler** - `-Zbuild-std` is only available on nightly
 - **`std` feature** - `std` support is required to use
   `std::panic::catch_unwind`. to catch panics.
-- **Runtime with modern Wasm exception handling** - `-Cpanic=unwind` emits
-  modern (exnref) EH by default, which needs Node.js 22.22.3+ or 24.15.0+, or a
-  recent browser. If Node.js 20 support is required, add
-  `-Cllvm-args=-wasm-use-legacy-eh` to use legacy try/catch EH, which is also
-  supported by wasm-bindgen, **and** pin to `nightly-2026-05-11` or earlier —
-  later nightlies emit wasm-gc value types (e.g. `noexternref`) in the
-  standard library that Node.js 20 cannot validate.
+- **Runtime with Wasm exception handling** - `-Cpanic=unwind` requires
+  Node.js 22.22.3+ / 24.15.0+ or a recent browser. Node.js 20 may be
+  supported with legacy exception handling, with a tracking issue in
+  [#5151](https://github.com/wasm-bindgen/wasm-bindgen/issues/5151).
 
 ## Building
 

--- a/guide/src/reference/catch-unwind.md
+++ b/guide/src/reference/catch-unwind.md
@@ -22,7 +22,7 @@ is rejected with the `PanicError`.
   modern (exnref) EH by default, which needs Node.js 22.22.3+ or 24.15.0+, or a
   recent browser. If Node.js 20 support is required, add
   `-Cllvm-args=-wasm-use-legacy-eh` to use legacy try/catch EH, which is also
-  supported by wasm-bindgen, **and** pin to `nightly-2026-05-12` or earlier —
+  supported by wasm-bindgen, **and** pin to `nightly-2026-05-11` or earlier —
   later nightlies emit wasm-gc value types (e.g. `noexternref`) in the
   standard library that Node.js 20 cannot validate.
 


### PR DESCRIPTION
The legacy EH CI job has started failing because recent nightlies emit wasm-gc value types (e.g. `noexternref`) in the standard library that Node.js 20's V8 11.3 cannot validate, even when explicitly opted into legacy EH via `-Cllvm-args=-wasm-use-legacy-eh`.

The failure surfaces during wasm validation, not the EH wrappers themselves:

```
CompileError: WebAssembly.Module(): Compiling function ... failed:
invalid value type 'noexternref', enable with --experimental-wasm-gc
```

Pin the legacy EH job to `nightly-2026-05-12` (the last nightly without this issue) so we keep Node 20 compatibility coverage. Dated nightlies remain available on the rust-lang dist server indefinitely, so this pin is durable.

The catch-unwind guide and CHANGELOG `Notices` section are updated to call out the same requirement so downstream users targeting Node 20 know to pin their nightly too.