### PR TITLE
Use `#[unsafe(export_name)]` instead of `#[no_mangle]` for exports

### DIFF
--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -223,7 +223,8 @@ impl ToTokens for ast::Struct {
         let name_len = name_str.len() as u32;
         let name_chars: Vec<u32> = name_str.chars().map(|c| c as u32).collect();
         let new_fn = Ident::new(&shared::new_function(&name_str), Span::call_site());
-        let free_fn = Ident::new(&shared::free_function(&name_str), Span::call_site());
+        let free_fn_name = shared::free_function(&name_str);
+        let free_fn = Ident::new(&free_fn_name, Span::call_site());
         let unwrap_fn = Ident::new(&shared::unwrap_function(&name_str), Span::call_site());
         let wasm_bindgen = &self.wasm_bindgen;
         let class_abi = quote! {
@@ -310,7 +311,7 @@ impl ToTokens for ast::Struct {
             #[automatically_derived]
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
-                #[no_mangle]
+                #[unsafe(export_name = #free_fn_name)]
                 #[doc(hidden)]
                 // `allow_delayed` is whether it's ok to not actually free the `ptr` immediately
                 // if it's still borrowed.
@@ -498,10 +499,8 @@ impl ToTokens for ast::Struct {
                     .unwrap_or_default();
                 let parent_qualified =
                     shared::qualified_name(self.extends_js_namespace.as_deref(), &parent_bare_name);
-                let upcast_fn = Ident::new(
-                    &shared::upcast_function(&name_str, &parent_qualified),
-                    Span::call_site(),
-                );
+                let upcast_fn_name = shared::upcast_function(&name_str, &parent_qualified);
+                let upcast_fn = Ident::new(&upcast_fn_name, Span::call_site());
                 (quote! {
                     #[automatically_derived]
                     impl #wasm_bindgen::__rt::core::convert::AsRef<#field_ty> for #name {
@@ -514,7 +513,7 @@ impl ToTokens for ast::Struct {
                     #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
                     #[automatically_derived]
                     const _: () = {
-                        #[no_mangle]
+                        #[unsafe(export_name = #upcast_fn_name)]
                         #[doc(hidden)]
                         pub unsafe extern "C-unwind" fn #upcast_fn(ptr: u32) -> u32 {
                             use #wasm_bindgen::__rt::alloc::rc::Rc;
@@ -552,6 +551,8 @@ impl ToTokens for ast::StructField {
         let ty = &self.ty;
         let getter = &self.getter;
         let setter = &self.setter;
+        let getter_name = getter.to_string();
+        let setter_name = setter.to_string();
 
         let maybe_assert_copy = if self.getter_with_clone.is_some() {
             quote! {}
@@ -581,7 +582,7 @@ impl ToTokens for ast::StructField {
             #[automatically_derived]
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
-                #[cfg_attr(all(target_family = "wasm", not(target_os = "wasi")), no_mangle)]
+                #[cfg_attr(all(target_family = "wasm", not(target_os = "wasi")), unsafe(export_name = #getter_name))]
                 #[doc(hidden)]
                 pub unsafe extern "C-unwind" fn #getter(js: #struct_abi)
                     -> #wasm_bindgen::convert::WasmRet<<#ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi>
@@ -624,7 +625,7 @@ impl ToTokens for ast::StructField {
             #[automatically_derived]
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
-                #[no_mangle]
+                #[unsafe(export_name = #setter_name)]
                 #[doc(hidden)]
                 pub unsafe extern "C-unwind" fn #setter(
                     js: #struct_abi,
@@ -1009,7 +1010,7 @@ impl TryToTokens for ast::Export {
                 #(#attrs)*
                 #[cfg_attr(
                     all(target_family = "wasm", not(target_os = "wasi")),
-                    export_name = #export_name,
+                    unsafe(export_name = #export_name),
                 )]
                 pub unsafe extern "C-unwind" fn #generated_name(#(#args),*) -> #wasm_bindgen::convert::WasmRet<#projection::Abi> {
                     const _: () = {
@@ -3199,7 +3200,8 @@ impl<T: ToTokens> ToTokens for Descriptor<'_, T> {
             return;
         }
 
-        let name = Ident::new(&format!("__wbindgen_describe_{ident}"), ident.span());
+        let name_str = format!("__wbindgen_describe_{ident}");
+        let name = Ident::new(&name_str, ident.span());
         let inner = &self.inner;
         let attrs = &self.attrs;
         let wasm_bindgen = &self.wasm_bindgen;
@@ -3209,7 +3211,7 @@ impl<T: ToTokens> ToTokens for Descriptor<'_, T> {
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
                 #(#attrs)*
-                #[no_mangle]
+                #[unsafe(export_name = #name_str)]
                 #[doc(hidden)]
                 pub extern "C-unwind" fn #name() {
                     use #wasm_bindgen::describe::*;

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -96,7 +96,7 @@ pub fn expand_class_marker(
     // output stream. If we were to do that then it wouldn't parse!
     //
     // Instead what we want to do is to generate the tokens for `program` into
-    // the header of the function. This'll inject some no_mangle functions and
+    // the header of the function. This'll inject some exported functions and
     // statics and such, and they should all be valid in the context of the
     // start of a function.
     //

--- a/guide/src/contributing/design/describe.md
+++ b/guide/src/contributing/design/describe.md
@@ -38,7 +38,7 @@ In addition to the shims we talked about above which JS generates the macro
 *also* generates something like:
 
 ```
-#[no_mangle]
+#[unsafe(export_name = "__wbindgen_describe_greet")]
 pub extern "C" fn __wbindgen_describe_greet() {
     <dyn Fn(&str)>::describe();
 }

--- a/guide/src/contributing/design/exporting-rust-struct.md
+++ b/guide/src/contributing/design/exporting-rust-struct.md
@@ -95,13 +95,13 @@ let's take a look at that.
 ```rust
 // original input to `#[wasm_bindgen]` omitted ...
 
-#[export_name = "foo_new"]
+#[unsafe(export_name = "foo_new")]
 pub extern "C" fn __wasm_bindgen_generated_Foo_new(arg0: i32) -> u32 {
     let ret = Foo::new(arg0);
     Box::into_raw(Box::new(WasmRefCell::new(ret))) as u32
 }
 
-#[export_name = "foo_get"]
+#[unsafe(export_name = "foo_get")]
 pub extern "C" fn __wasm_bindgen_generated_Foo_get(me: u32) -> i32 {
     let me = me as *mut WasmRefCell<Foo>;
     wasm_bindgen::__rt::assert_not_null(me);
@@ -109,7 +109,7 @@ pub extern "C" fn __wasm_bindgen_generated_Foo_get(me: u32) -> i32 {
     return me.borrow().get();
 }
 
-#[export_name = "foo_set"]
+#[unsafe(export_name = "foo_set")]
 pub extern "C" fn __wasm_bindgen_generated_Foo_set(me: u32, arg1: i32) {
     let me = me as *mut WasmRefCell<Foo>;
     wasm_bindgen::__rt::assert_not_null(me);
@@ -117,7 +117,7 @@ pub extern "C" fn __wasm_bindgen_generated_Foo_set(me: u32, arg1: i32) {
     me.borrow_mut().set(arg1);
 }
 
-#[no_mangle]
+#[unsafe(export_name = "__wbindgen_foo_free")]
 pub unsafe extern "C" fn __wbindgen_foo_free(me: u32) {
     let me = me as *mut WasmRefCell<Foo>;
     wasm_bindgen::__rt::assert_not_null(me);

--- a/guide/src/contributing/design/exporting-rust.md
+++ b/guide/src/contributing/design/exporting-rust.md
@@ -91,7 +91,7 @@ pub extern "C" fn greet(a: &str) -> String {
     format!("Hello, {}!", a)
 }
 
-#[export_name = "greet"]
+#[unsafe(export_name = "greet")]
 pub extern "C" fn __wasm_bindgen_generated_greet(
     arg0_ptr: *const u8,
     arg0_len: usize,

--- a/guide/src/contributing/design/js-objects-in-rust.md
+++ b/guide/src/contributing/design/js-objects-in-rust.md
@@ -91,7 +91,7 @@ pub fn foo(a: &JsValue) {
     // ...
 }
 
-#[export_name = "foo"]
+#[unsafe(export_name = "foo")]
 pub extern "C" fn __wasm_bindgen_generated_foo(arg0: u32) {
     let arg0 = unsafe {
         ManuallyDrop::new(JsValue::__from_idx(arg0))
@@ -188,7 +188,7 @@ pub fn foo(a: JsValue) {
     // ...
 }
 
-#[export_name = "foo"]
+#[unsafe(export_name = "foo")]
 pub extern "C" fn __wasm_bindgen_generated_foo(arg0: u32) {
     let arg0 = unsafe {
         JsValue::__from_idx(arg0)

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -751,7 +751,7 @@ struct BorrowedClosure<T: ?Sized, const UNWIND_SAFE: bool> {
 /// `(a, b)` must be a valid pair previously produced by `Box::into_raw` on a
 /// `Box<dyn FnOnce/FnMut/Fn>` closure, or `a` must be zero (in which case this
 /// is a no-op).
-#[no_mangle]
+#[unsafe(export_name = "__wbindgen_destroy_closure")]
 unsafe extern "C" fn __wbindgen_destroy_closure(a: WasmWord, b: WasmWord) {
     if a.is_zero() {
         return;

--- a/src/externref.rs
+++ b/src/externref.rs
@@ -126,13 +126,13 @@ fn internal_error(_msg: &str) -> ! {
 static HEAP_SLAB: __rt::ThreadLocalWrapper<RefCell<Slab>> =
     __rt::ThreadLocalWrapper(RefCell::new(Slab::new()));
 
-#[no_mangle]
+#[unsafe(export_name = "__externref_table_alloc")]
 pub extern "C" fn __externref_table_alloc() -> u32 {
     // Table indices are always 32-bit, even on wasm64.
     HEAP_SLAB.0.borrow_mut().alloc() as u32
 }
 
-#[no_mangle]
+#[unsafe(export_name = "__externref_table_dealloc")]
 pub extern "C" fn __externref_table_dealloc(idx: u32) {
     let idx = idx as usize;
     if idx < __rt::JSIDX_RESERVED as usize {
@@ -146,7 +146,7 @@ pub extern "C" fn __externref_table_dealloc(idx: u32) {
     HEAP_SLAB.0.borrow_mut().dealloc(idx)
 }
 
-#[no_mangle]
+#[unsafe(export_name = "__externref_drop_slice")]
 pub unsafe extern "C" fn __externref_drop_slice(ptr: WasmPtr<JsValue>, len: WasmWord) {
     let ptr = ptr.into_ptr();
     let len = len.into_usize();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ const _: () = {
     /// * it is not a position-independent executable;
     /// * and it does not call `__wasm_call_ctors`, directly or indirectly, from any
     ///   exported function.
-    #[no_mangle]
+    #[unsafe(export_name = "__wbindgen_skip_interpret_calls")]
     pub extern "C" fn __wbindgen_skip_interpret_calls() {}
 };
 

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -677,7 +677,7 @@ impl<T: ?Sized> BorrowMut<T> for RcRefMut<T> {
     }
 }
 
-#[no_mangle]
+#[unsafe(export_name = "__wbindgen_malloc")]
 pub extern "C" fn __wbindgen_malloc(size: WasmWord, align: WasmWord) -> WasmPtr<u8> {
     let size = size.into_usize();
     let align = align.into_usize();
@@ -697,7 +697,7 @@ pub extern "C" fn __wbindgen_malloc(size: WasmWord, align: WasmWord) -> WasmPtr<
     malloc_failure();
 }
 
-#[no_mangle]
+#[unsafe(export_name = "__wbindgen_realloc")]
 pub unsafe extern "C" fn __wbindgen_realloc(
     ptr: WasmPtr<u8>,
     old_size: WasmWord,
@@ -738,7 +738,7 @@ fn malloc_failure() -> ! {
     }
 }
 
-#[no_mangle]
+#[unsafe(export_name = "__wbindgen_free")]
 pub unsafe extern "C" fn __wbindgen_free(ptr: WasmPtr<u8>, size: WasmWord, align: WasmWord) {
     let size = size.into_usize();
     // This happens for zero-length slices, and in that case `ptr` is
@@ -793,7 +793,8 @@ pub fn link_mem_intrinsics() {
 #[cfg_attr(target_feature = "atomics", thread_local)]
 static GLOBAL_EXNDATA: ThreadLocalWrapper<Cell<[u32; 2]>> = ThreadLocalWrapper(Cell::new([0; 2]));
 
-#[no_mangle]
+#[allow(non_upper_case_globals)]
+#[unsafe(export_name = "__instance_terminated")]
 pub static mut __instance_terminated: u32 = 0;
 
 fn no_op() {}
@@ -802,7 +803,8 @@ pub static NO_OP_PTR: fn() = no_op;
 
 /// Stores the Wasm indirect-function-table index of the registered hard-abort
 /// callback.  Zero means no callback is registered.
-#[no_mangle]
+#[allow(non_upper_case_globals)]
+#[unsafe(export_name = "__abort_handler")]
 pub static mut __abort_handler: fn() = NO_OP_PTR;
 
 /// Register a callback invoked when a hard abort (instance termination) occurs.
@@ -841,7 +843,7 @@ pub fn schedule_reinit() {
     crate::__wbindgen_reinit();
 }
 
-#[no_mangle]
+#[unsafe(export_name = "__wbindgen_exn_store")]
 pub unsafe extern "C" fn __wbindgen_exn_store(idx: u32) {
     debug_assert_eq!(GLOBAL_EXNDATA.0.get()[0], 0);
     GLOBAL_EXNDATA.0.set([1, idx]);


### PR DESCRIPTION
wasm-bindgen indicates its wasm exports with `#[no_mangle]`, which makes the wasm symbol name implicitly equal to the Rust identifier. This switches every wasm-bindgen-emitted export to `#[unsafe(export_name = "...")]`, making the exported symbol explicit and decoupling it from the Rust identifier. This is also the forward-compatible spelling, since bare `#[no_mangle]` requires the `unsafe(...)` wrapper going forward.

The generated symbol names are unchanged, so consumers and the CLI side are unaffected.

Generated code (`crates/macro-support/src/codegen.rs`):

* struct `free`, `upcast`, field getter (the `cfg_attr` form), field setter, and the `__wbindgen_describe_*` descriptor shim now emit an explicit `export_name` equal to the previous symbol
* the existing main export shim's `export_name` is wrapped in `unsafe(...)` for consistency

Hand-written runtime exports (`src/`): `__externref_table_alloc`/`dealloc`/`drop_slice`, `__wbindgen_skip_interpret_calls`, `__wbindgen_malloc`/`realloc`/`free`/`exn_store`, `__wbindgen_destroy_closure`, and the `__instance_terminated` / `__abort_handler` statics.

One behavioural nuance: `#[no_mangle]` silently suppressed the `non_upper_case_globals` lint, but `#[export_name]` does not. The two lowercase statics are referenced by their Rust identifiers elsewhere, so they keep their idents plus an `#[allow(non_upper_case_globals)]`:

```rs
#[allow(non_upper_case_globals)]
#[unsafe(export_name = "__abort_handler")]
pub static mut __abort_handler: fn() = NO_OP_PTR;
```

`#[no_mangle]` is intentionally left in place where it is not a wasm-bindgen export: test fixtures and the parser logic that strips a *user's* `#[no_mangle]` from an exported function. The contributing design guide examples are updated to the new spelling.

Verified with `cargo build`/`clippy`/`fmt` on `wasm32-unknown-unknown`, the macro-support/shared/cli-support suites, and the CLI pipeline tests (87 pass; the 4 failures all reproduce on the base branch and are environmental). The WASI link command confirms the renamed exports still resolve.