### PR TITLE
fix(cli-support): handle i64 (width-8) loads in the descriptor interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ### Fixed
 
+* Fixed a panic ("Unhandled load width 8") in the descriptor interpreter when
+  processing `-Cinstrument-coverage`-instrumented modules, unblocking
+  `cargo llvm-cov --target wasm32-unknown-unknown` for crates whose describe
+  helpers get instrumented.
+  [#5179](https://github.com/wasm-bindgen/wasm-bindgen/pull/5179)
+
 ### Removed
 
 --------------------------------------------------------------------------------

--- a/crates/cli-support/src/interpreter/mod.rs
+++ b/crates/cli-support/src/interpreter/mod.rs
@@ -398,6 +398,15 @@ impl Frame<'_> {
                                 stack.push(result as i32);
                             }
                         };
+                    } else if width == 8 {
+                        // i64 load. Our stack/memory model is i32-based (mirroring
+                        // the width-8 store below, which keeps only the low 4
+                        // bytes). `-Cinstrument-coverage` emits i64 profiler
+                        // counter loads inside the `__wbindgen_describe_*` helper
+                        // functions; the loaded values never influence the
+                        // descriptor protocol, so pushing the low word is
+                        // sufficient for the interpreter to run to completion.
+                        stack.push(val);
                     } else {
                         panic!("Unhandled load width {width}");
                     }

--- a/crates/cli-support/src/interpreter/smoke_tests.rs
+++ b/crates/cli-support/src/interpreter/smoke_tests.rs
@@ -213,6 +213,54 @@ fn loads_and_stores() {
     interpret(wat, "foo", &[1, 50331650, 3]);
 }
 
+// Regression test: `-Cinstrument-coverage` injects i64 profiler-counter
+// load/store/add into the `__wbindgen_describe_*` helper functions. The
+// descriptor interpreter must tolerate width-8 (i64) loads (it already handled
+// width-8 stores) so coverage-instrumented modules can still be processed.
+// Without the i64-load handling this panics with "Unhandled load width 8".
+#[test]
+fn i64_loads_and_stores() {
+    let wat = r#"
+        (module
+            (import "__wbindgen_placeholder__" "__wbindgen_describe"
+              (func $__wbindgen_describe (param i32)))
+
+            (global $__stack_pointer (mut i32) (i32.const 65536))
+            (memory 1)
+
+            (func $foo
+                (local i32)
+
+                global.get $__stack_pointer
+                i32.const 16
+                i32.sub
+                local.set 0
+                local.get 0
+                global.set $__stack_pointer
+
+                ;; i64.store 42 at fp+0 (width 8)
+                local.get 0
+                i64.const 42
+                i64.store offset=0
+
+                ;; i64.load fp+0 (width 8), wrap to i32, and describe it
+                local.get 0
+                i64.load offset=0
+                i32.wrap_i64
+                call $__wbindgen_describe
+
+                local.get 0
+                i32.const 16
+                i32.add
+                global.set $__stack_pointer
+            )
+
+            (export "foo" (func $foo))
+        )
+    "#;
+    interpret(wat, "foo", &[42]);
+}
+
 #[test]
 fn calling_functions() {
     let wat = r#"


### PR DESCRIPTION
## Problem

Building `#[wasm_bindgen_test]` tests with `-Cinstrument-coverage` panics during `wasm-bindgen` processing:

```
thread 'main' panicked at crates/cli-support/src/interpreter/mod.rs:
Unhandled load width 8
```

The descriptor interpreter executes the `__wbindgen_describe_*` helper functions to extract type information. Coverage instrumentation injects i64 profiler-counter load/store/add into every function, including those helpers. The interpreter already handles width-8 stores but panics on width-8 loads, so any coverage-instrumented module that reaches the interpreter fails; this blocks `cargo llvm-cov --target wasm32-unknown-unknown` on crates whose describe helpers get instrumented.

## Fix

Mirror the existing width-8 store handling in the load path: push the low 32-bit word. The interpreter models the stack and memory as `i32`, and counter values never influence the descriptor protocol, so the low word is sufficient for the describe function to run to completion and emit correct type codes.

## Testing

- Adds the `i64_loads_and_stores` interpreter smoke test. It is RED without this change (panics "Unhandled load width 8") and green with it.
- All existing `cli-support` interpreter smoke tests pass.
- Verified end to end: `cargo llvm-cov test --target wasm32-unknown-unknown` now produces coverage for a crate with heavy dependencies (25 browser tests, real coverage emitted for the JS-boundary modules) where it previously panicked before any tests ran.
