### PR TITLE
web-sys: add maxAge to CookieInit dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ### Added
 
+* Added the `maxAge` attribute to the `CookieInit` dictionary in `web-sys`,
+  matching the current Cookie Store API specification.
+  [#5169](https://github.com/wasm-bindgen/wasm-bindgen/pull/5169)
+
 ### Changed
 
 ### Fixed

--- a/crates/web-sys/src/features/gen_CookieInit.rs
+++ b/crates/web-sys/src/features/gen_CookieInit.rs
@@ -30,6 +30,26 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `CookieInit`*"]
     #[wasm_bindgen(method, setter = "expires")]
     pub fn set_expires(this: &CookieInit, val: Option<f64>);
+    #[doc = "Get the `maxAge` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CookieInit`*"]
+    #[wasm_bindgen(method, getter = "maxAge")]
+    pub fn get_max_age(this: &CookieInit) -> Option<f64>;
+    #[doc = "Change the `maxAge` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CookieInit`*"]
+    #[wasm_bindgen(method, setter = "maxAge")]
+    pub fn set_max_age(this: &CookieInit, val: Option<f64>);
+    #[doc = "Change the `maxAge` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CookieInit`*"]
+    #[wasm_bindgen(method, setter = "maxAge")]
+    pub fn set_max_age_opt_i32(this: &CookieInit, val: Option<i32>);
+    #[doc = "Change the `maxAge` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CookieInit`*"]
+    #[wasm_bindgen(method, setter = "maxAge")]
+    pub fn set_max_age_opt_f64(this: &CookieInit, val: Option<f64>);
     #[doc = "Get the `name` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CookieInit`*"]
@@ -102,6 +122,11 @@ impl CookieInit {
     #[deprecated = "Use `set_expires()` instead."]
     pub fn expires(&mut self, val: Option<f64>) -> &mut Self {
         self.set_expires(val);
+        self
+    }
+    #[deprecated = "Use `set_max_age()` instead."]
+    pub fn max_age(&mut self, val: Option<f64>) -> &mut Self {
+        self.set_max_age(val);
         self
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/webidls/enabled/CookieStore.webidl
+++ b/crates/web-sys/webidls/enabled/CookieStore.webidl
@@ -39,6 +39,7 @@ dictionary CookieInit {
   USVString path = "/";
   CookieSameSite sameSite = "strict";
   boolean partitioned = false;
+  long long? maxAge = null;
 };
 
 dictionary CookieStoreDeleteOptions {


### PR DESCRIPTION
This adds the `maxAge` member to the `CookieInit` dictionary in `web-sys`, resolves #5166.

The Cookie Store API spec defines `maxAge` as a nullable `long long` on `CookieInit`, but it was missing from the bundled WebIDL, so users couldn't set a max-age when calling `CookieStore.set` with an options object. Browser support matches `partitioned` (which is already exposed), so there's no good reason to keep gating it.

* Updated `crates/web-sys/webidls/enabled/CookieStore.webidl` to include `long long? maxAge = null;`, matching the upstream w3c/webref IDL.
* Regenerated `gen_CookieInit.rs` via `cargo run --release --package wasm-bindgen-webidl -- webidls src/features ./Cargo.toml`, which adds `get_max_age` / `set_max_age` (plus the standard `_opt_i32` / `_opt_f64` overload setters and a deprecated builder-style `max_age`).

Before:

```rs
let opts = CookieInit::new("name", "value");
opts.set_expires(Some(timestamp_ms));
// no way to express max-age
```

After:

```rs
let opts = CookieInit::new("name", "value");
opts.set_max_age(Some(3600.0));
```

Verified with `cargo build -p web-sys --features CookieInit,CookieStore --target wasm32-unknown-unknown` and `cargo fmt --check -p web-sys`. No new tests are added since this is a straight WebIDL-driven binding addition consistent with the rest of `CookieInit`.