### PR TITLE
fix: use js_sys::futures instead of wasm_bindgen_futures in macro

### DIFF
--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -215,8 +215,7 @@ impl Parse for ClassMarker {
             js_class,
             js_namespace,
             wasm_bindgen: wasm_bindgen.unwrap_or_else(|| syn::parse_quote! { wasm_bindgen }),
-            wasm_bindgen_futures: wasm_bindgen_futures
-                .unwrap_or_else(|| syn::parse_quote! { wasm_bindgen_futures }),
+            wasm_bindgen_futures: wasm_bindgen_futures.unwrap_or_else(|| syn::parse_quote! { js_sys::futures }),
             js_sys: js_sys.unwrap_or_else(|| syn::parse_quote! { js_sys }),
         })
     }


### PR DESCRIPTION
### Description
We're starting to give the guidance that wasm-bindgen-futures is an optional dependency since we consolidated into `js_sys::futures`.

The problem is that the wasm-bindgen macro is still emitting for `wasm-bindgen-futures` in its output.

This makes `js_sys::futures` the default, unless an explicit wasm-bindgen-futures attribute is provided.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
