### PR TITLE
Emit ESM named exports for emscripten -sMODULARIZE=instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ### Added
 
+* Added the `--emscripten-post-js` CLI flag, passed by emcc for
+  `-sMODULARIZE=instance` builds. It emits a `library_bindgen.post.js` sidecar
+  with deferred ESM named exports of the clean wasm-bindgen API (`add`,
+  `Counter`, ...), which are otherwise unreachable in instance mode where the
+  consumer receives named exports instead of `Module`.
+  [#5207](https://github.com/wasm-bindgen/wasm-bindgen/pull/5207)
+
 ### Changed
 
 ### Fixed

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -79,6 +79,11 @@ pub struct FinalizedOutput {
     /// Content to write alongside the main JS as a sidecar that emcc loads
     /// with `--extern-pre-js`. Empty for non-emscripten output modes.
     pub emscripten_extern_pre_js: String,
+    /// Deferred ESM named-export glue, written alongside the main JS as a
+    /// sidecar that emcc loads with `--post-js`. Re-exports the clean
+    /// wasm-bindgen API (`add`, `Counter`, ...) under `-sMODULARIZE=instance`.
+    /// Empty for non-emscripten output modes.
+    pub emscripten_exports_post_js: String,
 }
 
 pub struct Context<'a> {
@@ -98,6 +103,13 @@ pub struct Context<'a> {
     emscripten_extern_pre_js: String,
     imports_post: String,
     export_name_list: Vec<String>,
+    /// Deferred ESM re-export glue for emscripten output, written to a sidecar
+    /// `library_bindgen_exports.post.js`. Accumulated at the same point the
+    /// `Module.<name> = <name>;` lines are emitted (the source of truth for
+    /// what's publicly exported), one self-contained line per export. Empty
+    /// for non-emscripten modes. See `generate_emscripten_wasm_loading` for
+    /// the rationale on why this can't live in the JS library or `--pre-js`.
+    emscripten_exports_post_js: String,
     typescript: String,
     typescript_emscripten_classes: String,
     config: &'a Bindgen,
@@ -331,6 +343,7 @@ impl<'a> Context<'a> {
             intrinsics: Some(Default::default()),
             imports_post: String::new(),
             export_name_list: Vec::new(),
+            emscripten_exports_post_js: String::new(),
             typescript: "/* tslint:disable */\n/* eslint-disable */\n".to_string(),
             typescript_emscripten_classes: String::new(),
             imported_names: Default::default(),
@@ -586,6 +599,13 @@ impl<'a> Context<'a> {
 
                     if export_name == id {
                         self.global(&format!("Module.{export_name} = {id};\n"));
+                        // Mirror this export as a deferred ESM named export in
+                        // the post-js sidecar. The value is only live after
+                        // `initBindgen` runs (it closes over the wasm
+                        // instance), so declare now and bind in `addOnPostCtor`.
+                        self.emscripten_exports_post_js.push_str(&format!(
+                            "export var {export_name}; addOnPostCtor(() => {{ {export_name} = Module['{export_name}']; }});\n"
+                        ));
                     } else {
                         self.global(&format!("export {{ {id} as {export_name} }};\n"));
                     }
@@ -864,11 +884,28 @@ impl<'a> Context<'a> {
             ts.push_str(&node_atomics_ts);
         }
 
+        // Emitted only when emcc requested it via `--emscripten-post-js`,
+        // which it passes solely for `-sMODULARIZE=instance`. The first line
+        // must be exactly `#preprocess` so emcc runs its preprocessor over the
+        // file; the `#if MODULARIZE == 'instance'` guard then keeps the export
+        // block (defensive — emcc only feeds us this flag in instance mode).
+        let emscripten_exports_post_js = if matches!(self.config.mode, OutputMode::Emscripten)
+            && self.config.emscripten_post_js
+        {
+            format!(
+                "#preprocess\n#if MODULARIZE == 'instance'\n{}#endif\n",
+                self.emscripten_exports_post_js
+            )
+        } else {
+            String::new()
+        };
+
         Ok(FinalizedOutput {
             js: self.globals.to_owned(),
             ts,
             start,
             emscripten_extern_pre_js: std::mem::take(&mut self.emscripten_extern_pre_js),
+            emscripten_exports_post_js,
         })
     }
 
@@ -1692,6 +1729,17 @@ if (require('worker_threads').isMainThread) {{
             ""
         };
 
+        // The `--post-js` export glue calls `addOnPostCtor`, a library
+        // function only linked in if something depends on it. Force it in
+        // alongside the other bindgen runtime deps when we actually emit
+        // export glue, so the post-js resolves under `MODULARIZE=instance`.
+        let post_ctor_dep =
+            if self.config.emscripten_post_js && !self.emscripten_exports_post_js.is_empty() {
+                ", '$addOnPostCtor'"
+            } else {
+                ""
+            };
+
         format!(
             r#"
             addToLibrary({{
@@ -1709,7 +1757,7 @@ if (require('worker_threads').isMainThread) {{
                 }}
             }});
 
-            extraLibraryFuncs.push('$initBindgen', '$addOnInit', '$wasm', {global_deps});
+            extraLibraryFuncs.push('$initBindgen', '$addOnInit', '$wasm'{post_ctor_dep}, {global_deps});
             "#,
             init_deps = init_dep_refs.join(", "),
             global_deps = global_dep_refs.join(", "),

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -43,6 +43,11 @@ pub struct Bindgen {
     split_linked_modules: bool,
     generate_reset_state: bool,
     force_enable_abort_handler: bool,
+    /// Set when emcc passes `--emscripten-post-js` (only in
+    /// `-sMODULARIZE=instance` builds). Emits the deferred ESM named-export
+    /// glue to a `library_bindgen.post.js` sidecar that emcc feeds through its
+    /// post-js pipeline.
+    emscripten_post_js: bool,
 }
 
 pub struct Output {
@@ -64,6 +69,10 @@ struct Generated {
     /// emcc loads via `--extern-pre-js`, containing ESM `import` statements
     /// that must live at module top-level. Empty for other modes.
     emscripten_extern_pre_js: String,
+    /// For `OutputMode::Emscripten` with `--emscripten-post-js` only: the
+    /// deferred ESM named-export glue emcc loads via `--post-js`. Empty
+    /// otherwise.
+    emscripten_exports_post_js: String,
 }
 
 #[derive(Clone)]
@@ -118,6 +127,7 @@ impl Bindgen {
             split_linked_modules: false,
             generate_reset_state: false,
             force_enable_abort_handler: false,
+            emscripten_post_js: false,
         }
     }
 
@@ -307,6 +317,11 @@ impl Bindgen {
 
     pub fn force_enable_abort_handler(&mut self, force_enable_abort_handler: bool) -> &mut Self {
         self.force_enable_abort_handler = force_enable_abort_handler;
+        self
+    }
+
+    pub fn emscripten_post_js(&mut self, emscripten_post_js: bool) -> &mut Self {
+        self.emscripten_post_js = emscripten_post_js;
         self
     }
 
@@ -511,6 +526,7 @@ impl Bindgen {
             ts,
             start,
             emscripten_extern_pre_js,
+            emscripten_exports_post_js,
         } = cx.finalize(stem)?;
         let generated = Generated {
             snippets: aux.snippets.clone(),
@@ -522,6 +538,7 @@ impl Bindgen {
             ts,
             start,
             emscripten_extern_pre_js,
+            emscripten_exports_post_js,
         };
 
         Ok(Output {
@@ -810,6 +827,20 @@ impl Output {
                     &extern_pre_js_path,
                     reset_indentation(&gen.emscripten_extern_pre_js),
                 )?;
+            }
+            // Deferred ESM named-export glue, emitted only when emcc requested
+            // it via `--emscripten-post-js` (instance mode). emcc reads it from
+            // this fixed path and feeds it through `--post-js`, which appends it
+            // after `postamble.js` — i.e. at module top level, where `export`
+            // is legal and the runtime helpers (`addOnPostCtor`) are defined.
+            // The `#preprocess` header opts the file into emcc's preprocessor,
+            // so write it verbatim (reset-indentation would mangle the leading
+            // directive).
+            let exports_post_js_path = out_dir.join("library_bindgen.post.js");
+            if gen.emscripten_exports_post_js.is_empty() {
+                let _ = fs::remove_file(&exports_post_js_path);
+            } else {
+                write(&exports_post_js_path, &gen.emscripten_exports_post_js)?;
             }
         } else {
             write(&js_path, reset_indentation(&gen.js))?;

--- a/crates/cli/src/wasm_bindgen.rs
+++ b/crates/cli/src/wasm_bindgen.rs
@@ -98,6 +98,12 @@ struct Args {
         help = "Enable abort handler even if building with panic=abort. Does nothing when panic=unwind."
     )]
     force_enable_abort_handler: bool,
+    #[arg(
+        long = "emscripten-post-js",
+        hide = true,
+        help = "Emit library_bindgen.post.js with deferred ESM named exports. Passed by emcc for -sMODULARIZE=instance."
+    )]
+    emscripten_post_js: bool,
     // The options below are deprecated. They're still parsed for backwards compatibility,
     // but we don't want to show them in `--help` to avoid distracting users.
     #[arg(long, hide = true)]
@@ -169,7 +175,8 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .split_linked_modules(args.split_linked_modules)
         .reference_types(args.reference_types)
         .reset_state_function(args.generate_reset_state)
-        .force_enable_abort_handler(args.force_enable_abort_handler);
+        .force_enable_abort_handler(args.force_enable_abort_handler)
+        .emscripten_post_js(args.emscripten_post_js);
 
     if let Some(ref name) = args.no_modules_global {
         b.no_modules_global(name)?;

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2345,6 +2345,128 @@ fn emscripten_namespaced_exports_valid_ts() {
     }
 }
 
+#[test]
+fn emscripten_post_js_named_exports() {
+    // Under `-sMODULARIZE=instance` the consumer receives ESM named exports +
+    // a default `init`, never `Module`, so the `Module.<name> = <name>;` lines
+    // in `library_bindgen.js` are dead writes. emcc passes `--emscripten-post-js`
+    // (instance mode only); wasm-bindgen then emits `library_bindgen.post.js`
+    // with deferred ESM re-exports of the clean API (`add`, `Counter`).
+    let mut project = Project::new("emscripten_post_js_named_exports");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub fn add(a: i32, b: i32) -> i32 {
+                a + b
+            }
+
+            #[wasm_bindgen]
+            pub struct Counter {
+                value: i32,
+            }
+
+            #[wasm_bindgen]
+            impl Counter {
+                #[wasm_bindgen(constructor)]
+                pub fn new(start: i32) -> Counter {
+                    Counter { value: start }
+                }
+                pub fn inc(&mut self) -> i32 {
+                    self.value += 1;
+                    self.value
+                }
+            }
+        "#,
+    );
+
+    let built = project.build();
+    let mut module = ModuleConfig::new().parse_file(&built).unwrap();
+    module.customs.add(RawCustomSection {
+        name: "__wasm_bindgen_emscripten_marker".into(),
+        data: vec![1],
+    });
+    let emscripten_wasm = project.root.join("emscripten_input.wasm");
+    module.emit_wasm_file(&emscripten_wasm).unwrap();
+
+    // --- With the flag: post-js sidecar is emitted with the deferred glue. ---
+    let out_dir = project.root.join("pkg-with-flag");
+    fs::create_dir_all(&out_dir).unwrap();
+    wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--emscripten-post-js".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir.as_os_str(),
+        emscripten_wasm.as_os_str(),
+    ])
+    .unwrap();
+
+    let post_js_path = out_dir.join("library_bindgen.post.js");
+    let post_js = fs::read_to_string(&post_js_path)
+        .expect("library_bindgen.post.js should be emitted with --emscripten-post-js");
+
+    // Rule 1: first line must be exactly `#preprocess`.
+    assert_eq!(
+        post_js.lines().next(),
+        Some("#preprocess"),
+        "post-js must open with the `#preprocess` directive:\n{post_js}"
+    );
+    // Rule 2: guarded by the MODULARIZE == 'instance' preprocessor block.
+    assert!(
+        post_js.contains("#if MODULARIZE == 'instance'") && post_js.contains("#endif"),
+        "post-js must guard the export block on instance mode:\n{post_js}"
+    );
+    // Rule 3: declare, then assign in addOnPostCtor (deferred, value-agnostic).
+    for name in ["add", "Counter"] {
+        assert!(
+            post_js.contains(&format!("export var {name};")),
+            "post-js must declare `export var {name};`:\n{post_js}"
+        );
+        assert!(
+            post_js.contains(&format!("{name} = Module['{name}'];")),
+            "post-js must bind `{name}` from Module in addOnPostCtor:\n{post_js}"
+        );
+    }
+    assert!(
+        post_js.contains("addOnPostCtor("),
+        "post-js must bind values inside addOnPostCtor:\n{post_js}"
+    );
+    // It must NOT eagerly read Module (init hasn't run when the file evaluates).
+    assert!(
+        !post_js.contains("export var add = Module"),
+        "post-js must not eagerly read Module at module-eval time:\n{post_js}"
+    );
+
+    // Rule 6: $addOnPostCtor must be force-linked so the call resolves.
+    let library = fs::read_to_string(out_dir.join("library_bindgen.js")).unwrap();
+    assert!(
+        library.contains("'$addOnPostCtor'"),
+        "library_bindgen.js must force-include $addOnPostCtor:\n{library}"
+    );
+
+    // --- Without the flag: no post-js sidecar, no $addOnPostCtor dep. ---
+    let out_dir_no = project.root.join("pkg-no-flag");
+    fs::create_dir_all(&out_dir_no).unwrap();
+    wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir_no.as_os_str(),
+        emscripten_wasm.as_os_str(),
+    ])
+    .unwrap();
+    assert!(
+        !out_dir_no.join("library_bindgen.post.js").exists(),
+        "library_bindgen.post.js must not be emitted without --emscripten-post-js"
+    );
+    let library_no = fs::read_to_string(out_dir_no.join("library_bindgen.js")).unwrap();
+    assert!(
+        !library_no.contains("'$addOnPostCtor'"),
+        "library_bindgen.js must not force $addOnPostCtor without the flag:\n{library_no}"
+    );
+}
+
 /// Look up an executable on `PATH`. Used so the test can opportunistically
 /// validate the generated .d.ts with `tsc` without hard-requiring it.
 fn which(name: &str) -> Option<PathBuf> {


### PR DESCRIPTION
This makes the clean wasm-bindgen JS API reachable when a Rust staticlib is linked with `emcc ... -sWASM_BINDGEN -sMODULARIZE=instance`.

Today `library_bindgen.js` publishes the clean wrappers with `Module.<name> = <name>;` inside the `$initBindgen` closure. That's correct for `MODULARIZE=1` (the consumer receives `Module`), but under `MODULARIZE=instance` the consumer receives ESM named exports + a default `init` and never sees `Module`, so those writes are dead. Only the mangled wasm exports (`_add`, ...) leak out; the clean `add` / `Counter` do not.

The wrappers can't simply be re-emitted as top-level declarations: e.g. `Counter` closes over `CounterFinalization`, which is built at init from the live `wasm` instance, so the export value only exists after `initBindgen` has run. The binding therefore has to be deferred (declared at module top level, assigned after init) and value-agnostic.

The handshake with emscripten is a single new CLI flag:

* `--emscripten-post-js` — emcc passes it **only** for `-sMODULARIZE=instance`. When present, wasm-bindgen emits one extra file into `--out-dir`, `library_bindgen.post.js`, which emcc feeds through its `--post-js` pipeline (appended after `postamble.js`, i.e. module top level where `export` is legal and the runtime helpers exist). The flag is never passed in any other mode, so older wasm-bindgen fails the (experimental) instance build loudly via clap's unknown-flag error while every other mode is unaffected.

The emitted file declares then assigns, so live bindings propagate to importers:

```js
#preprocess
#if MODULARIZE == 'instance'
export var add; addOnPostCtor(() => { add = Module['add']; });
export var Counter; addOnPostCtor(() => { Counter = Module['Counter']; });
#endif
```

giving consumers:

```js
import init, { add, Counter } from './out.mjs';
await init();
add(17, 25);            // 42
new Counter(40).inc();  // 41
```

Notes:

* `#preprocess` opts the file into emcc's preprocessor; the `#if MODULARIZE == 'instance'` guard keeps the export block (defensive — emcc only sends the flag in instance mode).
* `addOnPostCtor` runs after `addOnInit` (where `initBindgen` is registered), so `Module['<name>']` is populated by then. It's a library function only linked in on demand, so `library_bindgen.js` now force-includes `$addOnPostCtor` alongside its other runtime deps when the glue is emitted.
* The glue is accumulated at the same point the `Module.<name> = <name>;` lines are written — the single source of truth for what's public — so the two never drift.

Test coverage: a new CLI test builds an `add` fn + `Counter` struct, marks the module emscripten, and asserts that with `--emscripten-post-js` the `library_bindgen.post.js` sidecar has the `#preprocess` header, the instance guard, deferred `export var` + `addOnPostCtor` bindings (and no eager `Module` reads), and that `library_bindgen.js` force-includes `$addOnPostCtor`. Without the flag, no sidecar is emitted and the dep is absent.

Out of scope: the mangled wasm exports (`_add`, plus the large internal set force-exported via `--export=`) are still emitted as named ESM exports by emscripten's generic export path; trimming that is a separate emscripten-side concern.