### PR TITLE
Allow opting into js-sys futures codegen via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ### Added
 
+* The js-sys futures codegen opt-in can now also be enabled via the
+  `WASM_BINDGEN_USE_JS_SYS=1` environment variable, in addition to
+  `--cfg=wasm_bindgen_use_js_sys`. This works on stable when `--target`
+  is in use, where Cargo does not propagate the cfg to host proc-macros.
+  [#5164](https://github.com/wasm-bindgen/wasm-bindgen/pull/5164)
+
 ### Changed
 
 ### Fixed

--- a/crates/macro-support/src/ast.rs
+++ b/crates/macro-support/src/ast.rs
@@ -9,7 +9,13 @@ use syn::Path;
 use wasm_bindgen_shared as shared;
 
 pub fn use_js_sys_futures() -> bool {
-    cfg!(wasm_bindgen_use_js_sys)
+    // Honor either the build-time cfg or an expansion-time environment variable.
+    // The env-var form is necessary because `cfg!(...)` is resolved when this
+    // proc-macro crate is itself compiled (on the host), and Cargo does not pass
+    // `--cfg`/`RUSTFLAGS` to host proc-macros when `--target` is used. Reading
+    // an env var at expansion time provides a stable workflow that works
+    // regardless of how the consumer configures Cargo.
+    cfg!(wasm_bindgen_use_js_sys) || std::env::var_os("WASM_BINDGEN_USE_JS_SYS").is_some()
 }
 
 /// Whether a function is a start function, and if so, whether it

--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -361,12 +361,28 @@ async fn process_numbers() -> Result<f64, JsValue> {
 ## Using `js_sys` directly without `wasm-bindgen-futures`
 
 To make `#[wasm_bindgen]` emit `js_sys::futures` directly and drop the
-`wasm-bindgen-futures` dependency, depend on `js-sys` and build with
-`--cfg=wasm_bindgen_use_js_sys` (e.g. via `RUSTFLAGS` or `.cargo/config.toml`).
+`wasm-bindgen-futures` dependency, depend on `js-sys` and enable the opt-in
+in one of two equivalent ways:
 
-A cfg is used rather than a Cargo feature so the choice stays scoped to the
-crate that opts in — Cargo features union across the dep graph, which would
-flip codegen for every `#[wasm_bindgen]` user in the build.
+* Set the `WASM_BINDGEN_USE_JS_SYS=1` environment variable when invoking
+  Cargo, or
+* Build with `--cfg=wasm_bindgen_use_js_sys` (e.g. via `RUSTFLAGS` or
+  `.cargo/config.toml`).
+
+The environment-variable form is read at macro expansion time and therefore
+works on stable Rust even when `--target` is used. The `--cfg` form is
+resolved when `wasm-bindgen-macro-support` itself is compiled on the host;
+Cargo does not propagate `RUSTFLAGS` or `target.*.rustflags` to host
+proc-macros when `--target` is set (see
+[rust-lang/cargo#3349](https://github.com/rust-lang/cargo/issues/3349)),
+so the cfg-only path requires nightly with
+`-Z host-config -Z target-applies-to-host` or a host build that does not
+use `--target`.
+
+A cfg/env opt-in is used rather than a Cargo feature so the choice stays
+scoped to the crate that opts in — Cargo features union across the dep
+graph, which would flip codegen for every `#[wasm_bindgen]` user in the
+build.
 
 ## Compatibility note
 


### PR DESCRIPTION
This adds a stable workflow for opting into the `js_sys::futures` codegen path introduced in #5127.

Resolves https://github.com/wasm-bindgen/wasm-bindgen/issues/5104.

#5127 gated the opt-in on `cfg!(wasm_bindgen_use_js_sys)` inside `wasm-bindgen-macro-support`. That cfg is evaluated when the proc-macro crate is compiled on the host, and Cargo does not propagate `RUSTFLAGS` or `target.*.rustflags` to host proc-macros when `--target` is in use (see [rust-lang/cargo#3349](https://github.com/rust-lang/cargo/issues/3349) and the [`build.rustflags` docs](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags)). The host-config mechanism that solves this (`[host] rustflags` with `-Z host-config -Z target-applies-to-host`) is nightly-only. In practice this means the cfg cannot be enabled on stable Rust for a normal `cargo build --target wasm32-unknown-unknown` workflow.

This was confirmed empirically: with `RUSTFLAGS=--cfg=wasm_bindgen_use_js_sys cargo build --target wasm32-unknown-unknown`, the macro-support fingerprint records `rustflags: []` and the macro expansion sees the cfg as disabled. The same holds for `build.rustflags`, `target.<triple>.rustflags`, `target.\"cfg(all())\".rustflags`, `CARGO_TARGET_*_RUSTFLAGS`, and `build.target` in `.cargo/config.toml`. Only nightly `[host] rustflags` works.

Read the same opt-in from an environment variable as a stable fallback. Env vars set on the cargo subprocess are visible to proc-macros at expansion time via `std::env::var`, so consumers can do:

```sh
WASM_BINDGEN_USE_JS_SYS=1 cargo build --target wasm32-unknown-unknown
```

Before:

```rust
pub fn use_js_sys_futures() -> bool {
    cfg!(wasm_bindgen_use_js_sys)
}
```

After:

```rust
pub fn use_js_sys_futures() -> bool {
    cfg!(wasm_bindgen_use_js_sys) || std::env::var_os("WASM_BINDGEN_USE_JS_SYS").is_some()
}
```

The existing cfg path is unchanged; either source enables the codegen.

Verified end-to-end by vendoring this change into workers-rs and running its build + test suite — `#[wasm_bindgen]` expansions reference `js_sys::futures` and the `wasm-bindgen-futures` dependency is no longer pulled in. The guide and changelog are updated to document the env-var path and the rationale for offering both forms.