### PR TITLE
Fix externref/multivalue transforms when `strip = true` drops the `target_features` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ### Fixed
 
+* The `externref` and `multivalue` transforms are now enabled unless the module
+  *explicitly* disables the corresponding target feature
+  (`-Ctarget-feature=-reference-types` / `-multivalue`), instead of requiring
+  the `target_features` custom section to advertise them. Previously a stripped
+  section (for example from `strip = true` in a release profile) silently
+  disabled the transforms, which made `#[wasm_bindgen(catch)]` wrappers fail the
+  build with "externref table required for catch wrappers".
+
 ### Removed
 
 ## [0.2.125](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.123...0.2.125)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@
 
 ### Fixed
 
-* The `externref` and `multivalue` transforms are now enabled unless the module
-  *explicitly* disables the corresponding target feature
-  (`-Ctarget-feature=-reference-types` / `-multivalue`), instead of requiring
-  the `target_features` custom section to advertise them. Previously a stripped
-  section (for example from `strip = true` in a release profile) silently
-  disabled the transforms, which made `#[wasm_bindgen(catch)]` wrappers fail the
-  build with "externref table required for catch wrappers".
+* The `externref` and `multivalue` transforms now honor an explicit
+  `-Ctarget-feature=+/-<feature>` advertisement in the `target_features` custom
+  section. When that section is absent (for example because `strip = true`
+  dropped it), they fall back to checking whether the wasm-bindgen runtime was
+  built with `reference-types`, detected from its externref intrinsics.
+  Previously the transforms ran only when the section advertised the feature, so
+  a stripped section silently disabled them and made `#[wasm_bindgen(catch)]`
+  wrappers fail the build with "externref table required for catch wrappers". The
+  fallback leaves the transforms off for `-Ctarget-cpu=mvp` builds, which have
+  neither the section nor the intrinsics.
 
 ### Removed
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -353,15 +353,18 @@ impl Bindgen {
             self.mode = OutputMode::Emscripten;
         }
 
-        // Enable reference type transformations if the module is already using it.
-        if let Ok(true) = wasm_conventions::target_feature(&module, "reference-types") {
-            self.externref = true;
-        }
-
-        // Enable multivalue transformations if the module is already using it.
-        if let Ok(true) = wasm_conventions::target_feature(&module, "multivalue") {
-            self.multi_value = true;
-        }
+        // `reference-types` and `multivalue` are universally supported by
+        // today's engines (and on by default for `wasm32-unknown-unknown` since
+        // Rust 1.82), so enable the matching transforms unless the module
+        // explicitly disables them via `-Ctarget-feature=-<feature>`. We can't
+        // gate on the `target_features` section being present: `strip = true`
+        // drops it entirely, which would silently disable these transforms and
+        // break `#[wasm_bindgen(catch)]` ("externref table required for catch
+        // wrappers").
+        self.externref =
+            wasm_conventions::target_feature_enabled_by_default(&module, "reference-types")?;
+        self.multi_value =
+            wasm_conventions::target_feature_enabled_by_default(&module, "multivalue")?;
 
         // Check that no exported symbol is called "default" if we target web.
         if matches!(self.mode, OutputMode::Web)

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -353,18 +353,25 @@ impl Bindgen {
             self.mode = OutputMode::Emscripten;
         }
 
-        // `reference-types` and `multivalue` are universally supported by
-        // today's engines (and on by default for `wasm32-unknown-unknown` since
-        // Rust 1.82), so enable the matching transforms unless the module
-        // explicitly disables them via `-Ctarget-feature=-<feature>`. We can't
-        // gate on the `target_features` section being present: `strip = true`
-        // drops it entirely, which would silently disable these transforms and
-        // break `#[wasm_bindgen(catch)]` ("externref table required for catch
-        // wrappers").
-        self.externref =
-            wasm_conventions::target_feature_enabled_by_default(&module, "reference-types")?;
-        self.multi_value =
-            wasm_conventions::target_feature_enabled_by_default(&module, "multivalue")?;
+        // `reference-types` and `multivalue` are on by default for
+        // `wasm32-unknown-unknown` since Rust 1.82. Honor an explicit
+        // `-Ctarget-feature=+/-<feature>` advertisement when the `target_features`
+        // section is present; when it is absent (e.g. `strip = true` dropped it),
+        // detect support from the runtime's externref intrinsics instead. That
+        // keeps the transforms running on stripped modern builds, so
+        // `#[wasm_bindgen(catch)]` still works, while leaving them off on
+        // `-Ctarget-cpu=mvp` builds.
+        let default_modern_features = wasm_conventions::module_uses_externref_intrinsics(&module);
+        self.externref = wasm_conventions::target_feature_enabled_or(
+            &module,
+            "reference-types",
+            default_modern_features,
+        )?;
+        self.multi_value = wasm_conventions::target_feature_enabled_or(
+            &module,
+            "multivalue",
+            default_modern_features,
+        )?;
 
         // Check that no exported symbol is called "default" if we target web.
         if matches!(self.mode, OutputMode::Web)

--- a/crates/cli-support/src/transforms/externref/mod.rs
+++ b/crates/cli-support/src/transforms/externref/mod.rs
@@ -167,9 +167,9 @@ impl Context {
                 _ => continue,
             };
             match export.name.as_str() {
-                "__externref_table_alloc" => heap_alloc = Some(f),
-                "__externref_table_dealloc" => heap_dealloc = Some(f),
-                "__externref_drop_slice" => drop_slice = Some(f),
+                wasm_conventions::EXTERNREF_TABLE_ALLOC => heap_alloc = Some(f),
+                wasm_conventions::EXTERNREF_TABLE_DEALLOC => heap_dealloc = Some(f),
+                wasm_conventions::EXTERNREF_DROP_SLICE => drop_slice = Some(f),
                 _ => continue,
             }
             to_delete.push(export.id());

--- a/crates/cli-support/src/wasm_conventions.rs
+++ b/crates/cli-support/src/wasm_conventions.rs
@@ -292,48 +292,79 @@ pub fn get_or_insert_start_builder(module: &mut Module) -> &mut FunctionBuilder 
         .builder_mut()
 }
 
-pub fn target_feature(module: &Module, feature: &str) -> Result<bool> {
+/// Whether a target feature is enabled (`+`), disabled (`-`), or unspecified in
+/// the module's `target_features` custom section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureState {
+    /// The feature is advertised as enabled (`+feature`).
+    Enabled,
+    /// The feature is advertised as explicitly disabled (`-feature`).
+    Disabled,
+    /// The feature is not listed, or there is no `target_features` section at
+    /// all — for example because it was stripped from the binary.
+    Unspecified,
+}
+
+/// Inspect the module's `target_features` custom section to determine whether
+/// `feature` is enabled, disabled, or unspecified.
+pub fn target_feature_state(module: &Module, feature: &str) -> Result<FeatureState> {
     // Taken from <https://github.com/bytecodealliance/wasm-tools/blob/f1898f46bb9d96f0f09682415cb6ccfd6a4dca79/crates/wasmparser/src/limits.rs#L27>.
     anyhow::ensure!(feature.len() <= 100_000, "feature name too long");
 
-    // Try to find an existing section.
-    let section = module
+    // A missing section means the feature is unspecified (e.g. the section was
+    // stripped from the binary).
+    let Some((_, section)) = module
         .customs
         .iter()
-        .find(|(_, custom)| custom.name() == "target_features");
+        .find(|(_, custom)| custom.name() == "target_features")
+    else {
+        return Ok(FeatureState::Unspecified);
+    };
 
-    if let Some((_, section)) = section {
-        let section: &RawCustomSection = section
-            .as_any()
-            .downcast_ref()
-            .context("failed to read section")?;
-        let mut reader = BinaryReader::new(&section.data, 0);
-        // The first integer contains the target feature count.
-        let count = reader.read_var_u32()?;
+    let section: &RawCustomSection = section
+        .as_any()
+        .downcast_ref()
+        .context("failed to read section")?;
+    let mut reader = BinaryReader::new(&section.data, 0);
+    // The first integer contains the target feature count.
+    let count = reader.read_var_u32()?;
 
-        // Try to find if the target feature is already present.
-        for _ in 0..count {
-            // First byte is the prefix.
-            let prefix = reader.read_u8()?;
-            // Read the feature.
-            let length = reader.read_var_u32()?;
-            let this_feature = reader.read_bytes(length as usize)?;
+    // Look for the requested feature.
+    for _ in 0..count {
+        // First byte is the prefix (`+` enabled / `-` disabled).
+        let prefix = reader.read_u8()?;
+        // Read the feature name.
+        let length = reader.read_var_u32()?;
+        let this_feature = reader.read_bytes(length as usize)?;
 
-            // If we found the target feature, we are done here.
-            if this_feature == feature.as_bytes() {
-                // Make sure we set any existing prefix to "enabled".
-                if prefix == b'-' {
-                    return Ok(false);
-                }
-
-                return Ok(true);
-            }
+        if this_feature == feature.as_bytes() {
+            return Ok(if prefix == b'-' {
+                FeatureState::Disabled
+            } else {
+                FeatureState::Enabled
+            });
         }
-
-        Ok(false)
-    } else {
-        Ok(false)
     }
+
+    Ok(FeatureState::Unspecified)
+}
+
+/// Whether the module advertises `+feature`. Both an explicit `-feature` and an
+/// absent/stripped section report `false`; use [`target_feature_state`] when
+/// the distinction matters.
+pub fn target_feature(module: &Module, feature: &str) -> Result<bool> {
+    Ok(target_feature_state(module, feature)? == FeatureState::Enabled)
+}
+
+/// Whether `feature` should be treated as available, defaulting to enabled
+/// unless the module *explicitly* disables it (`-Ctarget-feature=-<feature>`).
+///
+/// Unlike [`target_feature`], a missing or stripped `target_features` section
+/// (e.g. from `strip = true`) counts as enabled. This suits features such as
+/// `reference-types` and `multivalue` that modern engines support universally
+/// and that recent toolchains enable by default.
+pub fn target_feature_enabled_by_default(module: &Module, feature: &str) -> Result<bool> {
+    Ok(target_feature_state(module, feature)? != FeatureState::Disabled)
 }
 
 pub fn insert_target_feature(module: &mut Module, new_feature: &str) -> Result<()> {
@@ -646,5 +677,79 @@ mod tests {
 
         assert_eq!(get_function_table_entry(&module, 0).unwrap(), func_a);
         assert_eq!(get_function_table_entry(&module, 128).unwrap(), func_b);
+    }
+
+    /// Build a module with a `target_features` section listing the given
+    /// `(prefix, name)` entries.
+    fn module_with_features(features: &[(u8, &str)]) -> Module {
+        let mut data = Vec::new();
+        leb128::write::unsigned(&mut data, features.len() as u64).unwrap();
+        for (prefix, name) in features {
+            data.push(*prefix);
+            leb128::write::unsigned(&mut data, name.len() as u64).unwrap();
+            data.extend_from_slice(name.as_bytes());
+        }
+        let mut module = Module::default();
+        module.customs.add(RawCustomSection {
+            name: String::from("target_features"),
+            data,
+        });
+        module
+    }
+
+    #[test]
+    fn target_feature_missing_section_is_unspecified() {
+        // A stripped binary has no `target_features` section at all.
+        let module = Module::default();
+        assert_eq!(
+            target_feature_state(&module, "reference-types").unwrap(),
+            FeatureState::Unspecified
+        );
+        assert!(!target_feature(&module, "reference-types").unwrap());
+    }
+
+    #[test]
+    fn target_feature_enabled_is_detected() {
+        let module = module_with_features(&[(b'+', "bulk-memory"), (b'+', "reference-types")]);
+        assert_eq!(
+            target_feature_state(&module, "reference-types").unwrap(),
+            FeatureState::Enabled
+        );
+        assert!(target_feature(&module, "reference-types").unwrap());
+    }
+
+    #[test]
+    fn target_feature_disabled_is_distinguished_from_missing() {
+        let module = module_with_features(&[(b'-', "reference-types")]);
+        assert_eq!(
+            target_feature_state(&module, "reference-types").unwrap(),
+            FeatureState::Disabled
+        );
+        // The bool wrapper still reports an explicit `-feature` as not enabled.
+        assert!(!target_feature(&module, "reference-types").unwrap());
+    }
+
+    #[test]
+    fn target_feature_section_without_entry_is_unspecified() {
+        let module = module_with_features(&[(b'+', "bulk-memory")]);
+        assert_eq!(
+            target_feature_state(&module, "reference-types").unwrap(),
+            FeatureState::Unspecified
+        );
+    }
+
+    #[test]
+    fn target_feature_enabled_by_default_only_excludes_explicit_disable() {
+        // A missing section and a section that simply omits the feature both
+        // default to enabled (the `strip = true` case this policy exists for).
+        assert!(target_feature_enabled_by_default(&Module::default(), "reference-types").unwrap());
+        let omitted = module_with_features(&[(b'+', "bulk-memory")]);
+        assert!(target_feature_enabled_by_default(&omitted, "reference-types").unwrap());
+        // An advertised feature is enabled...
+        let enabled = module_with_features(&[(b'+', "reference-types")]);
+        assert!(target_feature_enabled_by_default(&enabled, "reference-types").unwrap());
+        // ...and only an explicit `-feature` disables it.
+        let disabled = module_with_features(&[(b'-', "reference-types")]);
+        assert!(!target_feature_enabled_by_default(&disabled, "reference-types").unwrap());
     }
 }

--- a/crates/cli-support/src/wasm_conventions.rs
+++ b/crates/cli-support/src/wasm_conventions.rs
@@ -356,15 +356,42 @@ pub fn target_feature(module: &Module, feature: &str) -> Result<bool> {
     Ok(target_feature_state(module, feature)? == FeatureState::Enabled)
 }
 
-/// Whether `feature` should be treated as available, defaulting to enabled
-/// unless the module *explicitly* disables it (`-Ctarget-feature=-<feature>`).
+/// Whether `feature` should be treated as enabled. An explicit `+`/`-`
+/// advertisement decides it; when the feature is [`FeatureState::Unspecified`]
+/// (not listed, or the section was stripped) the result is
+/// `default_when_unspecified`.
+pub fn target_feature_enabled_or(
+    module: &Module,
+    feature: &str,
+    default_when_unspecified: bool,
+) -> Result<bool> {
+    Ok(match target_feature_state(module, feature)? {
+        FeatureState::Enabled => true,
+        FeatureState::Disabled => false,
+        FeatureState::Unspecified => default_when_unspecified,
+    })
+}
+
+/// Export names of the wasm-bindgen runtime's externref intrinsics. The runtime
+/// only emits them when built with the `reference-types` target feature.
+pub const EXTERNREF_TABLE_ALLOC: &str = "__externref_table_alloc";
+pub const EXTERNREF_TABLE_DEALLOC: &str = "__externref_table_dealloc";
+pub const EXTERNREF_DROP_SLICE: &str = "__externref_drop_slice";
+
+/// Whether the module's wasm-bindgen runtime was compiled with `reference-types`,
+/// detected by the presence of its externref table-allocation intrinsic.
 ///
-/// Unlike [`target_feature`], a missing or stripped `target_features` section
-/// (e.g. from `strip = true`) counts as enabled. This suits features such as
-/// `reference-types` and `multivalue` that modern engines support universally
-/// and that recent toolchains enable by default.
-pub fn target_feature_enabled_by_default(module: &Module, feature: &str) -> Result<bool> {
-    Ok(target_feature_state(module, feature)? != FeatureState::Disabled)
+/// When the `target_features` section is missing, this is how we tell a modern
+/// `wasm32-unknown-unknown` build from a `-Ctarget-cpu=mvp` one: `strip = true`
+/// drops the custom section but leaves these function exports in place, whereas an
+/// mvp build (reference-types off) never emits them at all. The runtime gates the
+/// same intrinsic on the `reference-types` target feature, so its presence means
+/// the externref and multivalue transforms are both safe and necessary.
+pub fn module_uses_externref_intrinsics(module: &Module) -> bool {
+    module
+        .exports
+        .iter()
+        .any(|export| export.name == EXTERNREF_TABLE_ALLOC)
 }
 
 pub fn insert_target_feature(module: &mut Module, new_feature: &str) -> Result<()> {
@@ -739,17 +766,32 @@ mod tests {
     }
 
     #[test]
-    fn target_feature_enabled_by_default_only_excludes_explicit_disable() {
-        // A missing section and a section that simply omits the feature both
-        // default to enabled (the `strip = true` case this policy exists for).
-        assert!(target_feature_enabled_by_default(&Module::default(), "reference-types").unwrap());
-        let omitted = module_with_features(&[(b'+', "bulk-memory")]);
-        assert!(target_feature_enabled_by_default(&omitted, "reference-types").unwrap());
-        // An advertised feature is enabled...
+    fn target_feature_enabled_or_honors_advertisement_then_falls_back() {
+        // An explicit advertisement wins regardless of the fallback.
         let enabled = module_with_features(&[(b'+', "reference-types")]);
-        assert!(target_feature_enabled_by_default(&enabled, "reference-types").unwrap());
-        // ...and only an explicit `-feature` disables it.
+        assert!(target_feature_enabled_or(&enabled, "reference-types", false).unwrap());
         let disabled = module_with_features(&[(b'-', "reference-types")]);
-        assert!(!target_feature_enabled_by_default(&disabled, "reference-types").unwrap());
+        assert!(!target_feature_enabled_or(&disabled, "reference-types", true).unwrap());
+
+        // Unspecified (missing section or omitted entry) uses the fallback.
+        assert!(target_feature_enabled_or(&Module::default(), "reference-types", true).unwrap());
+        assert!(!target_feature_enabled_or(&Module::default(), "reference-types", false).unwrap());
+        let omitted = module_with_features(&[(b'+', "bulk-memory")]);
+        assert!(target_feature_enabled_or(&omitted, "reference-types", true).unwrap());
+        assert!(!target_feature_enabled_or(&omitted, "reference-types", false).unwrap());
+    }
+
+    #[test]
+    fn externref_intrinsics_detected_via_export() {
+        // No exports (e.g. an `-Ctarget-cpu=mvp` build) means no intrinsics.
+        assert!(!module_uses_externref_intrinsics(&Module::default()));
+
+        // A module that exports the table-allocation intrinsic counts as a
+        // reference-types build, even with no `target_features` section.
+        let mut module = Module::default();
+        let func =
+            FunctionBuilder::new(&mut module.types, &[], &[]).finish(vec![], &mut module.funcs);
+        module.exports.add(EXTERNREF_TABLE_ALLOC, func);
+        assert!(module_uses_externref_intrinsics(&module));
     }
 }


### PR DESCRIPTION
### Description

wasm-bindgen only ran the externref/multivalue transforms when the input module advertised the corresponding feature in its `target_features` custom section. A release profile with `strip = true` drops that section entirely, which silently
disabled the externref transform and failed `#[wasm_bindgen(catch)]` builds with "externref table required for catch wrappers".

The transforms now key off the explicit advertisement instead. A new target_feature_state distinguishes an explicit -feature from an absent or stripped section, which the old bool-returning target_feature conflated. An explicit +/-
always wins.

When the section is absent we can't read the advertisement, so we fall back to detecting whether the wasm-bindgen runtime was built with reference-types, via the presence of its externref intrinsics (e.g. `__externref_table_alloc`). `strip
= true` drops only the custom section and keeps those exports, so stripped modern builds still get the transforms and `#[wasm_bindgen(catch)]` keeps working. A `-Ctarget-cpu=mvp` build emits neither the section nor the intrinsics, so it
correctly stays off.

We can't just treat a missing section as "enabled": that turns the transforms on for mvp builds too, which then fail with "failed to find the __wbindgen_externref_table_alloc function". Keying the fallback on the intrinsics avoids that.

<!-- Please describe the changes introduced by this PR. -->

### Checklist
<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
