### PR TITLE
Relaxed alignment requirement for 8-byte types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Fixed
 
+* Relaxed alignment requirement for 8-byte types.
+  [#5204](https://github.com/wasm-bindgen/wasm-bindgen/pull/5204)
+
 ### Removed
 
 ## [0.2.125](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.123...0.2.125)

--- a/crates/cli-support/src/interpreter/mod.rs
+++ b/crates/cli-support/src/interpreter/mod.rs
@@ -381,7 +381,8 @@ impl Frame<'_> {
                         "Read a negative or zero address value from the stack. Did we run out of memory?"
                     );
                     let width = e.kind.width();
-                    ensure!(address % width == 0);
+                    // Also support word-aligned 8-byte types.
+                    ensure!(address % width.min(4) == 0);
                     let val = self.interp.mem[address as usize / 4];
                     if width == 4 {
                         stack.push(val)
@@ -420,7 +421,8 @@ impl Frame<'_> {
                         "Read a negative or zero address value from the stack. Did we run out of memory?"
                     );
                     let width = e.kind.width();
-                    ensure!(address % width == 0);
+                    // Also support word-aligned 8-byte types.
+                    ensure!(address % width.min(4) == 0);
                     let index = address as usize / 4;
                     if width == 8 {
                         // Oops our stack is of i32s so we can't really handle a

--- a/crates/cli-support/src/interpreter/smoke_tests.rs
+++ b/crates/cli-support/src/interpreter/smoke_tests.rs
@@ -261,6 +261,54 @@ fn i64_loads_and_stores() {
     interpret(wat, "foo", &[42]);
 }
 
+// Regression test: a width-8 (i64) access that is only 4-byte aligned (not
+// 8-byte aligned). `-Cinstrument-coverage` injects i64 profiler-counter
+// load/store/add into the `__wbindgen_describe_*` helpers, and those counters
+// can land on a 4-aligned (not 8-aligned) slot. The interpreter models linear
+// memory as i32 words, so 4-byte alignment is sufficient; a natural-alignment
+// check wrongly panicked with "Condition failed: `address % width == 0` (4 vs 0)".
+#[test]
+fn i64_loads_and_stores_unaligned() {
+    let wat = r#"
+        (module
+            (import "__wbindgen_placeholder__" "__wbindgen_describe"
+              (func $__wbindgen_describe (param i32)))
+
+            (global $__stack_pointer (mut i32) (i32.const 65536))
+            (memory 1)
+
+            (func $foo
+                (local i32)
+
+                global.get $__stack_pointer
+                i32.const 16
+                i32.sub
+                local.set 0
+                local.get 0
+                global.set $__stack_pointer
+
+                ;; i64.store at fp+4: the address is only 4-aligned
+                local.get 0
+                i64.const 42
+                i64.store offset=4
+
+                local.get 0
+                i64.load offset=4
+                i32.wrap_i64
+                call $__wbindgen_describe
+
+                local.get 0
+                i32.const 16
+                i32.add
+                global.set $__stack_pointer
+            )
+
+            (export "foo" (func $foo))
+        )
+    "#;
+    interpret(wat, "foo", &[42]);
+}
+
 #[test]
 fn calling_functions() {
     let wat = r#"


### PR DESCRIPTION
### Description
Under `-Cinstrument-coverage` the compiler injects `i64` profiler-counter load/store into the `__wbindgen_describe_*` helpers. These do not follow 8-byte alignment breaking the two `address % width == 0` asserts. This patch relaxed these asserts.

### Checklist
- [x] Verified changelog requirement
