### PR TITLE
JsOption: strict undefined-only emptiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@
 
 ### Changed
 
+* `JsOption<T>` now treats only `undefined` as empty, aligning it with
+  TypeScript's strict `T | undefined` semantics and with `Option<T>`'s wire
+  shape (`None` ↔ `undefined`). Previously `is_empty`, `as_option`,
+  `into_option`, `unwrap`, `expect`, `unwrap_or_default`, and
+  `unwrap_or_else` treated both `null` and `undefined` as absent; JS `null`
+  is now a distinct present value. The `impl<T> UpcastFrom<Null> for
+  JsOption<T>` is removed (`Undefined` still models absence), and the
+  `Debug`/`Display` absent placeholder changed from `"null"` to
+  `"undefined"`. Code relying on `null → None` should return `undefined`
+  from the JS side, or check explicitly with
+  `val.as_option().filter(|v| !v.is_null())`.
+  [#5170](https://github.com/wasm-bindgen/wasm-bindgen/pull/5170)
+
 ### Fixed
 
 ### Removed

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -33,7 +33,7 @@ pub fn js_panic(err: JsValue) {
     #[cfg(all(feature = "std", not(target_feature = "atomics")))]
     ::std::panic::panic_any(err);
     #[cfg(not(all(feature = "std", not(target_feature = "atomics"))))]
-    ::core::panic!("{:?}", err);
+    ::core::panic!("{err:?}");
 }
 
 // Cast between arbitrary types supported by wasm-bindgen by going via JS.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -111,13 +111,16 @@ impl UpcastFrom<Null> for JsValue {}
 // JsOption
 #[wasm_bindgen(wasm_bindgen = crate)]
 extern "C" {
-    /// A nullable JS value of type `T`.
+    /// An optional JS value of type `T`.
     ///
     /// Unlike `Option<T>`, which is a Rust-side construct, `JsOption<T>` represents
-    /// a JS value that may be `T`, `null`, or `undefined`, where the null status is
+    /// a JS value that may be `T` or `undefined`, where the presence status is
     /// not yet known in Rust. The value remains in JS until inspected via methods
     /// like [`is_empty`](Self::is_empty), [`as_option`](Self::as_option), or
     /// [`into_option`](Self::into_option).
+    ///
+    /// Only `undefined` is treated as absent, matching TypeScript's `T | undefined`.
+    /// JavaScript `null` is a distinct present value.
     ///
     /// `T` must implement [`JsGeneric`], meaning it is any type that can be
     /// represented as a `JsValue` (e.g., `JsString`, `Number`, `Object`, etc.).
@@ -152,19 +155,19 @@ impl<T: JsGeneric> JsOption<T> {
         }
     }
 
-    /// Tests whether this `JsOption<T>` is empty (`null` or `undefined`).
+    /// Tests whether this `JsOption<T>` is empty (`undefined`).
     #[inline]
     pub fn is_empty(&self) -> bool {
-        JsValue::is_null_or_undefined(self)
+        JsValue::is_undefined(self)
     }
 
     /// Converts this `JsOption<T>` to an `Option<T>` by cloning the inner value.
     ///
-    /// Returns `None` if the value is `null` or `undefined`, otherwise returns
+    /// Returns `None` if the value is `undefined`, otherwise returns
     /// `Some(T)` with a clone of the contained value.
     #[inline]
     pub fn as_option(&self) -> Option<T> {
-        if JsValue::is_null_or_undefined(self) {
+        if JsValue::is_undefined(self) {
             None
         } else {
             let cloned = self.deref().clone();
@@ -174,11 +177,11 @@ impl<T: JsGeneric> JsOption<T> {
 
     /// Converts this `JsOption<T>` into an `Option<T>`, consuming `self`.
     ///
-    /// Returns `None` if the value is `null` or `undefined`, otherwise returns
+    /// Returns `None` if the value is `undefined`, otherwise returns
     /// `Some(T)` with the contained value.
     #[inline]
     pub fn into_option(self) -> Option<T> {
-        if JsValue::is_null_or_undefined(&self) {
+        if JsValue::is_undefined(&self) {
             None
         } else {
             Some(self.unchecked_into())
@@ -189,7 +192,7 @@ impl<T: JsGeneric> JsOption<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the value is `null` or `undefined`.
+    /// Panics if the value is `undefined`.
     #[inline]
     pub fn unwrap(self) -> T {
         self.expect("called `JsOption::unwrap()` on an empty value")
@@ -199,7 +202,7 @@ impl<T: JsGeneric> JsOption<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the value is `null` or `undefined`, with a panic message
+    /// Panics if the value is `undefined`, with a panic message
     /// including the passed message.
     #[inline]
     pub fn expect(self, msg: &str) -> T {
@@ -211,7 +214,7 @@ impl<T: JsGeneric> JsOption<T> {
 
     /// Returns the contained value or a default.
     ///
-    /// Returns the contained value if not `null` or `undefined`, otherwise
+    /// Returns the contained value if not `undefined`, otherwise
     /// returns the default value of `T`.
     #[inline]
     pub fn unwrap_or_default(self) -> T
@@ -223,7 +226,7 @@ impl<T: JsGeneric> JsOption<T> {
 
     /// Returns the contained value or computes it from a closure.
     ///
-    /// Returns the contained value if not `null` or `undefined`, otherwise
+    /// Returns the contained value if not `undefined`, otherwise
     /// calls `f` and returns the result.
     #[inline]
     pub fn unwrap_or_else<F>(self, f: F) -> T
@@ -245,7 +248,7 @@ impl<T: JsGeneric + fmt::Debug> fmt::Debug for JsOption<T> {
         write!(f, "{}?(", core::any::type_name::<T>())?;
         match self.as_option() {
             Some(v) => write!(f, "{v:?}")?,
-            None => f.write_str("null")?,
+            None => f.write_str("undefined")?,
         }
         f.write_str(")")
     }
@@ -256,7 +259,7 @@ impl<T: JsGeneric + fmt::Display> fmt::Display for JsOption<T> {
         write!(f, "{}?(", core::any::type_name::<T>())?;
         match self.as_option() {
             Some(v) => write!(f, "{v}")?,
-            None => f.write_str("null")?,
+            None => f.write_str("undefined")?,
         }
         f.write_str(")")
     }
@@ -264,7 +267,6 @@ impl<T: JsGeneric + fmt::Display> fmt::Display for JsOption<T> {
 
 impl UpcastFrom<JsValue> for JsOption<JsValue> {}
 impl<T> UpcastFrom<Undefined> for JsOption<T> {}
-impl<T> UpcastFrom<Null> for JsOption<T> {}
 impl<T> UpcastFrom<()> for JsOption<T> {}
 impl<T> UpcastFrom<JsOption<T>> for JsValue {}
 impl<T, U> UpcastFrom<JsOption<U>> for JsOption<T> where T: UpcastFrom<U> {}

--- a/tests/wasm/nullable.js
+++ b/tests/wasm/nullable.js
@@ -10,8 +10,7 @@ exports.return_number = () => 42;
 exports.return_string = () => "hello";
 
 exports.take_nullable_null = (val) => {
-    assert.ok(val === null || val === undefined, 
-        `expected null or undefined, got ${val}`);
+    assert.strictEqual(val, undefined, `expected undefined, got ${val}`);
 };
 
 exports.take_nullable_value = (val) => {
@@ -33,10 +32,10 @@ exports.take_nullable_string = (val) => {
 };
 
 exports.test_nullable_exports = () => {
-    // Test rust functions that return JsOption
+    // Test rust functions that return JsOption — strict: empty == undefined only.
     const nullVal = wasm.rust_return_nullable_null();
-    assert.ok(nullVal === null || nullVal === undefined,
-        `expected null or undefined from rust_return_nullable_null, got ${nullVal}`);
+    assert.strictEqual(nullVal, undefined,
+        `expected undefined from rust_return_nullable_null, got ${nullVal}`);
 
     const numVal = wasm.rust_return_nullable_value();
     assert.ok(numVal !== null && numVal !== undefined,
@@ -44,7 +43,6 @@ exports.test_nullable_exports = () => {
     assert.strictEqual(numVal, 456);
 
     // Test rust functions that take JsOption
-    wasm.rust_take_nullable_null(null);
     wasm.rust_take_nullable_null(undefined);
     wasm.rust_take_nullable_value(789);
 };

--- a/tests/wasm/nullable.rs
+++ b/tests/wasm/nullable.rs
@@ -1,4 +1,4 @@
-use js_sys::{JsOption, Null, Undefined};
+use js_sys::{JsOption, Undefined};
 use js_sys::{JsString, Number, Object};
 use wasm_bindgen::convert::Upcast;
 use wasm_bindgen::prelude::*;
@@ -62,8 +62,9 @@ fn test_from_option_none() {
 
 #[wasm_bindgen_test]
 fn test_is_empty_null() {
+    // Strict semantics: `null` is a present value, not empty.
     let val = return_null();
-    assert!(val.is_empty());
+    assert!(!val.is_empty());
 }
 
 #[wasm_bindgen_test]
@@ -88,7 +89,7 @@ fn test_as_option_some() {
 
 #[wasm_bindgen_test]
 fn test_as_option_none() {
-    let val = return_null();
+    let val = return_undefined();
     let opt = val.as_option();
     assert!(opt.is_none());
 }
@@ -103,7 +104,7 @@ fn test_into_option_some() {
 
 #[wasm_bindgen_test]
 fn test_into_option_none() {
-    let val = return_null();
+    let val = return_undefined();
     let opt = val.into_option();
     assert!(opt.is_none());
 }
@@ -118,7 +119,7 @@ fn test_unwrap_success() {
 #[wasm_bindgen_test]
 #[should_panic(expected = "called `JsOption::unwrap()` on an empty value")]
 fn test_unwrap_panic() {
-    let val = return_null();
+    let val = return_undefined();
     val.unwrap();
 }
 
@@ -132,13 +133,13 @@ fn test_expect_success() {
 #[wasm_bindgen_test]
 #[should_panic(expected = "custom error message")]
 fn test_expect_panic() {
-    let val = return_null();
+    let val = return_undefined();
     val.expect("custom error message");
 }
 
 #[wasm_bindgen_test]
 fn test_unwrap_or_default() {
-    let val = return_null();
+    let val = return_undefined();
     let num = val.unwrap_or_default();
     // Number::default() is Number::from(0)
     assert_eq!(num.value_of(), 0.0);
@@ -150,7 +151,7 @@ fn test_unwrap_or_default() {
 
 #[wasm_bindgen_test]
 fn test_unwrap_or_else() {
-    let val = return_null();
+    let val = return_undefined();
     let num = val.unwrap_or_else(|| Number::from(99));
     assert_eq!(num.value_of(), 99.0);
 
@@ -161,8 +162,9 @@ fn test_unwrap_or_else() {
 
 #[wasm_bindgen_test]
 fn test_import_null() {
+    // Strict semantics: JS `null` is a present value, not empty.
     let val = return_null();
-    assert!(val.is_empty());
+    assert!(!val.is_empty());
 }
 
 #[wasm_bindgen_test]
@@ -235,7 +237,7 @@ fn test_debug_null() {
     let val: JsOption<Number> = JsOption::new();
     let debug_str = format!("{:?}", val);
     assert!(debug_str.contains("Number"));
-    assert!(debug_str.contains("null"));
+    assert!(debug_str.contains("undefined"));
 }
 
 #[wasm_bindgen_test]
@@ -280,14 +282,6 @@ fn test_upcast_string_to_nullable() {
 }
 
 #[wasm_bindgen_test]
-fn test_upcast_null_to_nullable() {
-    // Null can upcast to JsOption<T> for any T
-    let null = Null::NULL;
-    let nullable: JsOption<Number> = null.upcast_into();
-    assert!(nullable.is_empty());
-}
-
-#[wasm_bindgen_test]
 fn test_upcast_undefined_to_nullable() {
     // Undefined can upcast to JsOption<T> for any T
     let undef = Undefined::UNDEFINED;
@@ -296,19 +290,15 @@ fn test_upcast_undefined_to_nullable() {
 }
 
 #[wasm_bindgen_test]
-fn test_upcast_null_to_different_nullable_types() {
-    // Null upcasts to JsOption of any type
-    let null = Null::NULL;
-
-    let nullable_num: JsOption<Number> = null.upcast_into();
+fn test_upcast_undefined_to_different_nullable_types() {
+    // Undefined upcasts to JsOption of any type
+    let nullable_num: JsOption<Number> = Undefined::UNDEFINED.upcast_into();
     assert!(nullable_num.is_empty());
 
-    let null = Null::NULL;
-    let nullable_str: JsOption<JsString> = null.upcast_into();
+    let nullable_str: JsOption<JsString> = Undefined::UNDEFINED.upcast_into();
     assert!(nullable_str.is_empty());
 
-    let null = Null::NULL;
-    let nullable_obj: JsOption<Object> = null.upcast_into();
+    let nullable_obj: JsOption<Object> = Undefined::UNDEFINED.upcast_into();
     assert!(nullable_obj.is_empty());
 }
 
@@ -320,12 +310,6 @@ fn test_upcast_in_function_call() {
 
     let s = JsString::from("test");
     take_nullable_string(s.upcast_into());
-}
-
-#[wasm_bindgen_test]
-fn test_upcast_null_in_function_call() {
-    // Test using upcast to pass Null to a function expecting JsOption
-    take_nullable_null(Null::NULL.upcast_into());
 }
 
 #[wasm_bindgen_test]
@@ -344,10 +328,6 @@ fn test_upcast_with_helper_function() {
     // Pass a Number directly via upcast
     let result = accepts_nullable_number(Number::from(99).upcast_into());
     assert_eq!(result, Some(99.0));
-
-    // Pass Null via upcast
-    let result = accepts_nullable_number(Null::NULL.upcast_into());
-    assert_eq!(result, None);
 
     // Pass Undefined via upcast
     let result = accepts_nullable_number(Undefined::UNDEFINED.upcast_into());


### PR DESCRIPTION
Aligns `JsOption<T>` with TypeScript's strict `T | undefined` semantics and with Rust's `Option<T>` wire shape (where `None` corresponds to `undefined`, not `null`).

Previously `is_empty`, `as_option`, and `into_option` treated both `null` and `undefined` as absent — TypeScript-loose behavior. With `strictNullChecks` widely adopted and `Option<T>` already pinned on `undefined` for its absence wire representation, the dual treatment is the inconsistent path.

Under the old loose semantics, JS `null` round-tripped through `JsOption<T>` was silently coerced into `None` in Rust, even though `null` is a distinct JS value. Any caller that needed to distinguish `null` from `undefined` had to bypass `JsOption` entirely. Under strict semantics, `undefined` ↔ `None` matches `Option<T>`'s ABI on the wire, and `null` is a present value of type `T`, matching TypeScript where `null` is not assignable to `T | undefined`. This makes `JsOption<T>` a faithful Rust mirror of `T | undefined` and keeps `null` available as a first-class value that downstream code can match on explicitly.

TypeScript distinguishes `T | undefined`, `T | null`, and `T | null | undefined` under `strictNullChecks`. The previous `JsOption<T>` mapped to `T | null | undefined` despite documentation suggesting it modeled an optional. The strict variant maps cleanly to `T | undefined`, which is what an unfilled optional argument or absent property actually is in JS/TS. If a binding genuinely needs `T | null`, the right tool is a different type (e.g. `Option<JsValue>` modeling the null sentinel explicitly), not a silently-coercing `JsOption`.

`#[wasm_bindgen]` already encodes `Option::None` as `undefined` on the wire. Before this change, `JsOption<T>::from_option(None)` and a returned `Option<T> = None` produced the same JS value (`undefined`), but a JS function returning `null` decoded asymmetrically: `Option<T>` saw `Some(null)` (or a coerce error depending on `T`) while `JsOption<T>` saw `is_empty() == true`. The two now agree: only `undefined` is absent.

Changes:

- `is_empty`, `as_option`, `into_option`, `unwrap`, `expect`, `unwrap_or_default`, `unwrap_or_else` only treat `undefined` as empty.
- `impl<T> UpcastFrom<Null> for JsOption<T>` removed — `Null` no longer silently models absence (`Undefined` still does).
- `Debug`/`Display` absent placeholder changed from `"null"` to `"undefined"`.
- Doc comments updated.
- Test fixtures updated; JS `null` is now treated as a present value, only `undefined` exercises empty branches.

Migration: code that relied on `null → None` will now see `Some(<null-valued T>)`. The fix is to either have the JS side return `undefined` when absence is intended (recommended — matches TS `?` and `T | undefined`), or check explicitly: `val.as_option().filter(|v| !v.is_null())` if both should be treated as absent at a specific call site.

This is a behavior change but a small one — the prior semantics were undocumented loose coercion. Builds on #5167.