### PR TITLE
Fix UpcastFrom soundness via lifetime-faithful ErasableGeneric repr

### DIFF
--- a/crates/macro/ui-tests/generic-import-non-erasable.stderr
+++ b/crates/macro/ui-tests/generic-import-non-erasable.stderr
@@ -33,8 +33,8 @@ error[E0271]: type mismatch resolving `<&u32 as ErasableGeneric>::Repr == &JsVal
 24 |     bar::<u32>(&42);
    |           ^^^ expected `&JsValue`, found `&u32`
    |
-   = note: expected reference `&'static wasm_bindgen::JsValue`
-              found reference `&'static u32`
+   = note: expected reference `&wasm_bindgen::JsValue`
+              found reference `&u32`
    = note: required for `u32` to implement `ErasableGenericBorrow<wasm_bindgen::JsValue>`
 note: required by a bound in `bar`
   --> ui-tests/generic-import-non-erasable.rs:3:1
@@ -52,8 +52,8 @@ error[E0271]: type mismatch resolving `<&mut u32 as ErasableGeneric>::Repr == &m
 29 |     baz::<u32>(&mut x);
    |           ^^^ expected `&mut JsValue`, found `&mut u32`
    |
-   = note: expected mutable reference `&'static mut wasm_bindgen::JsValue`
-              found mutable reference `&'static mut u32`
+   = note: expected mutable reference `&mut wasm_bindgen::JsValue`
+              found mutable reference `&mut u32`
    = note: required for `u32` to implement `ErasableGenericBorrowMut<wasm_bindgen::JsValue>`
 note: required by a bound in `baz`
   --> ui-tests/generic-import-non-erasable.rs:3:1

--- a/crates/macro/ui-tests/upcast-unsound.rs
+++ b/crates/macro/ui-tests/upcast-unsound.rs
@@ -1,0 +1,25 @@
+// Regression test for #5176: `UpcastFrom` must not let safe code launder a
+// short-lived borrow into a `'static` one via `upcast_into`/`upcast`.
+//
+// The malicious impl below is still allowed to exist, but calling the upcast
+// must fail to compile because the `ErasableGeneric` repr now carries the
+// borrow lifetime, so the source borrow would have to be `'static`.
+
+use wasm_bindgen::convert::{Upcast, UpcastFrom};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    type Foo;
+    type Bar;
+}
+
+// Launders any `'a` source borrow into a hardcoded `'static` target.
+impl<'a> UpcastFrom<&'a &'a Foo> for &'static &'static Bar {}
+
+fn launder_into(foo: &Foo) -> &'static &'static Bar {
+    let r: &&Foo = &foo;
+    r.upcast_into()
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/upcast-unsound.stderr
+++ b/crates/macro/ui-tests/upcast-unsound.stderr
@@ -1,0 +1,25 @@
+error[E0597]: `foo` does not live long enough
+  --> ui-tests/upcast-unsound.rs:21:20
+   |
+20 | fn launder_into(foo: &Foo) -> &'static &'static Bar {
+   |                 --- binding `foo` declared here
+21 |     let r: &&Foo = &foo;
+   |                    ^^^^ borrowed value does not live long enough
+22 |     r.upcast_into()
+   |     --------------- argument requires that `foo` is borrowed for `'static`
+23 | }
+   |  - `foo` dropped here while still borrowed
+
+error[E0521]: borrowed data escapes outside of function
+  --> ui-tests/upcast-unsound.rs:22:5
+   |
+20 | fn launder_into(foo: &Foo) -> &'static &'static Bar {
+   |                 ---  - let's call the lifetime of this reference `'1`
+   |                 |
+   |                 `foo` is a reference that is only valid in the function body
+21 |     let r: &&Foo = &foo;
+22 |     r.upcast_into()
+   |     ^^^^^^^^^^^^^^^
+   |     |
+   |     `foo` escapes the function body here
+   |     argument requires that `'1` must outlive `'static`

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -994,7 +994,10 @@ where
     }
 }
 
-// In ScopedClosure, the Rust closure type is the phantom type that erases.
-unsafe impl<T: ?Sized + WasmClosure> ErasableGeneric for ScopedClosure<'_, T> {
-    type Repr = ScopedClosure<'static, dyn FnMut()>;
+// In ScopedClosure, the Rust closure type is the phantom type that erases. The
+// scope lifetime is preserved (not erased to `'static`) so the `Repr`-equality
+// gate on `upcast`/`upcast_into` cannot launder a borrowed closure's lifetime;
+// see #5176.
+unsafe impl<'a, T: ?Sized + WasmClosure> ErasableGeneric for ScopedClosure<'a, T> {
+    type Repr = ScopedClosure<'a, dyn FnMut()>;
 }

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -70,7 +70,7 @@ macro_rules! closures {
             $($var: ErasableGeneric,)*
             R: ErasableGeneric
         {
-            type Repr = &'static (dyn $Fn ($(<$var as ErasableGeneric>::Repr,)*) -> <R as ErasableGeneric>::Repr + 'static);
+            type Repr = &'a (dyn $Fn ($(<$var as ErasableGeneric>::Repr,)*) -> <R as ErasableGeneric>::Repr + 'a);
         }
 
         // Invoke shim for closures. The const generic `UNWIND_SAFE` controls

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -495,9 +495,10 @@ const _: () = {
 // ScopedClosure<T1> upcasts to ScopedClosure<T2> when the underlying closure type T1 upcasts to T2.
 // The dyn Fn/FnMut UpcastFrom impls above encode correct variance (covariant return, contravariant args).
 //
-// The 'a: 'b bound is critical for soundness: it ensures the target lifetime 'b does not
-// exceed the source lifetime 'a. Without it, upcast_into could fabricate a
-// ScopedClosure<'static, _> from a short-lived ScopedClosure, enabling use-after-free.
+// The 'a: 'b bound encodes the covariant lifetime relationship. Lifetime safety
+// no longer rests on this bound alone: `ScopedClosure<'a, _>::Repr` now carries
+// `'a`, so the `Repr`-equality gate on the upcast itself rejects any lifetime
+// laundering independently (#5176).
 impl<'a: 'b, 'b, T1, T2> UpcastFrom<ScopedClosure<'a, T1>> for ScopedClosure<'b, T2>
 where
     T1: ?Sized + WasmClosure,

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -480,8 +480,8 @@ impl LongRefFromWasmAbi for str {
     }
 }
 
-unsafe impl ErasableGeneric for &str {
-    type Repr = &'static str;
+unsafe impl<'a> ErasableGeneric for &'a str {
+    type Repr = &'a str;
 }
 
 unsafe impl<T: ErasableGeneric> ErasableGeneric for Box<[T]> {
@@ -558,8 +558,11 @@ impl<T: ErasableGeneric<Repr = JsValue> + WasmDescribe> VectorIntoWasmAbi for T 
 // JsValue-like slice support (Rust-to-JS only)
 // JsValue-like are repr(transparent) over u32, so &[JsValue] is a contiguous array of heap indices
 
-unsafe impl<T: ErasableGeneric> ErasableGeneric for &[T] {
-    type Repr = &'static [T::Repr];
+unsafe impl<'a, T: ErasableGeneric> ErasableGeneric for &'a [T]
+where
+    <T as ErasableGeneric>::Repr: 'a,
+{
+    type Repr = &'a [T::Repr];
 }
 
 impl<'a, T, Target> UpcastFrom<&'a [T]> for &'a [Target] where Target: UpcastFrom<T> {}

--- a/src/rt/marker.rs
+++ b/src/rt/marker.rs
@@ -64,16 +64,31 @@ impl<T: ?Sized> MaybeUnwindSafe for T {}
 //     )
 // )]
 pub unsafe trait ErasableGeneric {
-    /// The singular concrete type that all generic variants can be transmuted on
-    type Repr: 'static;
+    /// The singular concrete type that all generic variants can be transmuted on.
+    ///
+    /// For reference types this deliberately carries the borrow lifetime (rather
+    /// than erasing it to `'static`). The lifetime-faithful repr is what makes
+    /// [`Upcast::upcast`](crate::convert::Upcast::upcast) and
+    /// [`upcast_into`](crate::convert::Upcast::upcast_into) sound: the
+    /// `Repr`-equality bound then rejects upcasts that would launder a
+    /// short-lived borrow into a longer one. The `'static` erasure that the JS
+    /// ABI boundary relies on (where borrows are only ever call-scoped) is
+    /// instead performed explicitly via an `unsafe` cast in codegen.
+    type Repr;
 }
 
-unsafe impl<T: ErasableGeneric> ErasableGeneric for &mut T {
-    type Repr = &'static mut T::Repr;
+unsafe impl<'b, T: ErasableGeneric> ErasableGeneric for &'b mut T
+where
+    <T as ErasableGeneric>::Repr: 'b,
+{
+    type Repr = &'b mut T::Repr;
 }
 
-unsafe impl<T: ErasableGeneric> ErasableGeneric for &T {
-    type Repr = &'static T::Repr;
+unsafe impl<'b, T: ErasableGeneric> ErasableGeneric for &'b T
+where
+    <T as ErasableGeneric>::Repr: 'b,
+{
+    type Repr = &'b T::Repr;
 }
 
 /// Trait bound marker for types that are passed as an own generic type.
@@ -111,11 +126,10 @@ where
 )]
 pub trait ErasableGenericBorrow<Target: ?Sized> {}
 
-impl<'a, T: ?Sized + 'a, ConcreteTarget: ?Sized + 'static> ErasableGenericBorrow<ConcreteTarget>
-    for T
+impl<'a, T: ?Sized + 'a, ConcreteTarget: ?Sized + 'a> ErasableGenericBorrow<ConcreteTarget> for T
 where
-    &'static ConcreteTarget: ErasableGeneric,
-    &'a T: ErasableGeneric<Repr = <&'static ConcreteTarget as ErasableGeneric>::Repr>,
+    &'a ConcreteTarget: ErasableGeneric,
+    &'a T: ErasableGeneric<Repr = <&'a ConcreteTarget as ErasableGeneric>::Repr>,
 {
 }
 
@@ -133,10 +147,9 @@ where
 )]
 pub trait ErasableGenericBorrowMut<Target: ?Sized> {}
 
-impl<'a, T: ?Sized + 'a, ConcreteTarget: ?Sized + 'static> ErasableGenericBorrowMut<ConcreteTarget>
-    for T
+impl<'a, T: ?Sized + 'a, ConcreteTarget: ?Sized + 'a> ErasableGenericBorrowMut<ConcreteTarget> for T
 where
-    &'static mut ConcreteTarget: ErasableGeneric,
-    &'a mut T: ErasableGeneric<Repr = <&'static mut ConcreteTarget as ErasableGeneric>::Repr>,
+    &'a mut ConcreteTarget: ErasableGeneric,
+    &'a mut T: ErasableGeneric<Repr = <&'a mut ConcreteTarget as ErasableGeneric>::Repr>,
 {
 }


### PR DESCRIPTION
This makes the generic upcasting machinery sound. Resolves #5176.

`Upcast::upcast`/`upcast_into` perform a transmute that is gated on `T: ErasableGeneric<Repr = Self::Repr>`. The intent is that this repr-equality bound proves the transmute is layout- and lifetime-compatible. But the reference impls erased the borrow lifetime to `'static`:

```rs
unsafe impl<T: ErasableGeneric> ErasableGeneric for &T {
    type Repr = &'static T::Repr;
}
```

so for any source borrow `&'a T` the repr was `&'static …`, and the gate could no longer see the lifetime. That let a safe `UpcastFrom` impl launder a short-lived borrow into a `'static` one — segfaulting in entirely safe code:

```rs
impl<'a> UpcastFrom<&'a &'a Foo> for &'static &'static Bar {}
// `& &foo` of any lifetime is now reinterpretable as `&'static &'static Bar`
```

The `'static` repr was deliberate: at the JS ABI boundary borrows are only ever call-scoped (JS-GC-rooted), so erasing them to `'static` is fine there. The problem is purely that the *same* repr was also trusted by `upcast`, where the value escapes back into Rust.

The fix splits those two safety models. `ErasableGeneric::Repr` now carries the real borrow lifetime, so the repr-equality gate rejects any upcast that would extend a lifetime while still accepting same-lifetime ones. The `'static` erasure the ABI boundary needs stays exactly where it was already sound — the explicit `unsafe` transmute codegen emits at the call site.

* `ErasableGeneric::Repr` drops the `'static` bound; `&T`/`&mut T`/`&[T]`/`&str`/closure reprs capture the actual borrow lifetime instead of `&'static`.
* `ErasableGenericBorrow`/`ErasableGenericBorrowMut` markers compare the borrowed repr at a common lifetime rather than against `&'static ConcreteTarget`.
* `UpcastFrom` stays a safe, user-implementable trait — the laundering impl still compiles, it just can no longer be *called*.

Before, this compiled; now it fails to compile with a lifetime error pointing at the repr-equality bound:

```rs
fn launder_into(foo: &Foo) -> &'static &'static Bar {
    let r: &&Foo = &foo;
    r.upcast_into() // error: `foo` is borrowed for `'static`
}
```

Test coverage: adds `upcast-unsound.rs` as a compile-fail UI test (the #5176 exploit), and updates `generic-import-non-erasable.stderr` for the now lifetime-faithful repr in diagnostics. The full `wasm-bindgen` and `js-sys` wasm suites pass, along with the existing upcast/generics/closure/slice tests, confirming legitimate same-lifetime upcasts are unaffected.