### PR TITLE
fix: Handle `Br` and `BrIf` instructions in the descriptor interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@
   ```
   [#5154](https://github.com/wasm-bindgen/wasm-bindgen/pull/5154)
 
+### Fixed
+
+* Fixed the descriptor interpreter panicking on `Br` and `BrIf`
+  instructions emitted by recent nightly compilers when building with
+  `panic=unwind`.
+  [#5158](https://github.com/wasm-bindgen/wasm-bindgen/pull/5158)
+
 ### Changed
 
 * When an exported struct uses `js_namespace`, the corresponding value

--- a/crates/cli-support/src/interpreter/mod.rs
+++ b/crates/cli-support/src/interpreter/mod.rs
@@ -70,6 +70,12 @@ pub struct Interpreter {
     /// and `__wasm_call_dtors`.
     skip_calls: HashSet<FunctionId>,
     stopped: bool,
+
+    // When a `Br` or `BrIf` (taken) instruction is executed, this holds the
+    // target InstrSeqId. Evaluation breaks out of nested blocks until the
+    // block whose seq matches this target is reached, at which point it is
+    // cleared and normal execution resumes after that block.
+    branch_target: Option<InstrSeqId>,
 }
 
 fn skip_calls(module: &Module, id: FunctionId) -> HashSet<FunctionId> {
@@ -200,6 +206,7 @@ impl Interpreter {
     pub fn interpret_descriptor(&mut self, id: FunctionId, module: &Module) -> &[u32] {
         self.descriptor.truncate(0);
         self.stopped = false;
+        self.branch_target = None;
 
         if let Some(sp) = self.stack_pointer {
             self.stack_pointer_initial = self.globals[&sp];
@@ -267,6 +274,20 @@ struct Frame<'a> {
 }
 
 impl Frame<'_> {
+    fn should_break_after_block(&mut self, seq: InstrSeqId) -> bool {
+        if self.interp.stopped {
+            return true;
+        }
+        if let Some(target) = self.interp.branch_target {
+            if target == seq {
+                self.interp.branch_target = None;
+            } else {
+                return true;
+            }
+        }
+        false
+    }
+
     fn eval(&mut self, seq: InstrSeqId) -> anyhow::Result<()> {
         use walrus::ir::*;
 
@@ -478,23 +499,38 @@ impl Frame<'_> {
                     }
                 }
 
+                Instr::Br(Br { block }) => {
+                    log::trace!("br {block:?}");
+                    self.interp.branch_target = Some(*block);
+                    break;
+                }
+
+                Instr::BrIf(BrIf { block }) => {
+                    let cond = stack.pop().unwrap();
+                    log::trace!("br_if {block:?} (cond={cond})");
+                    if cond != 0 {
+                        self.interp.branch_target = Some(*block);
+                        break;
+                    }
+                }
+
                 Instr::Block(block) => {
                     self.eval(block.seq)?;
-                    if self.interp.stopped {
+                    if self.should_break_after_block(block.seq) {
                         break;
                     }
                 }
 
                 Instr::Try(block) => {
                     self.eval(block.seq)?;
-                    if self.interp.stopped {
+                    if self.should_break_after_block(block.seq) {
                         break;
                     }
                 }
 
                 Instr::TryTable(block) => {
                     self.eval(block.seq)?;
-                    if self.interp.stopped {
+                    if self.should_break_after_block(block.seq) {
                         break;
                     }
                 }

--- a/crates/cli-support/src/interpreter/smoke_tests.rs
+++ b/crates/cli-support/src/interpreter/smoke_tests.rs
@@ -318,6 +318,92 @@ fn try_table_block() {
 }
 
 #[test]
+fn br_out_of_try_table() {
+    let wat = r#"
+        (module
+            (import "__wbindgen_placeholder__" "__wbindgen_describe"
+              (func $__wbindgen_describe (param i32)))
+            (global $__stack_pointer (mut i32) (i32.const 0))
+
+            (func $foo
+                (local i32)
+
+                global.get $__stack_pointer
+                i32.const 16
+                i32.sub
+                local.set 0
+                local.get 0
+                global.set $__stack_pointer
+
+                (block $outer
+                    (try_table (catch_all $outer)
+                        i32.const 42
+                        call $__wbindgen_describe
+                        br $outer
+                    )
+                )
+
+                local.get 0
+                i32.const 16
+                i32.add
+                global.set $__stack_pointer
+            )
+
+            (export "foo" (func $foo))
+        )
+    "#;
+    interpret(wat, "foo", &[42]);
+}
+
+#[test]
+fn br_if_taken() {
+    let wat = r#"
+        (module
+            (import "__wbindgen_placeholder__" "__wbindgen_describe"
+              (func $__wbindgen_describe (param i32)))
+
+            (func $foo
+                (block $skip
+                    i32.const 1
+                    br_if $skip
+                    i32.const 99
+                    call $__wbindgen_describe
+                )
+                i32.const 7
+                call $__wbindgen_describe
+            )
+
+            (export "foo" (func $foo))
+        )
+    "#;
+    interpret(wat, "foo", &[7]);
+}
+
+#[test]
+fn br_if_not_taken() {
+    let wat = r#"
+        (module
+            (import "__wbindgen_placeholder__" "__wbindgen_describe"
+              (func $__wbindgen_describe (param i32)))
+
+            (func $foo
+                (block $skip
+                    i32.const 0
+                    br_if $skip
+                    i32.const 5
+                    call $__wbindgen_describe
+                )
+                i32.const 10
+                call $__wbindgen_describe
+            )
+
+            (export "foo" (func $foo))
+        )
+    "#;
+    interpret(wat, "foo", &[5, 10]);
+}
+
+#[test]
 fn calling_functions_with_args() {
     let wat = r#"
         (module


### PR DESCRIPTION
### Description

The interpreter panics with "unknown instruction Br(...)" when processing descriptor functions compiled by recent nightly Rust with panic=unwind. The nightly compiler emits `br` as the normal exit path from `try_table` blocks wrapping closure bodies, but the interpreter had no handling for branch instructions.

Add support for `Br` (unconditional branch) and `BrIf` (conditional branch) by tracking the branch target and propagating it outward through nested blocks until the target is reached.

Fixes the panic:
  wbg_cast::breaks_if_inlined::<OwnedClosure<dyn FnMut<(CloseEvent,)>>>:
  unknown instruction Br(Br { block: Id { idx: 1 } })

### Checklist
- [x] Verified changelog requirement


Fixes #5157