### PR TITLE
Emit a wasm-bindgen-exports marker comment for emscripten builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 
 ### Added
 
-* Emscripten builds now emit a `library_bindgen.exports.json` sidecar: a JSON
-  array of the clean wasm-bindgen export names (the `Module.<name>` set), so
-  tooling can discover the public API in every emscripten build.
+* Emscripten builds now emit a `// wasm-bindgen-exports:` marker comment at the
+  top of `library_bindgen.js`, listing the clean wasm-bindgen export names (the
+  `Module.<name>` set) comma-separated, so tooling can discover the public API
+  in every emscripten build.
   [#5208](https://github.com/wasm-bindgen/wasm-bindgen/pull/5208)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ### Added
 
+* Emscripten builds now emit a `library_bindgen.exports.json` sidecar: a JSON
+  array of the clean wasm-bindgen export names (the `Module.<name>` set), so
+  tooling can discover the public API in every emscripten build.
+  [#5208](https://github.com/wasm-bindgen/wasm-bindgen/pull/5208)
+
 ### Changed
 
 ### Fixed

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -79,10 +79,6 @@ pub struct FinalizedOutput {
     /// Content to write alongside the main JS as a sidecar that emcc loads
     /// with `--extern-pre-js`. Empty for non-emscripten output modes.
     pub emscripten_extern_pre_js: String,
-    /// JSON array of the clean wasm-bindgen export names, written alongside the
-    /// main JS as a `library_bindgen.exports.json` sidecar. Empty for
-    /// non-emscripten output modes.
-    pub emscripten_exports_json: String,
 }
 
 pub struct Context<'a> {
@@ -102,12 +98,13 @@ pub struct Context<'a> {
     emscripten_extern_pre_js: String,
     imports_post: String,
     export_name_list: Vec<String>,
-    /// JSON array body of the clean wasm-bindgen export names, accumulated at
-    /// the same point the `Module.<name> = <name>;` lines are emitted (the
-    /// source of truth for what's publicly exported). Written to a
-    /// `library_bindgen.exports.json` sidecar so tooling can discover the
-    /// public API in every emscripten build. Empty for non-emscripten modes.
-    emscripten_exports_json: String,
+    /// Comma-separated list of the clean wasm-bindgen export names,
+    /// accumulated at the same point the `Module.<name> = <name>;` lines are
+    /// emitted (the source of truth for what's publicly exported). Emitted as a
+    /// `// wasm-bindgen-exports:` marker comment at the top of
+    /// `library_bindgen.js` so tooling can discover the public API in every
+    /// emscripten build. Empty for non-emscripten modes.
+    emscripten_exports_list: String,
     typescript: String,
     typescript_emscripten_classes: String,
     config: &'a Bindgen,
@@ -341,7 +338,7 @@ impl<'a> Context<'a> {
             intrinsics: Some(Default::default()),
             imports_post: String::new(),
             export_name_list: Vec::new(),
-            emscripten_exports_json: String::new(),
+            emscripten_exports_list: String::new(),
             typescript: "/* tslint:disable */\n/* eslint-disable */\n".to_string(),
             typescript_emscripten_classes: String::new(),
             imported_names: Default::default(),
@@ -597,12 +594,11 @@ impl<'a> Context<'a> {
 
                     if export_name == id {
                         self.global(&format!("Module.{export_name} = {id};\n"));
-                        // Record the public export name for the JSON sidecar.
-                        if !self.emscripten_exports_json.is_empty() {
-                            self.emscripten_exports_json.push(',');
+                        // Record the public export name for the sidecar list.
+                        if !self.emscripten_exports_list.is_empty() {
+                            self.emscripten_exports_list.push(',');
                         }
-                        self.emscripten_exports_json
-                            .push_str(&format!("{export_name:?}"));
+                        self.emscripten_exports_list.push_str(export_name);
                     } else {
                         self.global(&format!("export {{ {id} as {export_name} }};\n"));
                     }
@@ -881,18 +877,24 @@ impl<'a> Context<'a> {
             ts.push_str(&node_atomics_ts);
         }
 
-        let emscripten_exports_json = if matches!(self.config.mode, OutputMode::Emscripten) {
-            format!("[{}]\n", self.emscripten_exports_json)
+        // For emscripten, prepend a `// wasm-bindgen-exports:` marker comment
+        // listing the clean public export names so tooling can discover the
+        // public API in every build. A `//` line with no braces survives
+        // `reset_indentation` unchanged at module top level.
+        let js = if matches!(self.config.mode, OutputMode::Emscripten) {
+            format!(
+                "// wasm-bindgen-exports: {}\n{}",
+                self.emscripten_exports_list, self.globals
+            )
         } else {
-            String::new()
+            self.globals.to_owned()
         };
 
         Ok(FinalizedOutput {
-            js: self.globals.to_owned(),
+            js,
             ts,
             start,
             emscripten_extern_pre_js: std::mem::take(&mut self.emscripten_extern_pre_js),
-            emscripten_exports_json,
         })
     }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -79,6 +79,10 @@ pub struct FinalizedOutput {
     /// Content to write alongside the main JS as a sidecar that emcc loads
     /// with `--extern-pre-js`. Empty for non-emscripten output modes.
     pub emscripten_extern_pre_js: String,
+    /// JSON array of the clean wasm-bindgen export names, written alongside the
+    /// main JS as a `library_bindgen.exports.json` sidecar. Empty for
+    /// non-emscripten output modes.
+    pub emscripten_exports_json: String,
 }
 
 pub struct Context<'a> {
@@ -98,6 +102,12 @@ pub struct Context<'a> {
     emscripten_extern_pre_js: String,
     imports_post: String,
     export_name_list: Vec<String>,
+    /// JSON array body of the clean wasm-bindgen export names, accumulated at
+    /// the same point the `Module.<name> = <name>;` lines are emitted (the
+    /// source of truth for what's publicly exported). Written to a
+    /// `library_bindgen.exports.json` sidecar so tooling can discover the
+    /// public API in every emscripten build. Empty for non-emscripten modes.
+    emscripten_exports_json: String,
     typescript: String,
     typescript_emscripten_classes: String,
     config: &'a Bindgen,
@@ -331,6 +341,7 @@ impl<'a> Context<'a> {
             intrinsics: Some(Default::default()),
             imports_post: String::new(),
             export_name_list: Vec::new(),
+            emscripten_exports_json: String::new(),
             typescript: "/* tslint:disable */\n/* eslint-disable */\n".to_string(),
             typescript_emscripten_classes: String::new(),
             imported_names: Default::default(),
@@ -586,6 +597,12 @@ impl<'a> Context<'a> {
 
                     if export_name == id {
                         self.global(&format!("Module.{export_name} = {id};\n"));
+                        // Record the public export name for the JSON sidecar.
+                        if !self.emscripten_exports_json.is_empty() {
+                            self.emscripten_exports_json.push(',');
+                        }
+                        self.emscripten_exports_json
+                            .push_str(&format!("{export_name:?}"));
                     } else {
                         self.global(&format!("export {{ {id} as {export_name} }};\n"));
                     }
@@ -864,11 +881,18 @@ impl<'a> Context<'a> {
             ts.push_str(&node_atomics_ts);
         }
 
+        let emscripten_exports_json = if matches!(self.config.mode, OutputMode::Emscripten) {
+            format!("[{}]\n", self.emscripten_exports_json)
+        } else {
+            String::new()
+        };
+
         Ok(FinalizedOutput {
             js: self.globals.to_owned(),
             ts,
             start,
             emscripten_extern_pre_js: std::mem::take(&mut self.emscripten_extern_pre_js),
+            emscripten_exports_json,
         })
     }
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -64,6 +64,10 @@ struct Generated {
     /// emcc loads via `--extern-pre-js`, containing ESM `import` statements
     /// that must live at module top-level. Empty for other modes.
     emscripten_extern_pre_js: String,
+    /// For `OutputMode::Emscripten` only: a JSON array of the clean
+    /// wasm-bindgen export names, written to `library_bindgen.exports.json`.
+    /// Empty for other modes.
+    emscripten_exports_json: String,
 }
 
 #[derive(Clone)]
@@ -511,6 +515,7 @@ impl Bindgen {
             ts,
             start,
             emscripten_extern_pre_js,
+            emscripten_exports_json,
         } = cx.finalize(stem)?;
         let generated = Generated {
             snippets: aux.snippets.clone(),
@@ -522,6 +527,7 @@ impl Bindgen {
             ts,
             start,
             emscripten_extern_pre_js,
+            emscripten_exports_json,
         };
 
         Ok(Output {
@@ -811,6 +817,11 @@ impl Output {
                     reset_indentation(&gen.emscripten_extern_pre_js),
                 )?;
             }
+            // The clean wasm-bindgen export names as a JSON array, so tooling
+            // can discover the public API in every emscripten build (regardless
+            // of `--emscripten-post-js`).
+            let exports_json_path = out_dir.join("library_bindgen.exports.json");
+            write(&exports_json_path, &gen.emscripten_exports_json)?;
         } else {
             write(&js_path, reset_indentation(&gen.js))?;
         }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -64,10 +64,6 @@ struct Generated {
     /// emcc loads via `--extern-pre-js`, containing ESM `import` statements
     /// that must live at module top-level. Empty for other modes.
     emscripten_extern_pre_js: String,
-    /// For `OutputMode::Emscripten` only: a JSON array of the clean
-    /// wasm-bindgen export names, written to `library_bindgen.exports.json`.
-    /// Empty for other modes.
-    emscripten_exports_json: String,
 }
 
 #[derive(Clone)]
@@ -515,7 +511,6 @@ impl Bindgen {
             ts,
             start,
             emscripten_extern_pre_js,
-            emscripten_exports_json,
         } = cx.finalize(stem)?;
         let generated = Generated {
             snippets: aux.snippets.clone(),
@@ -527,7 +522,6 @@ impl Bindgen {
             ts,
             start,
             emscripten_extern_pre_js,
-            emscripten_exports_json,
         };
 
         Ok(Output {
@@ -817,11 +811,6 @@ impl Output {
                     reset_indentation(&gen.emscripten_extern_pre_js),
                 )?;
             }
-            // The clean wasm-bindgen export names as a JSON array, so tooling
-            // can discover the public API in every emscripten build (regardless
-            // of `--emscripten-post-js`).
-            let exports_json_path = out_dir.join("library_bindgen.exports.json");
-            write(&exports_json_path, &gen.emscripten_exports_json)?;
         } else {
             write(&js_path, reset_indentation(&gen.js))?;
         }

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2345,6 +2345,80 @@ fn emscripten_namespaced_exports_valid_ts() {
     }
 }
 
+#[test]
+fn emscripten_exports_json_lists_public_api() {
+    // Every emscripten build emits `library_bindgen.exports.json`, a JSON array
+    // of the clean wasm-bindgen export names (the `Module.<name> = <name>` set),
+    // so tooling can discover the public API regardless of build flags. Private
+    // internals (e.g. a private class) must not appear.
+    let mut project = Project::new("emscripten_exports_json_lists_public_api");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub fn add(a: i32, b: i32) -> i32 {
+                a + b
+            }
+
+            #[wasm_bindgen]
+            pub struct Counter {
+                value: i32,
+            }
+
+            #[wasm_bindgen]
+            impl Counter {
+                #[wasm_bindgen(constructor)]
+                pub fn new(start: i32) -> Counter {
+                    Counter { value: start }
+                }
+            }
+        "#,
+    );
+
+    let built = project.build();
+    let mut module = ModuleConfig::new().parse_file(&built).unwrap();
+    module.customs.add(RawCustomSection {
+        name: "__wasm_bindgen_emscripten_marker".into(),
+        data: vec![1],
+    });
+    let emscripten_wasm = project.root.join("emscripten_input.wasm");
+    module.emit_wasm_file(&emscripten_wasm).unwrap();
+
+    let out_dir = project.root.join("pkg-emscripten");
+    fs::create_dir_all(&out_dir).unwrap();
+    wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir.as_os_str(),
+        emscripten_wasm.as_os_str(),
+    ])
+    .unwrap();
+
+    let json = fs::read_to_string(out_dir.join("library_bindgen.exports.json"))
+        .expect("library_bindgen.exports.json should be emitted for emscripten builds");
+
+    // Valid JSON array of strings, containing exactly the public names.
+    let names: Vec<String> = serde_json::from_str(&json)
+        .unwrap_or_else(|e| panic!("exports json is not a JSON string array ({e}): {json}"));
+    let set: HashSet<&str> = names.iter().map(String::as_str).collect();
+    assert!(set.contains("add"), "missing `add` in exports json: {json}");
+    assert!(
+        set.contains("Counter"),
+        "missing `Counter` in exports json: {json}"
+    );
+    // No mangled wasm exports or private internals leak in.
+    assert!(
+        !set.contains("_add"),
+        "mangled wasm export leaked into exports json: {json}"
+    );
+    assert!(
+        names.iter().all(|n| !n.starts_with("__wbg")),
+        "internal `__wbg*` name leaked into exports json: {json}"
+    );
+}
+
 /// Look up an executable on `PATH`. Used so the test can opportunistically
 /// validate the generated .d.ts with `tsc` without hard-requiring it.
 fn which(name: &str) -> Option<PathBuf> {

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2346,12 +2346,13 @@ fn emscripten_namespaced_exports_valid_ts() {
 }
 
 #[test]
-fn emscripten_exports_json_lists_public_api() {
-    // Every emscripten build emits `library_bindgen.exports.json`, a JSON array
-    // of the clean wasm-bindgen export names (the `Module.<name> = <name>` set),
-    // so tooling can discover the public API regardless of build flags. Private
-    // internals (e.g. a private class) must not appear.
-    let mut project = Project::new("emscripten_exports_json_lists_public_api");
+fn emscripten_exports_marker_lists_public_api() {
+    // Every emscripten build emits a `// wasm-bindgen-exports:` marker comment
+    // at the top of `library_bindgen.js`, listing the clean wasm-bindgen export
+    // names (the `Module.<name> = <name>` set) comma-separated, so tooling can
+    // discover the public API regardless of build flags. Mangled wasm exports
+    // and internal `__wbg*` names must not appear.
+    let mut project = Project::new("emscripten_exports_marker_lists_public_api");
     project.file(
         "src/lib.rs",
         r#"
@@ -2396,26 +2397,29 @@ fn emscripten_exports_json_lists_public_api() {
     ])
     .unwrap();
 
-    let json = fs::read_to_string(out_dir.join("library_bindgen.exports.json"))
-        .expect("library_bindgen.exports.json should be emitted for emscripten builds");
+    let library = fs::read_to_string(out_dir.join("library_bindgen.js")).unwrap();
 
-    // Valid JSON array of strings, containing exactly the public names.
-    let names: Vec<String> = serde_json::from_str(&json)
-        .unwrap_or_else(|e| panic!("exports json is not a JSON string array ({e}): {json}"));
-    let set: HashSet<&str> = names.iter().map(String::as_str).collect();
-    assert!(set.contains("add"), "missing `add` in exports json: {json}");
+    // The marker is the first line and carries the comma-separated names.
+    let first = library.lines().next().unwrap_or("");
+    let list = first
+        .strip_prefix("// wasm-bindgen-exports:")
+        .unwrap_or_else(|| {
+            panic!("first line must be the `// wasm-bindgen-exports:` marker, got: {first:?}")
+        });
+    let names: HashSet<&str> = list.trim().split(',').map(str::trim).collect();
+    assert!(names.contains("add"), "missing `add` in marker: {first:?}");
     assert!(
-        set.contains("Counter"),
-        "missing `Counter` in exports json: {json}"
+        names.contains("Counter"),
+        "missing `Counter` in marker: {first:?}"
     );
-    // No mangled wasm exports or private internals leak in.
+    // No mangled wasm exports or internal names leak in.
     assert!(
-        !set.contains("_add"),
-        "mangled wasm export leaked into exports json: {json}"
+        !names.contains("_add"),
+        "mangled wasm export leaked into marker: {first:?}"
     );
     assert!(
         names.iter().all(|n| !n.starts_with("__wbg")),
-        "internal `__wbg*` name leaked into exports json: {json}"
+        "internal `__wbg*` name leaked into marker: {first:?}"
     );
 }
 


### PR DESCRIPTION
This makes the clean wasm-bindgen public API discoverable for every emscripten build.

Emscripten output publishes the clean wrappers with `Module.<name> = <name>;`, but there's no machine-readable list of which names those are — tooling that wants the public API has to scrape the generated JS. This adds a marker comment as the first line of `library_bindgen.js` listing those names, comma-separated:

```js
// wasm-bindgen-exports: Counter,add
```

It's emitted on every emscripten build, independent of any other flag. The names are collected at the single point that's already the source of truth for what's public — where the `Module.<name> = <name>;` line is written — so the list can never drift from the actual exports. Internal `__wbg*` names, private classes/enums, and the mangled wasm exports (`_add`) are not included. A `//` line with no braces passes through `reset_indentation` unchanged at module top level.

Test coverage: a new CLI test builds an `add` fn + `Counter` struct, marks the module emscripten, and asserts the first line of `library_bindgen.js` is the `// wasm-bindgen-exports:` marker carrying exactly the public names, with no mangled or `__wbg*` internals.
