### PR TITLE
Reuse LazyCell in js-sys

### DIFF
--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -36,7 +36,6 @@ futures-core-03-stream = ["dep:futures-util", "dep:futures-core"]
 cfg-if = "1.0.0"
 futures-core = { version = "0.3.8", default-features = false, optional = true }
 futures-util = { version = "0.3.31", default-features = false, features = ["std"], optional = true }
-once_cell = { version = "1.12", default-features = false }
 wasm-bindgen = { path = "../..", version = "=0.2.122", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/js-sys/src/futures/queue.rs
+++ b/crates/js-sys/src/futures/queue.rs
@@ -113,19 +113,11 @@ impl Queue {
     }
 
     pub(crate) fn with<R>(f: impl FnOnce(&Self) -> R) -> R {
-        use once_cell::unsync::Lazy;
-
-        struct Wrapper<T>(Lazy<T>);
-
-        #[cfg(not(target_feature = "atomics"))]
-        unsafe impl<T> Sync for Wrapper<T> {}
-
-        #[cfg(not(target_feature = "atomics"))]
-        unsafe impl<T> Send for Wrapper<T> {}
+        use wasm_bindgen::__rt::LazyCell;
 
         #[cfg_attr(target_feature = "atomics", thread_local)]
-        static QUEUE: Wrapper<Queue> = Wrapper(Lazy::new(Queue::new));
+        static QUEUE: LazyCell<Queue> = LazyCell::new(Queue::new);
 
-        f(&QUEUE.0)
+        f(&QUEUE)
     }
 }

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -13576,20 +13576,12 @@ impl Promise {
 /// This allows access to the global properties and global names by accessing
 /// the `Object` returned.
 pub fn global() -> Object {
-    use once_cell::unsync::Lazy;
-
-    struct Wrapper<T>(Lazy<T>);
-
-    #[cfg(not(target_feature = "atomics"))]
-    unsafe impl<T> Sync for Wrapper<T> {}
-
-    #[cfg(not(target_feature = "atomics"))]
-    unsafe impl<T> Send for Wrapper<T> {}
+    use wasm_bindgen::__rt::LazyCell;
 
     #[cfg_attr(target_feature = "atomics", thread_local)]
-    static GLOBAL: Wrapper<Object> = Wrapper(Lazy::new(get_global_object));
+    static GLOBAL: LazyCell<Object> = LazyCell::new(get_global_object);
 
-    return GLOBAL.0.clone();
+    return GLOBAL.clone();
 
     fn get_global_object() -> Object {
         // Accessing the global object is not an easy thing to do, and what we


### PR DESCRIPTION
### Description

wasm-bindgen exports `LazyCell` as a maybe thread safe lazily initialized type, but currently duplicates that unsafe code in js-sys to lazily initialize the global document and futures queue. This PR uses the exported type instead and removes the once_cell dependancy from js-sys.

This is purely a refactor. Keeping this logic centralized makes it easier to update in the future and makes it easier to patch in support for many js contexts per thread with https://github.com/wasm-bindgen/wasm-bindgen/issues/4908 / [wasm-bindgen-wry](https://github.com/DioxusLabs/wasm-bindgen-wry)

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement


