### PR TITLE
Make abort handler work when panic=abort if specifically requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@
 
 ### Added
 
+* Added the `--force-enable-abort-handler` CLI flag, which emits the hard-abort
+  detection and `set_on_abort` machinery on `panic=abort` builds. With
+  `panic=unwind` this machinery is generated automatically; the flag does
+  nothing there.
+  [#5191](https://github.com/wasm-bindgen/wasm-bindgen/pull/5191)
+
 ### Changed
 
 * Made the internal `__wbindgen_destroy_closure` export private in the Rust API.
+  [#5196](https://github.com/wasm-bindgen/wasm-bindgen/pull/5196)
 
 ### Fixed
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -4773,10 +4773,6 @@ if (require('worker_threads').isMainThread) {{
             }
         });
 
-        let Some(id) = import_id else {
-            return Ok(());
-        };
-
         if matches!(self.config.mode, OutputMode::Emscripten) {
             self.emscripten_library.push_str(
                 r#"
@@ -4803,38 +4799,13 @@ addToLibrary({
             "const __wbindgen_wrapped_jstag = new WebAssembly.Tag({ parameters: ['externref'] });",
         );
 
-        let memory = get_memory(self.module).unwrap();
-        let mem_view = self.expose_int32_memory(memory);
-        let table = self.export_function_table()?;
-
-        self.global(&format!(
-            "
-            let __wbg_terminated_addr;
-            let __wbg_called_abort = false;
-            function __wbg_call_abort_hook() {{
-                __wbg_called_abort = true;
-                try {{
-                    const idx = {mem_view}()[wasm.__abort_handler.value / 4];
-                    if (idx) wasm.{table}.get(idx)();
-                }} catch(_) {{}}
-            }}
-
-            function __wbg_handle_catch(e) {{
-                if (e instanceof WebAssembly.Exception && e.is(__wbindgen_wrapped_jstag)) {{
-                    throw e.getArg(__wbindgen_wrapped_jstag, 0);
-                }}
-                {mem_view}()[__wbg_terminated_addr] = 1;
-                __wbg_call_abort_hook();
-                throw e;
-            }}
-            "
-        ));
-
-        // Use the constant for the import
-        self.wasm_import_definitions.insert(
-            id,
-            ImportDefinition::GlobalRef("__wbindgen_wrapped_jstag".to_string()),
-        );
+        if let Some(id) = import_id {
+            // Use the constant for the import
+            self.wasm_import_definitions.insert(
+                id,
+                ImportDefinition::GlobalRef("__wbindgen_wrapped_jstag".to_string()),
+            );
+        };
 
         Ok(())
     }
@@ -4851,9 +4822,34 @@ addToLibrary({
 
         let mut termination_guard = String::from("function __wbg_call_guard() {");
         // Exception handling tags -> hard aborts
-        if self.aux.wrapped_js_tag.is_some() {
-            let memory = get_memory(self.module)?;
+        if self.aux.wrapped_js_tag.is_some() || self.config.force_enable_abort_handler {
+            let memory = get_memory(self.module).unwrap();
             let mem_view = self.expose_int32_memory(memory);
+            let table = self.export_function_table()?;
+
+            self.global(&format!(
+                "
+                let __wbg_terminated_addr;
+                let __wbg_called_abort = false;
+                function __wbg_call_abort_hook() {{
+                    __wbg_called_abort = true;
+                    try {{
+                        const idx = {mem_view}()[wasm.__abort_handler.value / 4];
+                        if (idx) wasm.{table}.get(idx)();
+                    }} catch(_) {{}}
+                }}
+
+                function __wbg_handle_catch(e) {{
+                    if (e instanceof WebAssembly.Exception && e.is(__wbindgen_wrapped_jstag)) {{
+                        throw e.getArg(__wbindgen_wrapped_jstag, 0);
+                    }}
+                    {mem_view}()[__wbg_terminated_addr] = 1;
+                    __wbg_call_abort_hook();
+                    throw e;
+                }}
+                "
+            ));
+
             termination_guard.push_str(&format!(
                 "
                 __wbg_terminated_addr ??= wasm.__instance_terminated.value / 4;

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -42,6 +42,7 @@ pub struct Bindgen {
     encode_into: EncodeInto,
     split_linked_modules: bool,
     generate_reset_state: bool,
+    force_enable_abort_handler: bool,
 }
 
 pub struct Output {
@@ -116,6 +117,7 @@ impl Bindgen {
             omit_default_module_path: true,
             split_linked_modules: false,
             generate_reset_state: false,
+            force_enable_abort_handler: false,
         }
     }
 
@@ -303,6 +305,11 @@ impl Bindgen {
         self
     }
 
+    pub fn force_enable_abort_handler(&mut self, force_enable_abort_handler: bool) -> &mut Self {
+        self.force_enable_abort_handler = force_enable_abort_handler;
+        self
+    }
+
     pub fn generate<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
         self.generate_output()?.emit(path.as_ref())
     }
@@ -478,7 +485,7 @@ impl Bindgen {
         // `__wbindgen_exn_store`) may be absent. Skip the transform until
         // proper emscripten-mode catch support lands.
         if !matches!(self.mode, OutputMode::Emscripten) {
-            generate_wasm_catch_wrappers(&mut module)?;
+            generate_wasm_catch_wrappers(&mut module, self.force_enable_abort_handler)?;
         }
 
         // We've done a whole bunch of transformations to the Wasm module, many
@@ -835,8 +842,11 @@ impl Output {
 /// When exception handling instructions are available in the module, this generates
 /// Wasm wrapper functions that catch JavaScript exceptions using `WebAssembly.JSTag`
 /// instead of relying on JS `handleError` wrappers.
-fn generate_wasm_catch_wrappers(module: &mut Module) -> Result<(), Error> {
-    let eh_version = transforms::detect_exception_handling_version(module);
+fn generate_wasm_catch_wrappers(
+    module: &mut Module,
+    enable_abort_handler: bool,
+) -> Result<(), Error> {
+    let eh_version = transforms::detect_exception_handling_version(module, enable_abort_handler);
     log::debug!("Exception handling version: {eh_version:?}");
 
     if eh_version == transforms::ExceptionHandlingVersion::None {

--- a/crates/cli-support/src/transforms/catch_handler.rs
+++ b/crates/cli-support/src/transforms/catch_handler.rs
@@ -32,7 +32,10 @@ enum WrapperKind {
     CatchWrapper,
     /// This rethrows recoverable exceptions with a wrapped tag so that our
     /// abort machinery will not treat them as fatal errors.
-    NonAbortingWrapper { wrapped_js_tag: TagId },
+    NonAbortingWrapper {
+        wrapped_js_tag: TagId,
+    },
+    Aborting,
 }
 
 /// Intrinsics and IDs needed to generate catch wrappers.
@@ -106,6 +109,8 @@ pub fn run(
     for (_import_id, func_id, adapter_id) in wit.implements.iter() {
         let wrapper_kind = if aux.imports_with_catch.contains(adapter_id) {
             WrapperKind::CatchWrapper
+        } else if eh_version == ExceptionHandlingVersion::ModernButWithPanicAbort {
+            WrapperKind::Aborting
         } else {
             WrapperKind::NonAbortingWrapper { wrapped_js_tag }
         };
@@ -211,7 +216,7 @@ fn generate_catch_wrapper(
     };
 
     match eh_version {
-        ExceptionHandlingVersion::Modern => {
+        ExceptionHandlingVersion::Modern | ExceptionHandlingVersion::ModernButWithPanicAbort => {
             generate_modern_eh_wrapper(&mut builder, module, &param_locals, &results, ctx);
         }
         ExceptionHandlingVersion::Legacy => {
@@ -458,6 +463,9 @@ fn emit_catch_handler(
             builder.call(exn_store);
             push_default_values(builder, results);
         }
+        WrapperKind::Aborting => {
+            builder.unreachable();
+        }
     }
 }
 
@@ -474,7 +482,7 @@ fn emit_catch_handler(
 /// This checks if `__instance_terminated` is nonzero and traps if so, ensuring
 /// that instance termination is never swallowed by an outer catch handler.
 fn emit_termination_guard(builder: &mut walrus::InstrSeqBuilder, ctx: CatchContext) {
-    let mem_arg = MemArg {
+    let mem_arg: MemArg = MemArg {
         align: 4,
         offset: 0,
     };
@@ -924,7 +932,7 @@ mod tests {
         wit.implements.push((import_id, import_func_id, adapter_id));
 
         // Verify EH is detected
-        let eh_version = super::super::detect_exception_handling_version(&module);
+        let eh_version = super::super::detect_exception_handling_version(&module, false);
         assert_eq!(eh_version, super::super::ExceptionHandlingVersion::Legacy);
 
         // Run the transform

--- a/crates/cli-support/src/transforms/mod.rs
+++ b/crates/cli-support/src/transforms/mod.rs
@@ -22,13 +22,17 @@ pub enum ExceptionHandlingVersion {
     Legacy,
     /// Modern EH (phase 4): try_table instruction
     Modern,
+    ModernButWithPanicAbort,
 }
 
 /// Detect which exception handling version is used in the module.
 ///
 /// Scans all functions for `Try` (legacy) vs `TryTable` (modern) instructions.
 /// If both are present, returns `Modern` as the module likely supports both.
-pub fn detect_exception_handling_version(module: &walrus::Module) -> ExceptionHandlingVersion {
+pub fn detect_exception_handling_version(
+    module: &walrus::Module,
+    enable_abort_handler: bool,
+) -> ExceptionHandlingVersion {
     struct EhDetector {
         has_try: bool,
         has_try_table: bool,
@@ -59,10 +63,15 @@ pub fn detect_exception_handling_version(module: &walrus::Module) -> ExceptionHa
         }
     }
 
-    match (detector.has_try_table, detector.has_try) {
-        (true, _) => ExceptionHandlingVersion::Modern,
-        (false, true) => ExceptionHandlingVersion::Legacy,
-        (false, false) => ExceptionHandlingVersion::None,
+    match (
+        detector.has_try_table,
+        detector.has_try,
+        enable_abort_handler,
+    ) {
+        (true, _, _) => ExceptionHandlingVersion::Modern,
+        (false, true, _) => ExceptionHandlingVersion::Legacy,
+        (false, false, true) => ExceptionHandlingVersion::ModernButWithPanicAbort,
+        (false, false, false) => ExceptionHandlingVersion::None,
     }
 }
 
@@ -104,7 +113,7 @@ mod tests {
         "#;
         let module = parse_wat(wat);
         assert_eq!(
-            detect_exception_handling_version(&module),
+            detect_exception_handling_version(&module, false),
             ExceptionHandlingVersion::None
         );
     }
@@ -126,7 +135,7 @@ mod tests {
         "#;
         let module = parse_wat(wat);
         assert_eq!(
-            detect_exception_handling_version(&module),
+            detect_exception_handling_version(&module, false),
             ExceptionHandlingVersion::Legacy
         );
     }
@@ -149,7 +158,7 @@ mod tests {
         "#;
         let module = parse_wat(wat);
         assert_eq!(
-            detect_exception_handling_version(&module),
+            detect_exception_handling_version(&module, false),
             ExceptionHandlingVersion::Modern
         );
     }
@@ -180,7 +189,7 @@ mod tests {
         "#;
         let module = parse_wat(wat);
         assert_eq!(
-            detect_exception_handling_version(&module),
+            detect_exception_handling_version(&module, false),
             ExceptionHandlingVersion::Modern
         );
     }

--- a/crates/cli/src/wasm_bindgen.rs
+++ b/crates/cli/src/wasm_bindgen.rs
@@ -93,6 +93,11 @@ struct Args {
         help = "Generate __wbg_reset_state function for Wasm reinitialization (experimental)"
     )]
     generate_reset_state: bool,
+    #[arg(
+        long = "force-enable-abort-handler",
+        help = "Enable abort handler even if building with panic=abort. Does nothing when panic=unwind."
+    )]
+    force_enable_abort_handler: bool,
     // The options below are deprecated. They're still parsed for backwards compatibility,
     // but we don't want to show them in `--help` to avoid distracting users.
     #[arg(long, hide = true)]
@@ -163,7 +168,8 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .omit_default_module_path(args.omit_default_module_path)
         .split_linked_modules(args.split_linked_modules)
         .reference_types(args.reference_types)
-        .reset_state_function(args.generate_reset_state);
+        .reset_state_function(args.generate_reset_state)
+        .force_enable_abort_handler(args.force_enable_abort_handler);
 
     if let Some(ref name) = args.no_modules_global {
         b.no_modules_global(name)?;

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -1259,6 +1259,7 @@ const HANDLER_LIB_RS: &str = r#"
     #[wasm_bindgen(inline_js = "
         export function js_throw_error() { throw new Error('JS import threw'); }
         export function set_was_dropped(val) { globalThis.was_dropped = val; }
+        export function get_js_error() { return new Error('A JS error!'); }
         let _callback = null;
         export function register_callback(f) { _callback = f; }
         export function js_call_callback_with_catch() {
@@ -1270,6 +1271,12 @@ const HANDLER_LIB_RS: &str = r#"
         fn set_was_dropped(val: bool);
         fn register_callback(f: &JsValue);
         fn js_call_callback_with_catch();
+        fn get_js_error() -> JsValue;
+    }
+
+    #[wasm_bindgen(js_namespace = console)]
+    extern "C" {
+        fn log(data: &str);
     }
 
     struct DropGuard;
@@ -1301,6 +1308,18 @@ const HANDLER_LIB_RS: &str = r#"
     }
 
     #[wasm_bindgen]
+    pub fn trigger_nested_unreachable() {
+        let closure: Closure<dyn Fn()> = Closure::own_assert_unwind_safe(|| {
+            trigger_unreachable();
+        });
+        register_callback(closure.as_ref());
+        closure.forget();
+        // log("This should  happen");
+        js_call_callback_with_catch();
+        // log("This shouldn't happen");
+    }
+
+    #[wasm_bindgen]
     pub fn trigger_panic() {
         let _guard = DropGuard::new();
         panic!("deliberate panic");
@@ -1312,19 +1331,22 @@ const HANDLER_LIB_RS: &str = r#"
         js_throw_error();
     }
 
+    #[wasm_bindgen]
+    pub fn call_throw_val() {
+        let val = get_js_error();
+        wasm_bindgen::throw_val(val);
+    }
+
     // --- abort handler ---
 
-    #[cfg(panic = "unwind")]
     #[no_mangle]
     pub static mut __abort_called: u32 = 0;
 
     fn on_abort() {
-        #[cfg(panic = "unwind")]
         unsafe { __abort_called = 1; }
     }
 
     fn on_abort_with_reinit() {
-        #[cfg(panic = "unwind")]
         unsafe { __abort_called = 1; }
         wasm_bindgen::handler::schedule_reinit();
     }
@@ -1349,7 +1371,7 @@ const HANDLER_LIB_RS: &str = r#"
 "#;
 
 #[test]
-fn termination_abort_handler() {
+fn termination_abort_handler_unwind_panic() {
     let mut project = Project::new("termination_abort_handler");
     project.file("src/lib.rs", HANDLER_LIB_RS).file(
         "Cargo.toml",
@@ -1436,6 +1458,281 @@ describe('abort handler', () => {
             assert.ok(e instanceof WebAssembly.RuntimeError);
             return true;
         });
+        assert.strictEqual(abortCalled(), true);
+        assert.strictEqual(isTerminated(), true);
+    });
+
+    it('all exports blocked after termination', () => {
+        assert.throws(() => wasm.simple_add(1, 2), /Module terminated/);
+    });
+});
+"#,
+    )
+    .unwrap();
+
+    Command::new("node")
+        .arg("--test")
+        .arg("test_abort_handler.js")
+        .current_dir(&out_dir)
+        .assert()
+        .success();
+}
+
+#[test]
+fn termination_abort_handler_unwind_abort1() {
+    let mut project = Project::new("termination_abort_handler");
+    project.file("src/lib.rs", HANDLER_LIB_RS).file(
+        "Cargo.toml",
+        &format!(
+            "
+                [package]
+                name = \"termination_abort_handler\"
+                authors = []
+                version = \"1.0.0\"
+                edition = '2021'
+
+                [dependencies]
+                wasm-bindgen = {{ path = '{}' }}
+
+                [lib]
+                crate-type = ['cdylib']
+
+                [workspace]
+
+                [profile.dev]
+                codegen-units = 1
+            ",
+            REPO_ROOT.display(),
+        ),
+    );
+
+    let out_dir = project
+        .wasm_bindgen("--target nodejs --force-enable-abort-handler")
+        .unwrap();
+
+    // Read __abort_called flag directly from linear memory after termination —
+    // JS-level exports are blocked but the buffer is still readable.
+    fs::write(
+        out_dir.join("test_abort_handler.js"),
+        r#"
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+let wasmExports = null;
+const OrigInstance = WebAssembly.Instance;
+WebAssembly.Instance = function(module, imports) {
+    const instance = new OrigInstance(module, imports);
+    wasmExports = instance.exports;
+    return instance;
+};
+const wasm = require('./termination_abort_handler.js');
+WebAssembly.Instance = OrigInstance;
+
+function abortCalled() {
+    const addr = wasmExports.__abort_called.value;
+    return new Int32Array(wasmExports.memory.buffer)[addr / 4] !== 0;
+}
+function isTerminated() {
+    const addr = wasmExports.__instance_terminated.value;
+    return new Int32Array(wasmExports.memory.buffer)[addr / 4] !== 0;
+}
+
+describe('abort handler', () => {
+    it('set_on_abort returns true with panic=unwind', () => {
+        assert.strictEqual(wasm.setup_abort_handler(), true);
+    });
+
+    it('handler not called before any fatal error', () => {
+        assert.strictEqual(abortCalled(), false);
+    });
+
+    it('throw_val doesnt fire the handler', () => {
+        assert.throws(() => wasm.call_throw_val(), /A JS error/);
+        assert.strictEqual(abortCalled(), false);
+        assert.strictEqual(isTerminated(), false);
+    });
+
+    it('unreachable fires the handler and terminates the instance', () => {
+        assert.throws(() => wasm.trigger_unreachable(), (e) => {
+            assert.ok(e instanceof WebAssembly.RuntimeError);
+            return true;
+        });
+        assert.strictEqual(abortCalled(), true);
+        assert.strictEqual(isTerminated(), true);
+    });
+
+    it('all exports blocked after termination', () => {
+        assert.throws(() => wasm.simple_add(1, 2), /Module terminated/);
+    });
+});
+"#,
+    )
+    .unwrap();
+
+    Command::new("node")
+        .arg("--test")
+        .arg("test_abort_handler.js")
+        .current_dir(&out_dir)
+        .assert()
+        .success();
+}
+
+#[test]
+fn termination_abort_handler_unwind_abort2() {
+    let mut project = Project::new("termination_abort_handler");
+    project.file("src/lib.rs", HANDLER_LIB_RS).file(
+        "Cargo.toml",
+        &format!(
+            "
+                [package]
+                name = \"termination_abort_handler\"
+                authors = []
+                version = \"1.0.0\"
+                edition = '2021'
+
+                [dependencies]
+                wasm-bindgen = {{ path = '{}' }}
+
+                [lib]
+                crate-type = ['cdylib']
+
+                [workspace]
+
+                [profile.dev]
+                codegen-units = 1
+            ",
+            REPO_ROOT.display(),
+        ),
+    );
+
+    let out_dir = project
+        .wasm_bindgen("--target nodejs --force-enable-abort-handler")
+        .unwrap();
+
+    // Read __abort_called flag directly from linear memory after termination —
+    // JS-level exports are blocked but the buffer is still readable.
+    fs::write(
+        out_dir.join("test_abort_handler.js"),
+        r#"
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+let wasmExports = null;
+const OrigInstance = WebAssembly.Instance;
+WebAssembly.Instance = function(module, imports) {
+    const instance = new OrigInstance(module, imports);
+    wasmExports = instance.exports;
+    return instance;
+};
+const wasm = require('./termination_abort_handler.js');
+WebAssembly.Instance = OrigInstance;
+
+function abortCalled() {
+    const addr = wasmExports.__abort_called.value;
+    return new Int32Array(wasmExports.memory.buffer)[addr / 4] !== 0;
+}
+function isTerminated() {
+    const addr = wasmExports.__instance_terminated.value;
+    return new Int32Array(wasmExports.memory.buffer)[addr / 4] !== 0;
+}
+
+describe('abort handler', () => {
+    it('set_on_abort returns true with panic=unwind', () => {
+        assert.strictEqual(wasm.setup_abort_handler(), true);
+    });
+
+    it('handler not called before any fatal error', () => {
+        assert.strictEqual(abortCalled(), false);
+    });
+
+    it('JS import throw fires the handler and terminates the instance', () => {
+        assert.throws(() => wasm.call_throwing_import(), /JS import threw/);
+        assert.strictEqual(abortCalled(), true);
+        assert.strictEqual(isTerminated(), true);
+    });
+
+    it('all exports blocked after termination', () => {
+        assert.throws(() => wasm.simple_add(1, 2), /Module terminated/);
+    });
+});
+"#,
+    )
+    .unwrap();
+
+    Command::new("node")
+        .arg("--test")
+        .arg("test_abort_handler.js")
+        .current_dir(&out_dir)
+        .assert()
+        .success();
+}
+
+#[test]
+fn termination_abort_handler_unwind_abort3() {
+    let mut project = Project::new("termination_abort_handler");
+    project.file("src/lib.rs", HANDLER_LIB_RS).file(
+        "Cargo.toml",
+        &format!(
+            "
+                [package]
+                name = \"termination_abort_handler\"
+                authors = []
+                version = \"1.0.0\"
+                edition = '2021'
+
+                [dependencies]
+                wasm-bindgen = {{ path = '{}' }}
+
+                [lib]
+                crate-type = ['cdylib']
+
+                [workspace]
+
+                [profile.dev]
+                codegen-units = 1
+            ",
+            REPO_ROOT.display(),
+        ),
+    );
+
+    let out_dir = project
+        .wasm_bindgen("--target nodejs --force-enable-abort-handler")
+        .unwrap();
+
+    // Read __abort_called flag directly from linear memory after termination —
+    // JS-level exports are blocked but the buffer is still readable.
+    fs::write(
+        out_dir.join("test_abort_handler.js"),
+        r#"
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+let wasmExports = null;
+const OrigInstance = WebAssembly.Instance;
+WebAssembly.Instance = function(module, imports) {
+    const instance = new OrigInstance(module, imports);
+    wasmExports = instance.exports;
+    return instance;
+};
+const wasm = require('./termination_abort_handler.js');
+WebAssembly.Instance = OrigInstance;
+
+function abortCalled() {
+    const addr = wasmExports.__abort_called.value;
+    return new Int32Array(wasmExports.memory.buffer)[addr / 4] !== 0;
+}
+function isTerminated() {
+    const addr = wasmExports.__instance_terminated.value;
+    return new Int32Array(wasmExports.memory.buffer)[addr / 4] !== 0;
+}
+
+describe('abort handler', () => {
+    it('set_on_abort returns true with panic=unwind', () => {
+        assert.strictEqual(wasm.setup_abort_handler(), true);
+    });
+
+    it('Trigger nested unreachable', () => {
+        assert.throws(() => wasm.trigger_nested_unreachable(), /unreachable/);
         assert.strictEqual(abortCalled(), true);
         assert.strictEqual(isTerminated(), true);
     });

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -112,37 +112,15 @@ On the no-modules target, `link_to!` won't work if used outside of a document,
 e.g. inside a worker. This is because it's impossible to figure out what the
 URL of the linked module is without a reference point like `import.meta.url`.
 
-### `--experimental-reset-state-function`
+### `--force-enable-abort-handler`
 
-Generates and publicly exports a `__wbg_reset_state()` function that allows
-reinitializing the entire library state for environments that wish to reuse
-and reset the same JavaScript execution context without reloading the entire
-library.
+Emits the hard-abort detection and abort-handler machinery even when building
+with `panic=abort`.
 
-This feature is currently only supported for `--target module`, `--target web`,
-and `--target nodejs`.
+With `panic=unwind` this machinery is generated automatically, since the module
+already contains the exception-handling instructions it relies on. A
+`panic=abort` build has no such instructions, so the abort hook registered via
+`set_on_abort` is never invoked unless this flag is passed. The flag does
+nothing for `panic=unwind` builds.
 
-When this flag is enabled, the generated code will also associate all objects
-with execution instance identity that validates and throws for stale references,
-carefully associating Wasm bindgen pointer and finalization references with
-an instance id that is changed whenever this function is called.
-
-**Example usage:**
-
-```javascript
-import { __wbg_reset_state, inc } from './wbg-lib.js';
-
-console.log(inc()); // logs 1
-console.log(inc()); // logs 2
-
-// fully reset the Wasm VM state
-__wbg_reset_state();
-
-console.log(inc()); // logs 1
-```
-
-**Note:** This feature adds overhead to the generated code and should only be 
-enabled when needed for environment-specific requirements.
-
-See also [Handling Aborts](./handling-aborts.md) for the `schedule_reinit()` API
-which automatically generates the reinit machinery without this flag.
+See [Handling Aborts](./handling-aborts.md) for the `set_on_abort` API.

--- a/guide/src/reference/handling-aborts.md
+++ b/guide/src/reference/handling-aborts.md
@@ -11,9 +11,11 @@ The `wasm_bindgen::handler` module provides hooks for responding to these events
 and optionally recovering by reinitializing the module.
 
 > **Note:** Hard abort detection and the abort handler API (`set_on_abort`)
-> currently require `panic=unwind`. Support for `panic=abort` may be added in
-> a future release. `schedule_reinit()` works with both `panic=unwind` and
-> `panic=abort`.
+> are enabled automatically when building with `panic=unwind`. With
+> `panic=abort` the module contains no exception-handling instructions, so the
+> abort machinery is not emitted unless you pass `--force-enable-abort-handler`
+> to `wasm-bindgen`. `schedule_reinit()` works with both `panic=unwind` and
+> `panic=abort` regardless of the flag.
 
 ## Termination States
 

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -815,9 +815,10 @@ pub static mut __abort_handler: fn() = NO_OP_PTR;
 /// export call from within the handler is immediately blocked.  A throwing
 /// or panicking handler cannot suppress the original error.
 ///
-/// **Experimental — only available when built with `panic=unwind`.**
-/// On `panic=abort` builds the no-op stub always returns `None` and the
-/// callback will never fire.
+/// **Experimental.** The callback fires automatically on `panic=unwind`
+/// builds. On `panic=abort` builds the abort machinery is only emitted when
+/// `wasm-bindgen` is run with `--force-enable-abort-handler`; without that flag
+/// the handler is registered but never fires.
 pub fn set_on_abort(f: fn()) -> Option<fn()> {
     let prev = unsafe { __abort_handler };
     unsafe {

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -793,19 +793,15 @@ pub fn link_mem_intrinsics() {
 #[cfg_attr(target_feature = "atomics", thread_local)]
 static GLOBAL_EXNDATA: ThreadLocalWrapper<Cell<[u32; 2]>> = ThreadLocalWrapper(Cell::new([0; 2]));
 
-#[cfg(panic = "unwind")]
 #[no_mangle]
 pub static mut __instance_terminated: u32 = 0;
 
-#[cfg(panic = "unwind")]
 fn no_op() {}
 
-#[cfg(panic = "unwind")]
 pub static NO_OP_PTR: fn() = no_op;
 
 /// Stores the Wasm indirect-function-table index of the registered hard-abort
 /// callback.  Zero means no callback is registered.
-#[cfg(panic = "unwind")]
 #[no_mangle]
 pub static mut __abort_handler: fn() = NO_OP_PTR;
 
@@ -822,7 +818,6 @@ pub static mut __abort_handler: fn() = NO_OP_PTR;
 /// **Experimental — only available when built with `panic=unwind`.**
 /// On `panic=abort` builds the no-op stub always returns `None` and the
 /// callback will never fire.
-#[cfg(panic = "unwind")]
 pub fn set_on_abort(f: fn()) -> Option<fn()> {
     let prev = unsafe { __abort_handler };
     unsafe {
@@ -835,11 +830,6 @@ pub fn set_on_abort(f: fn()) -> Option<fn()> {
     } else {
         None
     }
-}
-/// No-op stub for `panic=abort` builds — handler will never fire.
-#[cfg(not(panic = "unwind"))]
-pub fn set_on_abort(_f: fn()) -> Option<fn()> {
-    None
 }
 
 /// Schedule the instance for reinitialization before the next export call.


### PR DESCRIPTION
If --force-enable-abort-handler is passed, abort handler will work even with panic=abort.

Resolves https://github.com/wasm-bindgen/wasm-bindgen/issues/5090.