### PR TITLE
fix: mutable reference variance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@
 
 ### Fixed
 
+* Fixed incorrect variance in `&mut` reference upcasting. `&mut T` upcasts
+  were covariant in the pointee, so a `&mut T` could be widened to a `&mut`
+  of a supertype and used to write back a value the original type would not
+  accept, leaving a reference whose static type no longer matches the value
+  it points to. Mutable references are now *invariant* in their pointee:
+  `&mut T` only upcasts to `&mut Target` when both `Target: UpcastFrom<T>`
+  and `T: UpcastFrom<Target>` hold. This rejects the invalid widening but is
+  a breaking change for callers that relied on widening `&mut` references.
+  [#5176](https://github.com/wasm-bindgen/wasm-bindgen/issues/5176)
+
 * Fixed WASI targets (`wasm32-wasip1`/`wasm32-wasip2`) emitting unresolved
   `__wbindgen_placeholder__` imports, which broke component linking. The
   codegen and runtime gates now exclude `target_os = "wasi"` (restoring the

--- a/crates/macro/ui-tests/mut-ref-variance.rs
+++ b/crates/macro/ui-tests/mut-ref-variance.rs
@@ -1,0 +1,13 @@
+use js_sys::Number;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+
+fn main() {
+    // Invalid: `&mut` references are invariant in their pointee, so widening
+    // `&mut Vec<Number>` to `&mut Vec<JsValue>` is rejected (issue #5176).
+    // Allowing it (the old covariant behavior) would let a non-`Number`
+    // `JsValue` be written back through the `&mut Vec<Number>`, leaving it
+    // holding a value that is not a `Number`.
+    let mut xs: Vec<Number> = Vec::new();
+    let _widened: &mut Vec<JsValue> = (&mut xs).upcast_into();
+}

--- a/crates/macro/ui-tests/mut-ref-variance.stderr
+++ b/crates/macro/ui-tests/mut-ref-variance.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `Number: UpcastFrom<JsValue>` is not satisfied
+  --> ui-tests/mut-ref-variance.rs:12:49
+   |
+12 |     let _widened: &mut Vec<JsValue> = (&mut xs).upcast_into();
+   |                                                 ^^^^^^^^^^^ the trait `UpcastFrom<JsValue>` is not implemented for `Number`
+   |
+   = help: the following other types implement trait `UpcastFrom<S>`:
+             `Number` implements `UpcastFrom<Number>`
+             `Number` implements `UpcastFrom<f32>`
+             `Number` implements `UpcastFrom<f64>`
+             `Number` implements `UpcastFrom<i16>`
+             `Number` implements `UpcastFrom<i32>`
+             `Number` implements `UpcastFrom<i8>`
+             `Number` implements `UpcastFrom<u16>`
+             `Number` implements `UpcastFrom<u32>`
+             `Number` implements `UpcastFrom<u8>`
+   = note: required for `Vec<Number>` to implement `UpcastFrom<Vec<JsValue>>`
+   = note: 1 redundant requirement hidden
+   = note: required for `&mut Vec<JsValue>` to implement `UpcastFrom<&mut Vec<Number>>`
+   = note: required for `&mut Vec<Number>` to implement `wasm_bindgen::prelude::Upcast<&mut Vec<JsValue>>`

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -470,8 +470,42 @@ where
 {
 }
 
-// Reference impls using UpcastFrom
-impl<'a, T, Target> UpcastFrom<&'a mut T> for &'a mut Target where Target: UpcastFrom<T> {}
+// Reference impls using UpcastFrom.
+//
+// &mut T references are invariant. If you accept &mut T, you cannot upcast it
+// and write back a different type the caller could see.
+// Eg. this is not valid:
+// ```ignore
+// fn with_string() {
+//    let mut string = JsString::from("valid");
+//    let string_ref: &mut JsString = &mut string;
+//    // If &mut T was modeled as just covariant, we could upcast this to
+//    // &mut JsValue.
+//    let js_value_ref: &mut JsValue = string_ref.upcast_into();
+//    *js_value_ref = Object::new().into();
+//    // string is still typed as JsString, but it now wraps a plain object.
+//    // Converting it to a Rust String throws because the value is not a string.
+//    let _ = String::from(&string);
+// }
+// ```
+//
+// Requiring `UpcastFrom` in *both* directions means `T` and `Target` have to be
+// mutually upcastable -- i.e. equivalent, with the same set of valid values.
+// That is exactly what makes a `&mut` cast sound: anything written back through
+// the wider `&mut Target` view is still a valid `T`. So this rejects every
+// widening (the `JsString` -> `JsValue` case above, where `JsValue` does not
+// upcast back to `JsString`), while still allowing casts between genuinely
+// equivalent types in either direction. For example `()` and `Undefined` both
+// model "nothing" and upcast to each other, so a
+// `&mut Closure<dyn Fn(Undefined)>` can be upcast to a `&mut Closure<dyn Fn(())>`
+// and back.
+impl<'a, T: ?Sized, Target: ?Sized> UpcastFrom<&'a mut T> for &'a mut Target
+where
+    Target: UpcastFrom<T>,
+    T: UpcastFrom<Target>,
+{
+}
+// &T references are covariant, so we can allow from a specific type to a more general type
 impl<'a, T, Target> UpcastFrom<&'a T> for &'a Target where Target: UpcastFrom<T> {}
 
 // Tuple upcasts with structural covariance

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -476,17 +476,15 @@ where
 // and write back a different type the caller could see.
 // Eg. this is not valid:
 // ```ignore
-// fn with_string() {
-//    let mut string = JsString::from("valid");
-//    let string_ref: &mut JsString = &mut string;
-//    // If &mut T was modeled as just covariant, we could upcast this to
-//    // &mut JsValue.
-//    let js_value_ref: &mut JsValue = string_ref.upcast_into();
-//    *js_value_ref = Object::new().into();
-//    // string is still typed as JsString, but it now wraps a plain object.
-//    // Converting it to a Rust String throws because the value is not a string.
-//    let _ = String::from(&string);
-// }
+// let mut string = JsString::from("valid");
+// let string_ref: &mut JsString = &mut string;
+// // If &mut T was modeled as just covariant, we could upcast this to
+// // &mut JsValue.
+// let js_value_ref: &mut JsValue = string_ref.upcast_into();
+// *js_value_ref = Object::new().into();
+// // string is still typed as JsString, but it now wraps a plain object.
+// // Converting it to a Rust String throws because the value is not a string.
+// let _ = String::from(&string);
 // ```
 //
 // Requiring `UpcastFrom` in *both* directions means `T` and `Target` have to be

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -1243,4 +1243,23 @@ mod closure_variance {
             Closure::new(|_: JsValue, _: Undefined| 42i32);
         let _upcast: &Closure<dyn Fn(Number) -> JsValue> = closure.upcast();
     }
+
+    // `Undefined` and `()` are a genuine equivalence (mutually upcastable), so a
+    // cast between them is valid in BOTH directions. Because they are mutually
+    // upcastable, the now-invariant `&mut` reference impl allows upcasting a
+    // `&mut Closure<dyn Fn(Undefined)>` to a `&mut Closure<dyn Fn(())>` (and
+    // back) by calling `upcast_into` on the mutable reference itself. A widening
+    // such as `&mut Vec<Number>` to `&mut Vec<JsValue>` would be rejected, since
+    // `Number` and `JsValue` are not mutually upcastable.
+    #[wasm_bindgen_test]
+    fn arg_equivalence_undefined_to_unit() {
+        let mut closure: Closure<dyn Fn(Undefined)> = Closure::new(|_: Undefined| {});
+        let _equiv: &mut Closure<dyn Fn(())> = (&mut closure).upcast_into();
+    }
+
+    #[wasm_bindgen_test]
+    fn arg_equivalence_unit_to_undefined() {
+        let mut closure: Closure<dyn Fn(())> = Closure::new(|_: ()| {});
+        let _equiv: &mut Closure<dyn Fn(Undefined)> = (&mut closure).upcast_into();
+    }
 }


### PR DESCRIPTION
### Description
<!-- Please describe the changes introduced by this PR. -->

The current `UpcastFrom` implementation for `&mut T` models covariance which lets you upcast a type to a more general type. That is correct for `&T`, but leads to incoherent typing with `&mut T`:

```rust
let mut string = JsString::from("valid");
let string_ref: &mut JsString = &mut string;
// Curretly &mut T is modeled as just covariant so you can upcast the type to JsValue
let js_value_ref: &mut JsValue = string_ref.upcast_into();
*js_value_ref = Object::new().into();
// I now hold a `&mut JsString` reference which is actually `&mut Object`
// Converting it to a Rust String throws because the value is not a string.
let _ = String::from(&string);
```

This PR switches the model to make it invariant which only lets you cast between completely equivalent types like casting from `&mut Closure<dyn Fn(Undefined)>` -> `&mut Closure<dyn Fn(())>`.

This is the general version https://github.com/wasm-bindgen/wasm-bindgen/pull/748 which removed upcasting from any specific value -> JsValue for similar reasons.

This fixes the type variance issue in #5176, it does not effect the soundness issue described in the original report

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement

Note this is technically a breaking change. I see some breaking changes for apis where that breaking changed fixed a bug have been released in the past. If that is not the case, feel free to close