### PR TITLE
fix: make __wbindgen_destroy_closure private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Changed
 
+* Made the internal `__wbindgen_destroy_closure` export private in the Rust API.
+
 ### Fixed
 
 ### Removed

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -752,7 +752,7 @@ struct BorrowedClosure<T: ?Sized, const UNWIND_SAFE: bool> {
 /// `Box<dyn FnOnce/FnMut/Fn>` closure, or `a` must be zero (in which case this
 /// is a no-op).
 #[no_mangle]
-pub unsafe extern "C" fn __wbindgen_destroy_closure(a: WasmWord, b: WasmWord) {
+unsafe extern "C" fn __wbindgen_destroy_closure(a: WasmWord, b: WasmWord) {
     if a.is_zero() {
         return;
     }


### PR DESCRIPTION
### Description
Currently `__wbindgen_destroy_closure` is publicly documented under the closure module: https://wasm-bindgen.github.io/wasm-bindgen/api/wasm_bindgen/closure/fn.__wbindgen_destroy_closure.html

As far as I can tell, this is not meant for external consumers. It starts with `__wbindgen` which is typically reserved for cli consumed symbols and has no external callers outside of the explicit export search in the cli

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
