### PR TITLE
Make UpcastFrom unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### Changed
 
+* Made `wasm_bindgen::convert::UpcastFrom` an unsafe trait, requiring manual
+  implementations to use `unsafe impl`.
+  [#5177](https://github.com/wasm-bindgen/wasm-bindgen/pull/5177)
+
 * `JsOption<T>` now treats only `undefined` as empty, aligning it with
   TypeScript's strict `T | undefined` semantics and with `Option<T>`'s wire
   shape (`None` ↔ `undefined`). Previously `is_empty`, `as_option`,

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1807,18 +1807,18 @@ macro_rules! impl_tuple_covariance {
         // ArrayTuple -> Array
         // Allows (T1, T2, ...) to be used where (Target) is expected
         // when all T1, T2, ... are covariant to Target
-        impl<$($T,)+ Target> UpcastFrom<ArrayTuple<($($T,)+)>> for Array<Target>
+        unsafe impl<$($T,)+ Target> UpcastFrom<ArrayTuple<($($T,)+)>> for Array<Target>
         where
             $(Target: UpcastFrom<$T>,)+
         {
         }
-        impl<$($T,)+ Target> UpcastFrom<ArrayTuple<($($T,)+)>> for JsOption<Array<Target>>
+        unsafe impl<$($T,)+ Target> UpcastFrom<ArrayTuple<($($T,)+)>> for JsOption<Array<Target>>
         where
             $(Target: UpcastFrom<$T>,)+
         {}
         // Array<T> -> ArrayTuple<T, ...>
-        impl<T> UpcastFrom<Array<T>> for ArrayTuple<($($Ts,)+)> {}
-        impl<T: JsGeneric> UpcastFrom<Array<T>> for ArrayTuple<($(JsOption<$Ts>,)+)> {}
+        unsafe impl<T> UpcastFrom<Array<T>> for ArrayTuple<($($Ts,)+)> {}
+        unsafe impl<T: JsGeneric> UpcastFrom<Array<T>> for ArrayTuple<($(JsOption<$Ts>,)+)> {}
     };
 }
 
@@ -1832,9 +1832,12 @@ impl_tuple_covariance!([T1 T2 T3 T4 T5 T6 T7] [Target1 Target2 Target3 Target4 T
 impl_tuple_covariance!([T1 T2 T3 T4 T5 T6 T7 T8] [Target1 Target2 Target3 Target4 Target5 Target6 Target7 Target8] [T T T T T T T T]);
 
 // Tuple casting is implemented in core
-impl<T: JsTuple, U: JsTuple> UpcastFrom<ArrayTuple<T>> for ArrayTuple<U> where U: UpcastFrom<T> {}
-impl<T: JsTuple> UpcastFrom<ArrayTuple<T>> for JsValue {}
-impl<T: JsTuple> UpcastFrom<ArrayTuple<T>> for JsOption<JsValue> {}
+unsafe impl<T: JsTuple, U: JsTuple> UpcastFrom<ArrayTuple<T>> for ArrayTuple<U> where
+    U: UpcastFrom<T>
+{
+}
+unsafe impl<T: JsTuple> UpcastFrom<ArrayTuple<T>> for JsValue {}
+unsafe impl<T: JsTuple> UpcastFrom<ArrayTuple<T>> for JsOption<JsValue> {}
 
 /// Iterator returned by `Array::into_iter`
 #[derive(Debug, Clone)]
@@ -2346,7 +2349,7 @@ extern "C" {
     ) -> Result<ArrayBuffer, JsValue>;
 }
 
-impl UpcastFrom<&[u8]> for ArrayBuffer {}
+unsafe impl UpcastFrom<&[u8]> for ArrayBuffer {}
 
 // SharedArrayBuffer
 #[wasm_bindgen]
@@ -3279,8 +3282,8 @@ extern "C" {
     pub fn value_of(this: &Boolean) -> bool;
 }
 
-impl UpcastFrom<bool> for Boolean {}
-impl UpcastFrom<Boolean> for bool {}
+unsafe impl UpcastFrom<bool> for Boolean {}
+unsafe impl UpcastFrom<Boolean> for bool {}
 
 impl Boolean {
     /// Typed Boolean true constant.
@@ -4579,15 +4582,18 @@ extern "C" {
 }
 
 // Basic UpcastFrom impls for Function<T>
-impl<T: JsFunction> UpcastFrom<Function<T>> for JsValue {}
-impl<T: JsFunction> UpcastFrom<Function<T>> for JsOption<JsValue> {}
-impl<T: JsFunction> UpcastFrom<Function<T>> for Object {}
-impl<T: JsFunction> UpcastFrom<Function<T>> for JsOption<Object> {}
+unsafe impl<T: JsFunction> UpcastFrom<Function<T>> for JsValue {}
+unsafe impl<T: JsFunction> UpcastFrom<Function<T>> for JsOption<JsValue> {}
+unsafe impl<T: JsFunction> UpcastFrom<Function<T>> for Object {}
+unsafe impl<T: JsFunction> UpcastFrom<Function<T>> for JsOption<Object> {}
 
 // Blanket trait for Function upcast
 // Function<T> upcasts to Function<U> when the underlying fn type T upcasts to U.
 // The fn signature UpcastFrom impls already encode correct variance (covariant return, contravariant args).
-impl<T: JsFunction, U: JsFunction> UpcastFrom<Function<T>> for Function<U> where U: UpcastFrom<T> {}
+unsafe impl<T: JsFunction, U: JsFunction> UpcastFrom<Function<T>> for Function<U> where
+    U: UpcastFrom<T>
+{
+}
 
 // len() method for Function<T> using JsFunction::ARITY
 impl<T: JsFunction> Function<T> {
@@ -5368,7 +5374,7 @@ extern "C" {
     pub fn next<T: FromWasmAbi>(this: &Iterator<T>) -> Result<IteratorNext<T>, JsValue>;
 }
 
-impl<T> UpcastFrom<Iterator<T>> for Object {}
+unsafe impl<T> UpcastFrom<Iterator<T>> for Object {}
 
 impl Iterator {
     fn looks_like_iterator(it: &JsValue) -> bool {
@@ -5436,7 +5442,7 @@ extern "C" {
     ) -> Result<Promise<IteratorNext<T>>, JsValue>;
 }
 
-impl<T> UpcastFrom<AsyncIterator<T>> for Object {}
+unsafe impl<T> UpcastFrom<AsyncIterator<T>> for Object {}
 
 // iterators in JS are themselves iterable
 impl<T> AsyncIterable for AsyncIterator<T> {
@@ -6130,13 +6136,13 @@ macro_rules! number_from {
             }
         }
 
-        impl UpcastFrom<$x> for Number {}
+        unsafe impl UpcastFrom<$x> for Number {}
     )*)
 }
 number_from!(i8 u8 i16 u16 i32 u32 f32 f64);
 
 // The only guarantee for a JS number
-impl UpcastFrom<Number> for f64 {}
+unsafe impl UpcastFrom<Number> for f64 {}
 
 /// The error type returned when a checked integral type conversion fails.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -9813,14 +9819,14 @@ extern "C" {
 // These upcasts are non-castable due to the constraints on the function
 // but the UpcastFrom covariance must still extend through closure types.
 // (impl UpcastFrom really just means CovariantGeneric relation)
-impl UpcastFrom<String> for JsString {}
-impl UpcastFrom<JsString> for String {}
+unsafe impl UpcastFrom<String> for JsString {}
+unsafe impl UpcastFrom<JsString> for String {}
 
-impl UpcastFrom<&str> for JsString {}
-impl UpcastFrom<JsString> for &str {}
+unsafe impl UpcastFrom<&str> for JsString {}
+unsafe impl UpcastFrom<JsString> for &str {}
 
-impl UpcastFrom<char> for JsString {}
-impl UpcastFrom<JsString> for char {}
+unsafe impl UpcastFrom<char> for JsString {}
+unsafe impl UpcastFrom<JsString> for char {}
 
 impl JsString {
     /// Returns the `JsString` value of this JS value if it's an instance of a

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -1483,7 +1483,7 @@ impl TryToTokens for ast::ImportType {
             // 1. Always generate UpcastFrom<Self> for JsValue
             (quote! {
                 #[automatically_derived]
-                impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                unsafe impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                     for #wasm_bindgen::JsValue
                 #where_clause
                 {
@@ -1499,13 +1499,13 @@ impl TryToTokens for ast::ImportType {
                 // Always use #ty_generics so that lifetime params are included.
                 (quote! {
                     #[automatically_derived]
-                    impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    unsafe impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #rust_name #ty_generics
                     #where_clause
                     {
                     }
                     #[automatically_derived]
-                    impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    unsafe impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #wasm_bindgen::sys::JsOption<#rust_name #ty_generics>
                     #where_clause
                     {
@@ -1564,13 +1564,13 @@ impl TryToTokens for ast::ImportType {
                 // Structural covariance - Type<Target0, Target1, ...> can be upcast from Type<T1, T2, ...>
                 (quote! {
                     #[automatically_derived]
-                    impl #impl_generics_split #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    unsafe impl #impl_generics_split #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #rust_name #target_ty_generics
                     #where_clause_extended
                     {
                     }
                     #[automatically_derived]
-                    impl #impl_generics_split #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    unsafe impl #impl_generics_split #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #wasm_bindgen::sys::JsOption<#rust_name #target_ty_generics>
                     #where_clause_extended
                     {
@@ -1583,13 +1583,13 @@ impl TryToTokens for ast::ImportType {
             for superclass in self.extends.iter() {
                 (quote! {
                     #[automatically_derived]
-                    impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    unsafe impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #superclass
                     #where_clause
                     {
                     }
                     #[automatically_derived]
-                    impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    unsafe impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #wasm_bindgen::sys::JsOption<#superclass>
                     #where_clause
                     {

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -335,17 +335,17 @@ macro_rules! impl_fn_upcasts {
     };
 
     (@same []) => {
-        impl<R1, R2> UpcastFrom<fn() -> R1> for fn() -> R2
+        unsafe impl<R1, R2> UpcastFrom<fn() -> R1> for fn() -> R2
         where
             R2: UpcastFrom<R1>
         {}
 
-        impl<'a, R1, R2> UpcastFrom<dyn Fn() -> R1 + 'a> for dyn Fn() -> R2 + 'a
+        unsafe impl<'a, R1, R2> UpcastFrom<dyn Fn() -> R1 + 'a> for dyn Fn() -> R2 + 'a
         where
             R2: UpcastFrom<R1>
         {}
 
-        impl<'a, R1, R2> UpcastFrom<dyn FnMut() -> R1 + 'a> for dyn FnMut() -> R2 + 'a
+        unsafe impl<'a, R1, R2> UpcastFrom<dyn FnMut() -> R1 + 'a> for dyn FnMut() -> R2 + 'a
         where
             R2: UpcastFrom<R1>
         {}
@@ -353,19 +353,19 @@ macro_rules! impl_fn_upcasts {
 
     // Arguments implemented with contravariance
     (@same [$($A1:ident $A2:ident)+]) => {
-        impl<R1, R2, $($A1, $A2),+> UpcastFrom<fn($($A1),+) -> R1> for fn($($A2),+) -> R2
+        unsafe impl<R1, R2, $($A1, $A2),+> UpcastFrom<fn($($A1),+) -> R1> for fn($($A2),+) -> R2
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+
         {}
 
-        impl<'a, R1, R2, $($A1, $A2),+> UpcastFrom<dyn Fn($($A1),+) -> R1 + 'a> for dyn Fn($($A2),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($A1, $A2),+> UpcastFrom<dyn Fn($($A1),+) -> R1 + 'a> for dyn Fn($($A2),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+
         {}
 
-        impl<'a, R1, R2, $($A1, $A2),+> UpcastFrom<dyn FnMut($($A1),+) -> R1 + 'a> for dyn FnMut($($A2),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($A1, $A2),+> UpcastFrom<dyn FnMut($($A1),+) -> R1 + 'a> for dyn FnMut($($A2),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+
@@ -384,19 +384,19 @@ macro_rules! impl_fn_upcasts {
 
     // Extend: 0 -> N
     (@extend [] [$($O:ident)+]) => {
-        impl<R1, R2, $($O),+> UpcastFrom<fn() -> R1> for fn($($O),+) -> R2
+        unsafe impl<R1, R2, $($O),+> UpcastFrom<fn() -> R1> for fn($($O),+) -> R2
         where
             R2: UpcastFrom<R1>,
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($O),+> UpcastFrom<dyn Fn() -> R1 + 'a> for dyn Fn($($O),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($O),+> UpcastFrom<dyn Fn() -> R1 + 'a> for dyn Fn($($O),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($O),+> UpcastFrom<dyn FnMut() -> R1 + 'a> for dyn FnMut($($O),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($O),+> UpcastFrom<dyn FnMut() -> R1 + 'a> for dyn FnMut($($O),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($O: UpcastFrom<Undefined>,)+
@@ -405,21 +405,21 @@ macro_rules! impl_fn_upcasts {
 
     // Extend: N -> M
     (@extend [$($A1:ident $A2:ident)+] [$($O:ident)+]) => {
-        impl<R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<fn($($A1),+) -> R1> for fn($($A2,)+ $($O),+) -> R2
+        unsafe impl<R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<fn($($A1),+) -> R1> for fn($($A2,)+ $($O),+) -> R2
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+  // Contravariant
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn Fn($($A1),+) -> R1 + 'a> for dyn Fn($($A2,)+ $($O),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn Fn($($A1),+) -> R1 + 'a> for dyn Fn($($A2,)+ $($O),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+  // Contravariant
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn FnMut($($A1),+) -> R1 + 'a> for dyn FnMut($($A2,)+ $($O),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn FnMut($($A1),+) -> R1 + 'a> for dyn FnMut($($A2,)+ $($O),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+  // Contravariant
@@ -429,19 +429,19 @@ macro_rules! impl_fn_upcasts {
 
     // Shrink: N -> 0
     (@shrink [] [$($O:ident)+]) => {
-        impl<R1, R2, $($O),+> UpcastFrom<fn($($O),+) -> R1> for fn() -> R2
+        unsafe impl<R1, R2, $($O),+> UpcastFrom<fn($($O),+) -> R1> for fn() -> R2
         where
             R2: UpcastFrom<R1>,
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($O),+> UpcastFrom<dyn Fn($($O),+) -> R1 + 'a> for dyn Fn() -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($O),+> UpcastFrom<dyn Fn($($O),+) -> R1 + 'a> for dyn Fn() -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($O),+> UpcastFrom<dyn FnMut($($O),+) -> R1 + 'a> for dyn FnMut() -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($O),+> UpcastFrom<dyn FnMut($($O),+) -> R1 + 'a> for dyn FnMut() -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($O: UpcastFrom<Undefined>,)+
@@ -450,21 +450,21 @@ macro_rules! impl_fn_upcasts {
 
     // Shrink: M -> N
     (@shrink [$($A1:ident $A2:ident)+] [$($O:ident)+]) => {
-        impl<R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<fn($($A1,)+ $($O),+) -> R1> for fn($($A2),+) -> R2
+        unsafe impl<R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<fn($($A1,)+ $($O),+) -> R1> for fn($($A2),+) -> R2
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+  // Contravariant
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn Fn($($A1,)+ $($O),+) -> R1 + 'a> for dyn Fn($($A2),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn Fn($($A1,)+ $($O),+) -> R1 + 'a> for dyn Fn($($A2),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+  // Contravariant
             $($O: UpcastFrom<Undefined>,)+
         {}
 
-        impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn FnMut($($A1,)+ $($O),+) -> R1 + 'a> for dyn FnMut($($A2),+) -> R2 + 'a
+        unsafe impl<'a, R1, R2, $($A1, $A2,)+ $($O),+> UpcastFrom<dyn FnMut($($A1,)+ $($O),+) -> R1 + 'a> for dyn FnMut($($A2),+) -> R2 + 'a
         where
             R2: UpcastFrom<R1>,
             $($A1: UpcastFrom<$A2>,)+  // Contravariant
@@ -498,7 +498,7 @@ const _: () = {
 // The 'a: 'b bound is critical for soundness: it ensures the target lifetime 'b does not
 // exceed the source lifetime 'a. Without it, upcast_into could fabricate a
 // ScopedClosure<'static, _> from a short-lived ScopedClosure, enabling use-after-free.
-impl<'a: 'b, 'b, T1, T2> UpcastFrom<ScopedClosure<'a, T1>> for ScopedClosure<'b, T2>
+unsafe impl<'a: 'b, 'b, T1, T2> UpcastFrom<ScopedClosure<'a, T1>> for ScopedClosure<'b, T2>
 where
     T1: ?Sized + WasmClosure,
     T2: ?Sized + WasmClosure + UpcastFrom<T1>,

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -137,9 +137,9 @@ macro_rules! type_wasm_native {
             }
         }
 
-        impl UpcastFrom<$t> for JsValue {}
-        impl UpcastFrom<$t> for JsOption<JsValue> {}
-        impl UpcastFrom<$t> for $t {}
+        unsafe impl UpcastFrom<$t> for JsValue {}
+        unsafe impl UpcastFrom<$t> for JsOption<JsValue> {}
+        unsafe impl UpcastFrom<$t> for $t {}
     )*)
 }
 
@@ -151,10 +151,10 @@ type_wasm_native!(
     f64 as f64
 );
 
-impl UpcastFrom<u64> for u128 {}
-impl UpcastFrom<u64> for JsOption<u128> {}
-impl UpcastFrom<i64> for i128 {}
-impl UpcastFrom<i64> for JsOption<i128> {}
+unsafe impl UpcastFrom<u64> for u128 {}
+unsafe impl UpcastFrom<u64> for JsOption<u128> {}
+unsafe impl UpcastFrom<i64> for i128 {}
+unsafe impl UpcastFrom<i64> for JsOption<i128> {}
 
 /// Sentinel value used to encode `None` for optional pointer-sized and
 /// 32-bit numeric values transferred over the JS `number` ABI.
@@ -213,9 +213,9 @@ macro_rules! type_wasm_native_f64_option {
             }
         }
 
-        impl UpcastFrom<$t> for JsValue {}
-        impl UpcastFrom<$t> for JsOption<JsValue> {}
-        impl UpcastFrom<$t> for $t {}
+        unsafe impl UpcastFrom<$t> for JsValue {}
+        unsafe impl UpcastFrom<$t> for JsOption<JsValue> {}
+        unsafe impl UpcastFrom<$t> for $t {}
     )*)
 }
 
@@ -228,40 +228,40 @@ type_wasm_native_f64_option!(
 );
 
 #[cfg(target_pointer_width = "32")]
-impl UpcastFrom<isize> for i32 {}
+unsafe impl UpcastFrom<isize> for i32 {}
 #[cfg(target_pointer_width = "32")]
-impl UpcastFrom<isize> for JsOption<i32> {}
+unsafe impl UpcastFrom<isize> for JsOption<i32> {}
 
-impl UpcastFrom<isize> for i64 {}
-impl UpcastFrom<isize> for JsOption<i64> {}
-impl UpcastFrom<isize> for i128 {}
-impl UpcastFrom<isize> for JsOption<i128> {}
+unsafe impl UpcastFrom<isize> for i64 {}
+unsafe impl UpcastFrom<isize> for JsOption<i64> {}
+unsafe impl UpcastFrom<isize> for i128 {}
+unsafe impl UpcastFrom<isize> for JsOption<i128> {}
 
-impl UpcastFrom<i32> for isize {}
-impl UpcastFrom<i32> for JsOption<isize> {}
-impl UpcastFrom<i32> for i64 {}
-impl UpcastFrom<i32> for JsOption<i64> {}
-impl UpcastFrom<i32> for i128 {}
-impl UpcastFrom<i32> for JsOption<i128> {}
+unsafe impl UpcastFrom<i32> for isize {}
+unsafe impl UpcastFrom<i32> for JsOption<isize> {}
+unsafe impl UpcastFrom<i32> for i64 {}
+unsafe impl UpcastFrom<i32> for JsOption<i64> {}
+unsafe impl UpcastFrom<i32> for i128 {}
+unsafe impl UpcastFrom<i32> for JsOption<i128> {}
 
-impl UpcastFrom<u32> for usize {}
-impl UpcastFrom<u32> for JsOption<usize> {}
-impl UpcastFrom<u32> for u64 {}
-impl UpcastFrom<u32> for JsOption<u64> {}
-impl UpcastFrom<u32> for u128 {}
-impl UpcastFrom<u32> for JsOption<u128> {}
+unsafe impl UpcastFrom<u32> for usize {}
+unsafe impl UpcastFrom<u32> for JsOption<usize> {}
+unsafe impl UpcastFrom<u32> for u64 {}
+unsafe impl UpcastFrom<u32> for JsOption<u64> {}
+unsafe impl UpcastFrom<u32> for u128 {}
+unsafe impl UpcastFrom<u32> for JsOption<u128> {}
 
 #[cfg(target_pointer_width = "32")]
-impl UpcastFrom<usize> for u32 {}
+unsafe impl UpcastFrom<usize> for u32 {}
 #[cfg(target_pointer_width = "32")]
-impl UpcastFrom<usize> for JsOption<u32> {}
-impl UpcastFrom<usize> for u64 {}
-impl UpcastFrom<usize> for JsOption<u64> {}
-impl UpcastFrom<usize> for u128 {}
-impl UpcastFrom<usize> for JsOption<u128> {}
+unsafe impl UpcastFrom<usize> for JsOption<u32> {}
+unsafe impl UpcastFrom<usize> for u64 {}
+unsafe impl UpcastFrom<usize> for JsOption<u64> {}
+unsafe impl UpcastFrom<usize> for u128 {}
+unsafe impl UpcastFrom<usize> for JsOption<u128> {}
 
-impl UpcastFrom<f32> for f64 {}
-impl UpcastFrom<f32> for JsOption<f64> {}
+unsafe impl UpcastFrom<f32> for f64 {}
+unsafe impl UpcastFrom<f32> for JsOption<f64> {}
 
 /// The sentinel value is 0xFF_FFFF for primitives with less than 32 bits.
 ///
@@ -304,45 +304,45 @@ macro_rules! type_abi_as_u32 {
             type Resolution = $t;
         }
 
-        impl UpcastFrom<$t> for JsValue {}
-        impl UpcastFrom<$t> for JsOption<JsValue> {}
-        impl UpcastFrom<$t> for $t {}
+        unsafe impl UpcastFrom<$t> for JsValue {}
+        unsafe impl UpcastFrom<$t> for JsOption<JsValue> {}
+        unsafe impl UpcastFrom<$t> for $t {}
     )*)
 }
 
 type_abi_as_u32!(i8 u8 i16 u16);
 
-impl UpcastFrom<i8> for i16 {}
-impl UpcastFrom<i8> for JsOption<i16> {}
-impl UpcastFrom<i8> for i32 {}
-impl UpcastFrom<i8> for JsOption<i32> {}
-impl UpcastFrom<i8> for i64 {}
-impl UpcastFrom<i8> for JsOption<i64> {}
-impl UpcastFrom<i8> for i128 {}
-impl UpcastFrom<i8> for JsOption<i128> {}
+unsafe impl UpcastFrom<i8> for i16 {}
+unsafe impl UpcastFrom<i8> for JsOption<i16> {}
+unsafe impl UpcastFrom<i8> for i32 {}
+unsafe impl UpcastFrom<i8> for JsOption<i32> {}
+unsafe impl UpcastFrom<i8> for i64 {}
+unsafe impl UpcastFrom<i8> for JsOption<i64> {}
+unsafe impl UpcastFrom<i8> for i128 {}
+unsafe impl UpcastFrom<i8> for JsOption<i128> {}
 
-impl UpcastFrom<u8> for u16 {}
-impl UpcastFrom<u8> for JsOption<u16> {}
-impl UpcastFrom<u8> for u32 {}
-impl UpcastFrom<u8> for JsOption<u32> {}
-impl UpcastFrom<u8> for u64 {}
-impl UpcastFrom<u8> for JsOption<u64> {}
-impl UpcastFrom<u8> for u128 {}
-impl UpcastFrom<u8> for JsOption<u128> {}
+unsafe impl UpcastFrom<u8> for u16 {}
+unsafe impl UpcastFrom<u8> for JsOption<u16> {}
+unsafe impl UpcastFrom<u8> for u32 {}
+unsafe impl UpcastFrom<u8> for JsOption<u32> {}
+unsafe impl UpcastFrom<u8> for u64 {}
+unsafe impl UpcastFrom<u8> for JsOption<u64> {}
+unsafe impl UpcastFrom<u8> for u128 {}
+unsafe impl UpcastFrom<u8> for JsOption<u128> {}
 
-impl UpcastFrom<i16> for i32 {}
-impl UpcastFrom<i16> for JsOption<i32> {}
-impl UpcastFrom<i16> for i64 {}
-impl UpcastFrom<i16> for JsOption<i64> {}
-impl UpcastFrom<i16> for i128 {}
-impl UpcastFrom<i16> for JsOption<i128> {}
+unsafe impl UpcastFrom<i16> for i32 {}
+unsafe impl UpcastFrom<i16> for JsOption<i32> {}
+unsafe impl UpcastFrom<i16> for i64 {}
+unsafe impl UpcastFrom<i16> for JsOption<i64> {}
+unsafe impl UpcastFrom<i16> for i128 {}
+unsafe impl UpcastFrom<i16> for JsOption<i128> {}
 
-impl UpcastFrom<u16> for u32 {}
-impl UpcastFrom<u16> for JsOption<u32> {}
-impl UpcastFrom<u16> for u64 {}
-impl UpcastFrom<u16> for JsOption<u64> {}
-impl UpcastFrom<u16> for u128 {}
-impl UpcastFrom<u16> for JsOption<u128> {}
+unsafe impl UpcastFrom<u16> for u32 {}
+unsafe impl UpcastFrom<u16> for JsOption<u32> {}
+unsafe impl UpcastFrom<u16> for u64 {}
+unsafe impl UpcastFrom<u16> for JsOption<u64> {}
+unsafe impl UpcastFrom<u16> for u128 {}
+unsafe impl UpcastFrom<u16> for JsOption<u128> {}
 
 impl IntoWasmAbi for bool {
     type Abi = u32;
@@ -384,9 +384,9 @@ impl Promising for bool {
     type Resolution = bool;
 }
 
-impl UpcastFrom<bool> for JsValue {}
-impl UpcastFrom<bool> for JsOption<JsValue> {}
-impl UpcastFrom<bool> for bool {}
+unsafe impl UpcastFrom<bool> for JsValue {}
+unsafe impl UpcastFrom<bool> for JsOption<JsValue> {}
+unsafe impl UpcastFrom<bool> for bool {}
 
 impl IntoWasmAbi for char {
     type Abi = u32;
@@ -429,9 +429,9 @@ impl Promising for char {
     type Resolution = char;
 }
 
-impl UpcastFrom<char> for JsValue {}
-impl UpcastFrom<char> for JsOption<JsValue> {}
-impl UpcastFrom<char> for char {}
+unsafe impl UpcastFrom<char> for JsValue {}
+unsafe impl UpcastFrom<char> for JsOption<JsValue> {}
+unsafe impl UpcastFrom<char> for char {}
 
 impl<T> IntoWasmAbi for *const T {
     type Abi = WasmWordRepr;
@@ -455,8 +455,8 @@ unsafe impl<T: ErasableGeneric> ErasableGeneric for *const T {
     type Repr = *const T::Repr;
 }
 
-impl<T, Target> UpcastFrom<*const T> for *const Target where Target: UpcastFrom<T> {}
-impl<T, Target> UpcastFrom<*const T> for JsOption<*const Target> where Target: UpcastFrom<T> {}
+unsafe impl<T, Target> UpcastFrom<*const T> for *const Target where Target: UpcastFrom<T> {}
+unsafe impl<T, Target> UpcastFrom<*const T> for JsOption<*const Target> where Target: UpcastFrom<T> {}
 
 impl<T> IntoWasmAbi for Option<*const T> {
     type Abi = f64;
@@ -472,8 +472,9 @@ unsafe impl<T: ErasableGeneric> ErasableGeneric for Option<T> {
     type Repr = Option<<T as ErasableGeneric>::Repr>;
 }
 
-impl<T, Target> UpcastFrom<Option<T>> for Option<Target> where Target: UpcastFrom<T> {}
-impl<T, Target> UpcastFrom<Option<T>> for JsOption<Option<Target>> where Target: UpcastFrom<T> {}
+unsafe impl<T, Target> UpcastFrom<Option<T>> for Option<Target> where Target: UpcastFrom<T> {}
+unsafe impl<T, Target> UpcastFrom<Option<T>> for JsOption<Option<Target>> where Target: UpcastFrom<T>
+{}
 
 impl<T> FromWasmAbi for Option<*const T> {
     type Abi = f64;
@@ -699,8 +700,8 @@ impl Promising for () {
     type Resolution = Undefined;
 }
 
-impl UpcastFrom<()> for JsValue {}
-impl UpcastFrom<()> for () {}
+unsafe impl UpcastFrom<()> for JsValue {}
+unsafe impl UpcastFrom<()> for () {}
 
 unsafe impl ErasableGeneric for () {
     type Repr = ();
@@ -766,13 +767,13 @@ impl<T: ErasableGeneric + Promising, E: ErasableGeneric> Promising for Result<T,
     type Resolution = Result<<T as Promising>::Resolution, E>;
 }
 
-impl<T, E, TargetT, TargetE> UpcastFrom<Result<T, E>> for Result<TargetT, TargetE>
+unsafe impl<T, E, TargetT, TargetE> UpcastFrom<Result<T, E>> for Result<TargetT, TargetE>
 where
     TargetT: UpcastFrom<T>,
     TargetE: UpcastFrom<E>,
 {
 }
-impl<T, E, TargetT, TargetE> UpcastFrom<Result<T, E>> for JsOption<Result<TargetT, TargetE>>
+unsafe impl<T, E, TargetT, TargetE> UpcastFrom<Result<T, E>> for JsOption<Result<TargetT, TargetE>>
 where
     TargetT: UpcastFrom<T>,
     TargetE: UpcastFrom<E>,
@@ -807,9 +808,9 @@ impl Promising for JsError {
     type Resolution = JsError;
 }
 
-impl UpcastFrom<JsError> for JsValue {}
-impl UpcastFrom<JsError> for JsOption<JsValue> {}
-impl UpcastFrom<JsError> for JsError {}
+unsafe impl UpcastFrom<JsError> for JsValue {}
+unsafe impl UpcastFrom<JsError> for JsOption<JsValue> {}
+unsafe impl UpcastFrom<JsError> for JsError {}
 
 /// # ⚠️ Unstable
 ///

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -488,15 +488,15 @@ unsafe impl<T: ErasableGeneric> ErasableGeneric for Box<[T]> {
     type Repr = Box<[T::Repr]>;
 }
 
-impl UpcastFrom<&str> for &str {}
+unsafe impl UpcastFrom<&str> for &str {}
 
-impl<T, Target> UpcastFrom<Box<[T]>> for Box<[Target]> where Target: UpcastFrom<T> {}
+unsafe impl<T, Target> UpcastFrom<Box<[T]>> for Box<[Target]> where Target: UpcastFrom<T> {}
 
 unsafe impl<T: ErasableGeneric> ErasableGeneric for Vec<T> {
     type Repr = Vec<T::Repr>;
 }
 
-impl<T, Target> UpcastFrom<Vec<T>> for Vec<Target> where Target: UpcastFrom<T> {}
+unsafe impl<T, Target> UpcastFrom<Vec<T>> for Vec<Target> where Target: UpcastFrom<T> {}
 
 impl<T: VectorIntoWasmAbi> IntoWasmAbi for Box<[T]> {
     type Abi = <T as VectorIntoWasmAbi>::Abi;
@@ -562,7 +562,7 @@ unsafe impl<T: ErasableGeneric> ErasableGeneric for &[T] {
     type Repr = &'static [T::Repr];
 }
 
-impl<'a, T, Target> UpcastFrom<&'a [T]> for &'a [Target] where Target: UpcastFrom<T> {}
+unsafe impl<'a, T, Target> UpcastFrom<&'a [T]> for &'a [Target] where Target: UpcastFrom<T> {}
 
 impl<T: ErasableGeneric<Repr = JsValue> + WasmDescribe> IntoWasmAbi for &[T] {
     type Abi = WasmSlice;

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -395,7 +395,7 @@ impl<T: FromWasmAbi> FromWasmAbi for AssertUnwindSafe<T> {
 ///
 /// This means implementing `UpcastFrom<Source> for Target` automatically gives you
 /// `Upcast<Target> for Source`, enabling `source.upcast()` to produce `Target`.
-pub trait UpcastFrom<S: ?Sized> {}
+pub unsafe trait UpcastFrom<S: ?Sized> {}
 
 /// A trait for type-safe generic upcasting.
 ///
@@ -471,20 +471,20 @@ where
 }
 
 // Reference impls using UpcastFrom
-impl<'a, T, Target> UpcastFrom<&'a mut T> for &'a mut Target where Target: UpcastFrom<T> {}
-impl<'a, T, Target> UpcastFrom<&'a T> for &'a Target where Target: UpcastFrom<T> {}
+unsafe impl<'a, T, Target> UpcastFrom<&'a mut T> for &'a mut Target where Target: UpcastFrom<T> {}
+unsafe impl<'a, T, Target> UpcastFrom<&'a T> for &'a Target where Target: UpcastFrom<T> {}
 
 // Tuple upcasts with structural covariance
 macro_rules! impl_tuple_upcast {
     ([$($T:ident)+] [$($Target:ident)+]) => {
         // Structural covariance: (T...) -> (Target...)
-        impl<$($T,)+ $($Target,)+> UpcastFrom<($($T,)+)> for ($($Target,)+)
+        unsafe impl<$($T,)+ $($Target,)+> UpcastFrom<($($T,)+)> for ($($Target,)+)
         where
             $($Target: JsGeneric + UpcastFrom<$T>,)+
             $($T: JsGeneric,)+
         {
         }
-        impl<$($T: JsGeneric,)+ $($Target: JsGeneric,)+> UpcastFrom<($($T,)+)> for JsOption<($($Target,)+)>
+        unsafe impl<$($T: JsGeneric,)+ $($Target: JsGeneric,)+> UpcastFrom<($($T,)+)> for JsOption<($($Target,)+)>
         where
             $($Target: JsGeneric + UpcastFrom<$T>,)+
             $($T: JsGeneric,)+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -966,7 +966,7 @@ impl AsRef<JsValue> for JsValue {
     }
 }
 
-impl UpcastFrom<JsValue> for JsValue {}
+unsafe impl UpcastFrom<JsValue> for JsValue {}
 
 // Loosely based on toInt32 in ecma-272 for abi semantics
 // with restriction that it only applies for numbers

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -63,10 +63,10 @@ impl fmt::Display for Undefined {
     }
 }
 
-impl UpcastFrom<Undefined> for Undefined {}
-impl UpcastFrom<()> for Undefined {}
-impl UpcastFrom<Undefined> for () {}
-impl UpcastFrom<Undefined> for JsValue {}
+unsafe impl UpcastFrom<Undefined> for Undefined {}
+unsafe impl UpcastFrom<()> for Undefined {}
+unsafe impl UpcastFrom<Undefined> for () {}
+unsafe impl UpcastFrom<Undefined> for JsValue {}
 
 // Null
 #[wasm_bindgen(wasm_bindgen = crate)]
@@ -105,8 +105,8 @@ impl fmt::Display for Null {
     }
 }
 
-impl UpcastFrom<Null> for Null {}
-impl UpcastFrom<Null> for JsValue {}
+unsafe impl UpcastFrom<Null> for Null {}
+unsafe impl UpcastFrom<Null> for JsValue {}
 
 // JsOption
 #[wasm_bindgen(wasm_bindgen = crate)]
@@ -265,8 +265,8 @@ impl<T: JsGeneric + fmt::Display> fmt::Display for JsOption<T> {
     }
 }
 
-impl UpcastFrom<JsValue> for JsOption<JsValue> {}
-impl<T> UpcastFrom<Undefined> for JsOption<T> {}
-impl<T> UpcastFrom<()> for JsOption<T> {}
-impl<T> UpcastFrom<JsOption<T>> for JsValue {}
-impl<T, U> UpcastFrom<JsOption<U>> for JsOption<T> where T: UpcastFrom<U> {}
+unsafe impl UpcastFrom<JsValue> for JsOption<JsValue> {}
+unsafe impl<T> UpcastFrom<Undefined> for JsOption<T> {}
+unsafe impl<T> UpcastFrom<()> for JsOption<T> {}
+unsafe impl<T> UpcastFrom<JsOption<T>> for JsValue {}
+unsafe impl<T, U> UpcastFrom<JsOption<U>> for JsOption<T> where T: UpcastFrom<U> {}


### PR DESCRIPTION
### Description

Marks UpcastFrom as unsafe since that allows you to transmute in safe code. Without the unsafe keyword it is possible to transmute lifetimes incorrectly with safe code using the unstable convert module

Closes #5176 

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
