### PR TITLE
fix: remove Upcast from Array to ArrayTuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 
 ### Fixed
 
+* Removed invalid `js_sys::Array<T>` to `js_sys::ArrayTuple<(...)>` upcasts.
+  `ArrayTuple` encodes a fixed tuple arity, while a plain JavaScript array does
+  not prove that arity statically.
+
 * Fixed WASI targets (`wasm32-wasip1`/`wasm32-wasip2`) emitting unresolved
   `__wbindgen_placeholder__` imports, which broke component linking. The
   codegen and runtime gates now exclude `target_os = "wasi"` (restoring the

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1803,7 +1803,7 @@ impl_tuple!(8 [JsTuple1 JsTuple2 JsTuple3 JsTuple4 JsTuple5 JsTuple6 JsTuple7 Js
 
 // Macro to generate structural covariance impls for each arity
 macro_rules! impl_tuple_covariance {
-    ([$($T:ident)+] [$($Target:ident)+] [$($Ts:ident)+]) => {
+    ([$($T:ident)+] [$($Target:ident)+]) => {
         // ArrayTuple -> Array
         // Allows (T1, T2, ...) to be used where (Target) is expected
         // when all T1, T2, ... are covariant to Target
@@ -1816,20 +1816,17 @@ macro_rules! impl_tuple_covariance {
         where
             $(Target: UpcastFrom<$T>,)+
         {}
-        // Array<T> -> ArrayTuple<T, ...>
-        impl<T> UpcastFrom<Array<T>> for ArrayTuple<($($Ts,)+)> {}
-        impl<T: JsGeneric> UpcastFrom<Array<T>> for ArrayTuple<($(JsOption<$Ts>,)+)> {}
     };
 }
 
-impl_tuple_covariance!([T1][Target1][T]);
-impl_tuple_covariance!([T1 T2] [Target1 Target2] [T T]);
-impl_tuple_covariance!([T1 T2 T3] [Target1 Target2 Target3] [T T T]);
-impl_tuple_covariance!([T1 T2 T3 T4] [Target1 Target2 Target3 Target4] [T T T T]);
-impl_tuple_covariance!([T1 T2 T3 T4 T5] [Target1 Target2 Target3 Target4 Target5] [T T T T T]);
-impl_tuple_covariance!([T1 T2 T3 T4 T5 T6] [Target1 Target2 Target3 Target4 Target5 Target6] [T T T T T T]);
-impl_tuple_covariance!([T1 T2 T3 T4 T5 T6 T7] [Target1 Target2 Target3 Target4 Target5 Target6 Target7] [T T T T T T T]);
-impl_tuple_covariance!([T1 T2 T3 T4 T5 T6 T7 T8] [Target1 Target2 Target3 Target4 Target5 Target6 Target7 Target8] [T T T T T T T T]);
+impl_tuple_covariance!([T1][Target1]);
+impl_tuple_covariance!([T1 T2] [Target1 Target2]);
+impl_tuple_covariance!([T1 T2 T3] [Target1 Target2 Target3]);
+impl_tuple_covariance!([T1 T2 T3 T4] [Target1 Target2 Target3 Target4]);
+impl_tuple_covariance!([T1 T2 T3 T4 T5] [Target1 Target2 Target3 Target4 Target5]);
+impl_tuple_covariance!([T1 T2 T3 T4 T5 T6] [Target1 Target2 Target3 Target4 Target5 Target6]);
+impl_tuple_covariance!([T1 T2 T3 T4 T5 T6 T7] [Target1 Target2 Target3 Target4 Target5 Target6 Target7]);
+impl_tuple_covariance!([T1 T2 T3 T4 T5 T6 T7 T8] [Target1 Target2 Target3 Target4 Target5 Target6 Target7 Target8]);
 
 // Tuple casting is implemented in core
 impl<T: JsTuple, U: JsTuple> UpcastFrom<ArrayTuple<T>> for ArrayTuple<U> where U: UpcastFrom<T> {}

--- a/crates/js-sys/tests/wasm/Object.rs
+++ b/crates/js-sys/tests/wasm/Object.rs
@@ -484,7 +484,7 @@ fn value_of() {
 fn entries_typed() {
     let arr: Array = Array::new();
     let func: Function = Function::new_no_args("");
-    let obj: Object<JsString> = Reflect::construct(&func, arr.upcast())
+    let obj: Object<JsString> = Reflect::construct(&func, arr.unchecked_ref())
         .unwrap()
         .unchecked_into();
     Reflect::set(&obj, &"a".into(), &JsString::from("1").into()).unwrap();

--- a/crates/js-sys/tests/wasm/Reflect.rs
+++ b/crates/js-sys/tests/wasm/Reflect.rs
@@ -63,7 +63,7 @@ fn construct() {
     #[cfg(not(js_sys_unstable_apis))]
     let instance = Reflect::construct(&RECTANGLE_CLASS, &args).unwrap();
     #[cfg(js_sys_unstable_apis)]
-    let instance = Reflect::construct(&RECTANGLE_CLASS, args.upcast()).unwrap();
+    let instance = Reflect::construct(&RECTANGLE_CLASS, args.unchecked_ref()).unwrap();
     assert_eq!(Rectangle::from(instance).x(), 10);
 }
 


### PR DESCRIPTION
### Description
<!-- Please describe the changes introduced by this PR. -->

Removes upcasts from `Array<T>` -> `ArrayTuple<(T, *)>`. If the array doesn't have the number of elements the tuple has, this results in invalid values which breaks the type safety guarantee of the `Upcast` trait. The inverse (`ArrayTuple<(T, *)>` -> `Array<T>`) is a superset relationship so upcasting is always safe.


This example no longer compiles:
```rust
let array: Array<Number> = Array::new_typed();
// upcast should only be able to cast concrete values into more
// general values where the conversion cannot fail
let _one: ArrayTuple<(Number,)> = array.upcast_into();
let first: Number = _one.get0();
// this throws because the number is not a number
assert!(first.value_of().is_finite());
```

Fixes #5184

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement

Note this is technically a breaking change. I see some breaking changes for apis where that breaking changed fixed a bug have been released in the past. If that is not the case, feel free to close