### PR TITLE
Hoist emscripten exports into top-level library symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   `-sMODULARIZE=instance` and as `Module.<name>` properties in factory mode,
   with no extra sidecar files. Namespaced exports are exported through their
   namespace root (e.g. `app`), assembled in the root symbol's `__postset`.
-  [#5209](https://github.com/wasm-bindgen/wasm-bindgen/pull/5209)
+  [#5209](https://github.com/wasm-bindgen/wasm-bindgen/pull/5210)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@
 ### Changed
 
 * Emscripten output now hoists every clean export (free functions, classes,
-  enums, their finalization registries and string-enum tables) out of the
-  `$initBindgen` init closure into its own top-level `addToLibrary` symbol, and
-  self-registers it via `EXPORTED_FUNCTIONS` / `extraLibraryFuncs`. emscripten
-  then emits the clean API (`add`, `Counter`, ...) as named ESM exports under
-  `-sMODULARIZE=instance` and as `Module.<name>` properties in factory mode,
-  with no extra sidecar files. Namespaced exports are exported through their
-  namespace root (e.g. `app`), assembled in the root symbol's `__postset`.
+  enums, plus their finalization registries and string-enum tables) out of the
+  `$initBindgen` init closure into its own top-level `addToLibrary` symbol and
+  self-registers it into `EXPORTED_FUNCTIONS`. emscripten then emits the clean
+  API (`add`, `Counter`, ...) as named ESM exports under `-sMODULARIZE=instance`
+  and as `Module.<name>` properties (via each symbol's `__postset`) in factory
+  mode, with no extra sidecar files. Namespaced exports are reached through
+  their namespace root (e.g. `app`), assembled in the root symbol's `__postset`.
+  User module/inline-js imports are now wired as `addToLibrary` shims (they were
+  previously dropped, since emcc resolves imports only against `env`), and their
+  ESM-imported bindings are `__wbg_`-prefixed to avoid colliding with emcc
+  runtime names such as `Module`/`HEAP8`.
   [#5210](https://github.com/wasm-bindgen/wasm-bindgen/pull/5210)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 
 ### Changed
 
-* Emscripten output now hoists each non-namespaced clean export (free functions
-  and classes, plus their finalization registries) out of the `$initBindgen`
-  init closure into its own top-level `addToLibrary` symbol, and self-registers
-  it via `EXPORTED_FUNCTIONS` / `extraLibraryFuncs`. emscripten then emits the
-  clean API (`add`, `Counter`, ...) as named ESM exports under
+* Emscripten output now hoists every clean export (free functions, classes,
+  enums, their finalization registries and string-enum tables) out of the
+  `$initBindgen` init closure into its own top-level `addToLibrary` symbol, and
+  self-registers it via `EXPORTED_FUNCTIONS` / `extraLibraryFuncs`. emscripten
+  then emits the clean API (`add`, `Counter`, ...) as named ESM exports under
   `-sMODULARIZE=instance` and as `Module.<name>` properties in factory mode,
-  with no extra sidecar files. Namespaced exports are unchanged.
+  with no extra sidecar files. Namespaced exports are exported through their
+  namespace root (e.g. `app`), assembled in the root symbol's `__postset`.
   [#5209](https://github.com/wasm-bindgen/wasm-bindgen/pull/5209)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Changed
 
+* Emscripten output now hoists each non-namespaced clean export (free functions
+  and classes, plus their finalization registries) out of the `$initBindgen`
+  init closure into its own top-level `addToLibrary` symbol, and self-registers
+  it via `EXPORTED_FUNCTIONS` / `extraLibraryFuncs`. emscripten then emits the
+  clean API (`add`, `Counter`, ...) as named ESM exports under
+  `-sMODULARIZE=instance` and as `Module.<name>` properties in factory mode,
+  with no extra sidecar files. Namespaced exports are unchanged.
+  [#5209](https://github.com/wasm-bindgen/wasm-bindgen/pull/5209)
+
 ### Fixed
 
 * Relaxed alignment requirement for 8-byte types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   `-sMODULARIZE=instance` and as `Module.<name>` properties in factory mode,
   with no extra sidecar files. Namespaced exports are exported through their
   namespace root (e.g. `app`), assembled in the root symbol's `__postset`.
-  [#5209](https://github.com/wasm-bindgen/wasm-bindgen/pull/5210)
+  [#5210](https://github.com/wasm-bindgen/wasm-bindgen/pull/5210)
 
 ### Fixed
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2305,9 +2305,18 @@ if (require('worker_threads').isMainThread) {{
                 : new FinalizationRegistry({finalization_callback})"
         );
         if hoist {
-            // The callback closes over the module-scope `wasm` global.
+            // Emit the registry's *source* as a string-valued library member.
+            // emscripten evaluates non-string library values while loading the
+            // library file, then re-serializes them from the live object. A
+            // `FinalizationRegistry` instance has no enumerable own properties,
+            // so that round-trip would collapse it to `{}` and drop
+            // `register`/`unregister`. A string member is emitted verbatim as
+            // `var XFinalization = <source>` (same as intrinsic values like
+            // `$cachedTextDecoder: "new TextDecoder()"`). The callback closes
+            // over the module-scope `wasm` global.
+            let value_lit = format!("{finalization_value:?}");
             self.emscripten_library(&format!(
-                "addToLibrary({{\n    ${identifier}Finalization: {finalization_value},\n    \
+                "addToLibrary({{\n    ${identifier}Finalization: {value_lit},\n    \
                  ${identifier}Finalization__deps: ['$wasm']\n}});"
             ));
         } else {
@@ -6502,7 +6511,12 @@ addToLibrary({
             // ESM exports / `Module.<name>`; namespaced ones are private and
             // reached through their namespace root.
             let is_namespaced = enum_.js_namespace.is_some();
-            let value = format!("Object.freeze({{\n{variants}}})");
+            // String-valued member so the `Object.freeze(...)` source is
+            // emitted verbatim. As a live value it would be evaluated while
+            // loading the library and re-serialized to a plain object, losing
+            // `Object.freeze` (see the finalization-registry note in
+            // `write_class`).
+            let value = format!("{:?}", format!("Object.freeze({{\n{variants}}})"));
             self.hoist_emscripten_export(
                 &identifier,
                 &value,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -514,6 +514,52 @@ impl<'a> Context<'a> {
         }
     }
 
+    /// Hoist a clean export (free function, class, or enum) to a library symbol
+    /// and, when it's namespaced, register a declaration-free entry in the
+    /// export tree so the namespace root assembles `ns.<name> = <identifier>`
+    /// and the `.d.ts` namespace shape resolves `typeof <identifier>`. The
+    /// hoisted symbol is public (named ESM export / `Module.<name>`) unless it's
+    /// namespaced (reached via the root) or `private`. Shared by the function,
+    /// class, and enum emission paths.
+    fn hoist_emscripten_export_with_tree(
+        &mut self,
+        identifier: &str,
+        value: &str,
+        extra_deps: &[&str],
+        postset_extra: &str,
+        private: bool,
+        js_name: &str,
+        js_namespace: Option<&[String]>,
+        ts_definition: String,
+        parent_identifier: Option<String>,
+    ) -> Result<(), Error> {
+        let is_namespaced = js_namespace.is_some();
+        self.hoist_emscripten_export(
+            identifier,
+            value,
+            extra_deps,
+            postset_extra,
+            !is_namespaced && !private,
+        );
+        if is_namespaced {
+            define_export(
+                &mut self.exports,
+                js_name,
+                js_namespace.unwrap_or_default(),
+                ExportEntry::Definition(ExportDefinition {
+                    identifier: identifier.to_string(),
+                    comments: None,
+                    definition: String::new(),
+                    ts_definition,
+                    ts_comments: None,
+                    private,
+                    parent_identifier,
+                }),
+            )?;
+        }
+        Ok(())
+    }
+
     /// Register a wasm-bindgen-internal helper as an intrinsic.
     ///
     /// `deps` lists library symbols the intrinsic body itself references by
@@ -2257,7 +2303,6 @@ if (require('worker_threads').isMainThread) {{
         // Hoisted classes need their finalization registry as a sibling library
         // symbol rather than a `$initBindgen` local.
         let hoist = matches!(self.config.mode, OutputMode::Emscripten);
-        let is_namespaced = class.js_namespace.is_some();
         let finalization_value = format!(
             "(typeof FinalizationRegistry === 'undefined')\n\
                 ? {{ register: () => {{}}, unregister: () => {{}} }}\n\
@@ -2469,31 +2514,17 @@ if (require('worker_threads').isMainThread) {{
             }
             let extra_dep_refs: Vec<&str> = extra_deps.iter().map(String::as_str).collect();
             // Private classes are hoisted but not exposed as a runtime value.
-            self.hoist_emscripten_export(
+            self.hoist_emscripten_export_with_tree(
                 &identifier,
                 dst.trim_end(),
                 &extra_dep_refs,
                 &format!("{dispose_wiring} "),
-                !is_namespaced && !class.private,
-            );
-            // Namespaced classes still need a tree entry (empty definition) so
-            // the root assembles `ns.Class = <identifier>`.
-            if is_namespaced {
-                define_export(
-                    &mut self.exports,
-                    js_name,
-                    class.js_namespace.as_deref().unwrap_or_default(),
-                    ExportEntry::Definition(ExportDefinition {
-                        identifier: class.identifier.clone(),
-                        comments: None,
-                        definition: String::new(),
-                        ts_definition,
-                        ts_comments: None,
-                        private: class.private,
-                        parent_identifier: parent_identifier.clone(),
-                    }),
-                )?;
-            }
+                class.private,
+                js_name,
+                class.js_namespace.as_deref(),
+                ts_definition,
+                parent_identifier.clone(),
+            )?;
             return Ok(());
         }
 
@@ -5282,33 +5313,20 @@ addToLibrary({
                         };
 
                         if matches!(self.config.mode, OutputMode::Emscripten) {
-                            // Hoist into a library symbol. Namespaced functions
-                            // are hoisted privately and recorded in the tree
-                            // (empty definition) so the root wires `ns.fn`.
+                            // Hoist into a library symbol (namespaced functions
+                            // are hoisted privately and wired via their root).
                             let value = format!("function {identifier}{code}");
-                            self.hoist_emscripten_export(
+                            self.hoist_emscripten_export_with_tree(
                                 &identifier,
                                 &value,
                                 &[],
                                 "",
-                                !is_namespaced,
-                            );
-                            if is_namespaced {
-                                define_export(
-                                    &mut self.exports,
-                                    name,
-                                    export.js_namespace.as_deref().unwrap_or_default(),
-                                    ExportEntry::Definition(ExportDefinition {
-                                        identifier: identifier.clone(),
-                                        comments: None,
-                                        definition: String::new(),
-                                        ts_definition,
-                                        ts_comments,
-                                        private: false,
-                                        parent_identifier: None,
-                                    }),
-                                )?;
-                            }
+                                false,
+                                name,
+                                export.js_namespace.as_deref(),
+                                ts_definition,
+                                None,
+                            )?;
                         } else {
                             let definition = format!("function {identifier}{code}\n");
                             define_export(
@@ -6475,34 +6493,21 @@ addToLibrary({
 
         if matches!(self.config.mode, OutputMode::Emscripten) {
             // Hoist the frozen enum into a library symbol like functions and
-            // classes.
-            let is_namespaced = enum_.js_namespace.is_some();
-            // String-valued so the `Object.freeze(...)` source is emitted
-            // verbatim (see the finalization-registry note in `write_class`).
+            // classes. String-valued so the `Object.freeze(...)` source is
+            // emitted verbatim (see the finalization-registry note in
+            // `write_class`).
             let value = format!("{:?}", format!("Object.freeze({{\n{variants}}})"));
-            self.hoist_emscripten_export(
+            self.hoist_emscripten_export_with_tree(
                 &identifier,
                 &value,
                 &[],
                 "",
-                !is_namespaced && !enum_.private,
-            );
-            if is_namespaced {
-                define_export(
-                    &mut self.exports,
-                    &enum_.name,
-                    enum_.js_namespace.as_deref().unwrap_or_default(),
-                    ExportEntry::Definition(ExportDefinition {
-                        identifier: identifier.clone(),
-                        comments: None,
-                        definition: String::new(),
-                        ts_definition,
-                        ts_comments: None,
-                        private: enum_.private,
-                        parent_identifier: None,
-                    }),
-                )?;
-            }
+                enum_.private,
+                &enum_.name,
+                enum_.js_namespace.as_deref(),
+                ts_definition,
+                None,
+            )?;
             return Ok(());
         }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1768,32 +1768,19 @@ if (require('worker_threads').isMainThread) {{
 
         // Self-register the hoisted public exports at compile time. emscripten
         // runs `--js-library` files in the compiler context, so we can push
-        // straight onto its settings (the same way `extraLibraryFuncs` is used
-        // below):
-        //   * `extraLibraryFuncs` force-keeps each `$<id>` library symbol.
-        //   * `EXPORTED_FUNCTIONS` makes `jsifier` prepend `export` to the
-        //     symbol's declaration under `MODULARIZE=instance`, producing a
-        //     named ESM export. (Factory mode gets `Module.<id>` via the
-        //     symbol's `__postset`.)
-        let export_lib_refs: Vec<String> = self
+        // straight onto its settings. Adding each name to `EXPORTED_FUNCTIONS`
+        // does double duty in `jsifier`: membership forces the `$<id>` library
+        // symbol to be included (`EXPORTED_FUNCTIONS.has(mangleCSymbolName(key))`
+        // at jsifier.mjs:419) *and* makes it prepend `export` to the symbol's
+        // declaration under `MODULARIZE=instance` (jsifier.mjs:802) — a named
+        // ESM export. Factory mode gets `Module.<id>` via the symbol's
+        // `__postset`. So no separate `extraLibraryFuncs` force-keep is needed;
+        // the transitive closure is pulled in by each symbol's `__deps`.
+        let self_register = self
             .emscripten_runtime_exports
             .iter()
-            .map(|id| format!("'${id}'"))
-            .collect();
-        let self_register = if self.emscripten_runtime_exports.is_empty() {
-            String::new()
-        } else {
-            let funcs: Vec<String> = self
-                .emscripten_runtime_exports
-                .iter()
-                .map(|id| format!("EXPORTED_FUNCTIONS.add('{id}');"))
-                .collect();
-            format!(
-                "extraLibraryFuncs.push({});\n{}\n",
-                export_lib_refs.join(", "),
-                funcs.join("\n"),
-            )
-        };
+            .map(|id| format!("EXPORTED_FUNCTIONS.add('{id}');\n"))
+            .collect::<String>();
 
         format!(
             r#"

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -4494,6 +4494,22 @@ if (require('worker_threads').isMainThread) {{
             .push((name.to_string(), rename));
     }
 
+    /// Module-scope local name for an imported value. In emscripten mode user
+    /// imports are emitted as ESM imports in the `--extern-pre-js` sidecar,
+    /// landing at module top level alongside emcc's runtime; the imported name
+    /// comes verbatim from the user's JS module, so prefix the local with
+    /// `__wbg_` to avoid colliding with arbitrary names (`Module`, `HEAP8`,
+    /// `wasm`, ...). The import is aliased (`import { Foo as __wbg_Foo }`) and
+    /// every shim references the same prefixed local. Other modes are
+    /// unaffected (their imports aren't merged into a foreign module scope).
+    fn generate_import_identifier(&mut self, name: &str) -> String {
+        if matches!(self.config.mode, OutputMode::Emscripten) {
+            self.generate_identifier(&format!("__wbg_{name}"))
+        } else {
+            self.generate_identifier(name)
+        }
+    }
+
     fn import_name(&mut self, import: &JsImport) -> Result<String, Error> {
         if let Some(name) = self.imported_names.get(&import.name) {
             let mut name = name.clone();
@@ -4505,13 +4521,13 @@ if (require('worker_threads').isMainThread) {{
 
         let mut name = match &import.name {
             JsImportName::Module { module, name } => {
-                let unique_name = self.generate_identifier(name);
+                let unique_name = self.generate_import_identifier(name);
                 self.add_module_import(module.clone(), name, &unique_name);
                 unique_name
             }
 
             JsImportName::LocalModule { module, name } => {
-                let unique_name = self.generate_identifier(name);
+                let unique_name = self.generate_import_identifier(name);
                 let module = self.config.local_module_name(module);
                 self.add_module_import(module, name, &unique_name);
                 unique_name
@@ -4525,7 +4541,7 @@ if (require('worker_threads').isMainThread) {{
                 let module = self
                     .config
                     .inline_js_module_name(unique_crate_identifier, *snippet_idx_in_crate);
-                let unique_name = self.generate_identifier(name);
+                let unique_name = self.generate_import_identifier(name);
                 self.add_module_import(module, name, &unique_name);
                 unique_name
             }
@@ -5493,6 +5509,16 @@ addToLibrary({
         id: ImportId,
         instrs: &[InstructionData],
     ) -> Result<bool, Error> {
+        // Emscripten resolves wasm imports only against its `env` library, so
+        // (unlike bundler/web/nodejs, which wire a direct module import via
+        // `import * as` + the import object) it can't satisfy an import that
+        // points straight at an arbitrary user module. Always fall through to a
+        // JS shim, which becomes an `addToLibrary` function calling the
+        // (prefixed) ESM-imported binding emitted into the extern-pre sidecar.
+        if matches!(self.config.mode, OutputMode::Emscripten) {
+            return Ok(false);
+        }
+
         // First up extract the ID of the single called adapter, if any.
         let mut call = None;
         for instr in instrs {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -195,6 +195,14 @@ pub struct Context<'a> {
     /// before generating each import and diffing afterwards.
     emscripten_import_deps: BTreeMap<ImportId, BTreeSet<String>>,
 
+    /// Clean public export identifiers (free functions and classes) that have
+    /// been hoisted into top-level `addToLibrary` symbols in emscripten mode.
+    /// Used to self-register them at compile time via `EXPORTED_RUNTIME_METHODS`
+    /// (inclusion + `Module.<name>` in factory mode) and `EXPORTED_FUNCTIONS`
+    /// (the `export` prefix under `MODULARIZE=instance`), so emscripten emits
+    /// the clean named exports itself.
+    emscripten_runtime_exports: Vec<String>,
+
     /// `true` when the module's memory is a memory64 (wasm64) memory.
     memory64: bool,
 
@@ -358,6 +366,7 @@ impl<'a> Context<'a> {
             adapter_deps: Default::default(),
             emscripten_global_deps: Default::default(),
             emscripten_import_deps: Default::default(),
+            emscripten_runtime_exports: Default::default(),
             memory64,
             super_skip_sentinel_emitted: false,
         })
@@ -370,8 +379,16 @@ impl<'a> Context<'a> {
         if self.super_skip_sentinel_emitted {
             return;
         }
-        self.globals
-            .push_str("const __wbgSuperSkip = Symbol('wasm-bindgen.super-skip');\n");
+        if matches!(self.config.mode, OutputMode::Emscripten) {
+            // Hoisted classes live in top-level `addToLibrary` symbols, so the
+            // sentinel their constructors compare against must also be a
+            // module-scope library symbol (not a `const` inside `$initBindgen`).
+            self.export_to_emscripten("__wbgSuperSkip", "Symbol('wasm-bindgen.super-skip')", &[]);
+            self.adapter_deps.insert("__wbgSuperSkip".to_string());
+        } else {
+            self.globals
+                .push_str("const __wbgSuperSkip = Symbol('wasm-bindgen.super-skip');\n");
+        }
         self.super_skip_sentinel_emitted = true;
     }
 
@@ -458,6 +475,40 @@ impl<'a> Context<'a> {
             "addToLibrary({{\n    ${js_name}: \"{}\"{deps_str}\n}});",
             content.replace('\\', "\\\\").replace('"', "\\\""),
         ));
+    }
+
+    /// Hoist a clean public export (a free function or class) into its own
+    /// top-level `addToLibrary({ $id: <value>, ... })` library symbol so
+    /// emscripten can turn it into a named ESM export under
+    /// `MODULARIZE=instance` (see `self_register_emscripten_exports`).
+    ///
+    /// `value` is the right-hand side expression — a named function expression
+    /// (`function add(a, b) { ... }`) or class expression (`class Counter
+    /// { ... }`). `extra_deps` lists additional `$`-less library symbols the
+    /// value references directly (e.g. a class's `<id>Finalization` and its
+    /// `extends` parent); every hoisted symbol also depends on `$initBindgen`,
+    /// which aggregates `$wasm` plus all intrinsic deps, so nothing the body
+    /// references by bare name is tree-shaken. `postset_extra` is JS run right
+    /// after the symbol is defined, before it's attached to `Module` (used for
+    /// the class `Symbol.dispose` wiring); the `Module.<id> = <id>` attachment
+    /// keeps factory mode (`MODULARIZE=1`) working.
+    fn hoist_emscripten_export(
+        &mut self,
+        identifier: &str,
+        value: &str,
+        extra_deps: &[&str],
+        postset_extra: &str,
+    ) {
+        let mut deps = vec!["$initBindgen".to_string()];
+        deps.extend(extra_deps.iter().map(|d| format!("${d}")));
+        let deps_fmt: Vec<String> = deps.iter().map(|d| format!("'{d}'")).collect();
+        let postset = format!("{postset_extra}Module['{identifier}'] = {identifier};");
+        self.emscripten_library(&format!(
+            "addToLibrary({{\n    ${identifier}: {value},\n    \
+             ${identifier}__deps: [{}],\n    ${identifier}__postset: {postset:?}\n}});",
+            deps_fmt.join(", "),
+        ));
+        self.emscripten_runtime_exports.push(identifier.to_string());
     }
 
     /// Register a wasm-bindgen-internal helper as an intrinsic.
@@ -1692,6 +1743,35 @@ if (require('worker_threads').isMainThread) {{
             ""
         };
 
+        // Self-register the hoisted public exports at compile time. emscripten
+        // runs `--js-library` files in the compiler context, so we can push
+        // straight onto its settings (the same way `extraLibraryFuncs` is used
+        // below):
+        //   * `extraLibraryFuncs` force-keeps each `$<id>` library symbol.
+        //   * `EXPORTED_FUNCTIONS` makes `jsifier` prepend `export` to the
+        //     symbol's declaration under `MODULARIZE=instance`, producing a
+        //     named ESM export. (Factory mode gets `Module.<id>` via the
+        //     symbol's `__postset`.)
+        let export_lib_refs: Vec<String> = self
+            .emscripten_runtime_exports
+            .iter()
+            .map(|id| format!("'${id}'"))
+            .collect();
+        let self_register = if self.emscripten_runtime_exports.is_empty() {
+            String::new()
+        } else {
+            let funcs: Vec<String> = self
+                .emscripten_runtime_exports
+                .iter()
+                .map(|id| format!("EXPORTED_FUNCTIONS.add('{id}');"))
+                .collect();
+            format!(
+                "extraLibraryFuncs.push({});\n{}\n",
+                export_lib_refs.join(", "),
+                funcs.join("\n"),
+            )
+        };
+
         format!(
             r#"
             addToLibrary({{
@@ -1710,7 +1790,7 @@ if (require('worker_threads').isMainThread) {{
             }});
 
             extraLibraryFuncs.push('$initBindgen', '$addOnInit', '$wasm', {global_deps});
-            "#,
+            {self_register}"#,
             init_deps = init_dep_refs.join(", "),
             global_deps = global_dep_refs.join(", "),
         )
@@ -2192,11 +2272,29 @@ if (require('worker_threads').isMainThread) {{
             )
         };
 
-        self.globals.push_str(&format!(
-            "const {identifier}Finalization = (typeof FinalizationRegistry === 'undefined')
-                ? {{ register: () => {{}}, unregister: () => {{}} }}
-                : new FinalizationRegistry({finalization_callback});\n"
-        ));
+        // Non-namespaced classes in emscripten mode are hoisted into top-level
+        // `addToLibrary` symbols (so they become named ESM exports / `Module`
+        // properties); their finalization registry must be a sibling library
+        // symbol rather than a `const` inside `$initBindgen`. Namespaced
+        // classes stay on the `$initBindgen` path (nested `Module.<ns>` shape).
+        let hoist =
+            matches!(self.config.mode, OutputMode::Emscripten) && class.js_namespace.is_none();
+        let finalization_value = format!(
+            "(typeof FinalizationRegistry === 'undefined')\n\
+                ? {{ register: () => {{}}, unregister: () => {{}} }}\n\
+                : new FinalizationRegistry({finalization_callback})"
+        );
+        if hoist {
+            // The callback closes over the module-scope `wasm` global.
+            self.emscripten_library(&format!(
+                "addToLibrary({{\n    ${identifier}Finalization: {finalization_value},\n    \
+                 ${identifier}Finalization__deps: ['$wasm']\n}});"
+            ));
+        } else {
+            self.globals.push_str(&format!(
+                "const {identifier}Finalization = {finalization_value};\n"
+            ));
+        }
 
         // If the class is inspectable, generate `toJSON` and `toString`
         // to expose all readable properties of the class. Otherwise,
@@ -2373,9 +2471,32 @@ if (require('worker_threads').isMainThread) {{
             String::new()
         };
 
-        dst.push_str(&format!(
-            "if (Symbol.dispose) {identifier}.prototype[Symbol.dispose] = {identifier}.prototype.free;\n"
-        ));
+        let dispose_wiring = format!(
+            "if (Symbol.dispose) {identifier}.prototype[Symbol.dispose] = {identifier}.prototype.free;"
+        );
+
+        if hoist {
+            // `dst` is the bare `class {identifier} { ... }` expression; the
+            // `Symbol.dispose` wiring is a follow-up statement, so it goes in
+            // the `__postset`. Deps: the sibling finalization registry and, if
+            // present, the `extends` parent (also a hoisted library symbol).
+            let identifier = identifier.clone();
+            let mut extra_deps: Vec<String> = vec![format!("{identifier}Finalization")];
+            if let Some(parent) = &parent_identifier {
+                extra_deps.push(parent.clone());
+            }
+            let extra_dep_refs: Vec<&str> = extra_deps.iter().map(String::as_str).collect();
+            self.hoist_emscripten_export(
+                &identifier,
+                dst.trim_end(),
+                &extra_dep_refs,
+                &format!("{dispose_wiring} "),
+            );
+            return Ok(());
+        }
+
+        dst.push_str(&dispose_wiring);
+        dst.push('\n');
 
         let ts_comments = if class.generate_typescript {
             Some(class.comments.clone())
@@ -5137,21 +5258,31 @@ addToLibrary({
                             (String::new(), None)
                         };
 
-                        let definition = format!("function {identifier}{code}\n");
-                        define_export(
-                            &mut self.exports,
-                            name,
-                            export.js_namespace.as_deref().unwrap_or_default(),
-                            ExportEntry::Definition(ExportDefinition {
-                                identifier: identifier.clone(),
-                                comments: Some(js_docs),
-                                definition,
-                                ts_definition,
-                                ts_comments,
-                                private: false,
-                                parent_identifier: None,
-                            }),
-                        )?;
+                        if matches!(self.config.mode, OutputMode::Emscripten) && !is_namespaced {
+                            // Hoist into a top-level library symbol so emscripten
+                            // exports it as a named ESM export (instance mode) and
+                            // attaches it to `Module` (factory mode). Namespaced
+                            // functions stay on the `$initBindgen` path below since
+                            // they live under a nested `Module.<ns>...` shape.
+                            let value = format!("function {identifier}{code}");
+                            self.hoist_emscripten_export(&identifier, &value, &[], "");
+                        } else {
+                            let definition = format!("function {identifier}{code}\n");
+                            define_export(
+                                &mut self.exports,
+                                name,
+                                export.js_namespace.as_deref().unwrap_or_default(),
+                                ExportEntry::Definition(ExportDefinition {
+                                    identifier: identifier.clone(),
+                                    comments: Some(js_docs),
+                                    definition,
+                                    ts_definition,
+                                    ts_comments,
+                                    private: false,
+                                    parent_identifier: None,
+                                }),
+                            )?;
+                        }
                     }
                     AuxExportKind::Constructor(class) => {
                         let exported = self.require_class(class);

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -483,32 +483,51 @@ impl<'a> Context<'a> {
     /// `MODULARIZE=instance` (see `self_register_emscripten_exports`).
     ///
     /// `value` is the right-hand side expression — a named function expression
-    /// (`function add(a, b) { ... }`) or class expression (`class Counter
-    /// { ... }`). `extra_deps` lists additional `$`-less library symbols the
-    /// value references directly (e.g. a class's `<id>Finalization` and its
-    /// `extends` parent); every hoisted symbol also depends on `$initBindgen`,
-    /// which aggregates `$wasm` plus all intrinsic deps, so nothing the body
-    /// references by bare name is tree-shaken. `postset_extra` is JS run right
-    /// after the symbol is defined, before it's attached to `Module` (used for
-    /// the class `Symbol.dispose` wiring); the `Module.<id> = <id>` attachment
-    /// keeps factory mode (`MODULARIZE=1`) working.
+    /// (`function add(a, b) { ... }`), class expression (`class Counter
+    /// { ... }`), or `{}` for a namespace root. `extra_deps` lists additional
+    /// `$`-less library symbols the value/postset references (a class's
+    /// `<id>Finalization` and its `extends` parent; a namespace root's leaf
+    /// symbols); every hoisted symbol also depends on `$initBindgen`, which
+    /// aggregates `$wasm` plus all intrinsic deps, so nothing referenced by
+    /// bare name is tree-shaken. `postset_extra` is JS run right after the
+    /// symbol is defined (the class `Symbol.dispose` wiring, or a namespace
+    /// root's nested assembly).
+    ///
+    /// `public` marks a top-level export: it adds the `Module.<id> = <id>`
+    /// attachment (factory mode) and records the name for self-registration
+    /// into `EXPORTED_FUNCTIONS` (named ESM export under instance mode).
+    /// Namespace *leaves* are hoisted with `public = false`: they're reachable
+    /// only through their namespace root, which is the public export.
     fn hoist_emscripten_export(
         &mut self,
         identifier: &str,
         value: &str,
         extra_deps: &[&str],
         postset_extra: &str,
+        public: bool,
     ) {
         let mut deps = vec!["$initBindgen".to_string()];
         deps.extend(extra_deps.iter().map(|d| format!("${d}")));
         let deps_fmt: Vec<String> = deps.iter().map(|d| format!("'{d}'")).collect();
-        let postset = format!("{postset_extra}Module['{identifier}'] = {identifier};");
+        let module_attach = if public {
+            format!("Module['{identifier}'] = {identifier};")
+        } else {
+            String::new()
+        };
+        let postset = format!("{postset_extra}{module_attach}");
+        let postset_field = if postset.is_empty() {
+            String::new()
+        } else {
+            format!(",\n    ${identifier}__postset: {postset:?}")
+        };
         self.emscripten_library(&format!(
             "addToLibrary({{\n    ${identifier}: {value},\n    \
-             ${identifier}__deps: [{}],\n    ${identifier}__postset: {postset:?}\n}});",
+             ${identifier}__deps: [{}]{postset_field}\n}});",
             deps_fmt.join(", "),
         ));
-        self.emscripten_runtime_exports.push(identifier.to_string());
+        if public {
+            self.emscripten_runtime_exports.push(identifier.to_string());
+        }
     }
 
     /// Register a wasm-bindgen-internal helper as an intrinsic.
@@ -2272,13 +2291,14 @@ if (require('worker_threads').isMainThread) {{
             )
         };
 
-        // Non-namespaced classes in emscripten mode are hoisted into top-level
-        // `addToLibrary` symbols (so they become named ESM exports / `Module`
-        // properties); their finalization registry must be a sibling library
-        // symbol rather than a `const` inside `$initBindgen`. Namespaced
-        // classes stay on the `$initBindgen` path (nested `Module.<ns>` shape).
-        let hoist =
-            matches!(self.config.mode, OutputMode::Emscripten) && class.js_namespace.is_none();
+        // In emscripten mode every class is hoisted into top-level
+        // `addToLibrary` symbols, so its finalization registry must be a
+        // sibling library symbol rather than a `const` inside `$initBindgen`.
+        // A non-namespaced class is a *public* export (named ESM export /
+        // `Module.<name>`); a namespaced class is hoisted privately and reached
+        // through its namespace root (the public export).
+        let hoist = matches!(self.config.mode, OutputMode::Emscripten);
+        let is_namespaced = class.js_namespace.is_some();
         let finalization_value = format!(
             "(typeof FinalizationRegistry === 'undefined')\n\
                 ? {{ register: () => {{}}, unregister: () => {{}} }}\n\
@@ -2491,7 +2511,29 @@ if (require('worker_threads').isMainThread) {{
                 dst.trim_end(),
                 &extra_dep_refs,
                 &format!("{dispose_wiring} "),
+                !is_namespaced,
             );
+            // A namespaced class still needs a namespace-tree entry so its root
+            // assembles `ns.Class = <identifier>` and the `.d.ts` namespace
+            // shape resolves `typeof <identifier>`. The declaration itself is
+            // the hoisted library symbol above, so the tree entry carries an
+            // empty definition.
+            if is_namespaced {
+                define_export(
+                    &mut self.exports,
+                    js_name,
+                    class.js_namespace.as_deref().unwrap_or_default(),
+                    ExportEntry::Definition(ExportDefinition {
+                        identifier: class.identifier.clone(),
+                        comments: None,
+                        definition: String::new(),
+                        ts_definition,
+                        ts_comments: None,
+                        private: class.private,
+                        parent_identifier: parent_identifier.clone(),
+                    }),
+                )?;
+            }
             return Ok(());
         }
 
@@ -2669,42 +2711,41 @@ if (require('worker_threads').isMainThread) {{
                     // don't clobber each other.
                     let emit_existing =
                         existing || matches!(self.config.mode, OutputMode::Emscripten);
-                    let ns_dst = self.write_namespace(&identifier, &ns.ns, emit_existing)?;
+                    let mut leaf_ids = Vec::new();
+                    let ns_dst =
+                        self.write_namespace(&identifier, &ns.ns, emit_existing, &mut leaf_ids)?;
                     let ts_dst = if self.config.typescript {
                         Self::write_namespace_ts(&ns.ns, "")?
                     } else {
                         String::new()
                     };
-                    let definition = if matches!(self.config.mode, OutputMode::Emscripten) {
-                        // Attach to `Module.<identifier>` and bind a local
-                        // `const` in one expression so the `ns_dst` lines
-                        // below can write unqualified `identifier.foo.bar`.
-                        format!(
-                            "const {identifier} = Module.{identifier} = Module.{identifier} || {{}};\n{ns_dst}"
-                        )
-                    } else if !existing {
+                    if matches!(self.config.mode, OutputMode::Emscripten) {
+                        // The namespace root is the public export: a top-level
+                        // `{}` library symbol. Its leaves are hoisted private
+                        // library symbols listed as deps (so emscripten emits
+                        // them first), and `ns_dst` assembles the nested shape
+                        // (`root.a.b = <leaf>`) in the root's `__postset`.
+                        if self.config.typescript {
+                            self.typescript
+                                .push_str(&format!("{identifier}: {ts_dst};\n"));
+                        }
+                        let leaf_refs: Vec<&str> = leaf_ids.iter().map(String::as_str).collect();
+                        self.hoist_emscripten_export(
+                            &identifier,
+                            "{}",
+                            &leaf_refs,
+                            ns_dst.trim_end(),
+                            true,
+                        );
+                        continue;
+                    }
+                    let definition = if !existing {
                         format!("const {identifier} = {{}};\n{ns_dst}")
                     } else {
                         self.global(&ns_dst);
                         "".to_string()
                     };
-                    // Emscripten splices `self.typescript` line-by-line into
-                    // `interface BindgenModule { ... }`. The module-scope
-                    // `export let foo: { ... };` form `export_def` would
-                    // produce is invalid inside an interface body (TS1131),
-                    // so push the namespace shape as a plain interface
-                    // member (`foo: { ... };`) directly and hand
-                    // `export_def` an empty `ts_definition` to skip its TS
-                    // emission path.
-                    let ts_definition = if matches!(self.config.mode, OutputMode::Emscripten) {
-                        if self.config.typescript {
-                            self.typescript
-                                .push_str(&format!("{identifier}: {ts_dst};\n"));
-                        }
-                        String::new()
-                    } else {
-                        format!("let {identifier}: {ts_dst};\n")
-                    };
+                    let ts_definition = format!("let {identifier}: {ts_dst};\n");
                     self.export_def(
                         Some(export_name),
                         &ExportDefinition {
@@ -2728,7 +2769,9 @@ if (require('worker_threads').isMainThread) {{
         name: &str,
         namespace: &[(String, ExportEntry)],
         existing: bool,
+        leaf_ids: &mut Vec<String>,
     ) -> Result<String, Error> {
+        let emscripten = matches!(self.config.mode, OutputMode::Emscripten);
         let mut output = String::new();
         for (key, entry) in namespace {
             let full_name = if is_valid_ident(key) {
@@ -2742,10 +2785,19 @@ if (require('worker_threads').isMainThread) {{
                         "{full_name} {}= {{}};\n",
                         if existing { "||" } else { "" }
                     ));
-                    output.push_str(&self.write_namespace(&full_name, &ns.ns, existing)?);
+                    output.push_str(&self.write_namespace(&full_name, &ns.ns, existing, leaf_ids)?);
                 }
                 ExportEntry::Definition(def) => {
-                    self.export_def(None, def);
+                    // In emscripten mode the leaf's declaration is its own
+                    // hoisted library symbol (see `write_class` / the function
+                    // export branch), so we only wire `ns.leaf = <identifier>`
+                    // here and record the symbol so the namespace root can list
+                    // it as a dep. Other modes inline the declaration.
+                    if emscripten {
+                        leaf_ids.push(def.identifier.clone());
+                    } else {
+                        self.export_def(None, def);
+                    }
                     output.push_str(&format!("{full_name} = {};\n", def.identifier));
                 }
             }
@@ -5258,14 +5310,38 @@ addToLibrary({
                             (String::new(), None)
                         };
 
-                        if matches!(self.config.mode, OutputMode::Emscripten) && !is_namespaced {
-                            // Hoist into a top-level library symbol so emscripten
-                            // exports it as a named ESM export (instance mode) and
-                            // attaches it to `Module` (factory mode). Namespaced
-                            // functions stay on the `$initBindgen` path below since
-                            // they live under a nested `Module.<ns>...` shape.
+                        if matches!(self.config.mode, OutputMode::Emscripten) {
+                            // Hoist into a top-level library symbol. Non-namespaced
+                            // functions are public (named ESM export in instance
+                            // mode, `Module.<name>` in factory mode). Namespaced
+                            // functions are hoisted privately and still recorded in
+                            // the namespace tree (with an empty definition, since
+                            // the declaration is now the library symbol) so the
+                            // namespace root assembles `ns.fn = <identifier>`.
                             let value = format!("function {identifier}{code}");
-                            self.hoist_emscripten_export(&identifier, &value, &[], "");
+                            self.hoist_emscripten_export(
+                                &identifier,
+                                &value,
+                                &[],
+                                "",
+                                !is_namespaced,
+                            );
+                            if is_namespaced {
+                                define_export(
+                                    &mut self.exports,
+                                    name,
+                                    export.js_namespace.as_deref().unwrap_or_default(),
+                                    ExportEntry::Definition(ExportDefinition {
+                                        identifier: identifier.clone(),
+                                        comments: None,
+                                        definition: String::new(),
+                                        ts_definition,
+                                        ts_comments,
+                                        private: false,
+                                        parent_identifier: None,
+                                    }),
+                                )?;
+                            }
                         } else {
                             let definition = format!("function {identifier}{code}\n");
                             define_export(
@@ -6420,6 +6496,39 @@ addToLibrary({
             typescript
         };
 
+        if matches!(self.config.mode, OutputMode::Emscripten) {
+            // Hoist the frozen enum object into its own library symbol, like
+            // functions and classes. Non-namespaced public enums become named
+            // ESM exports / `Module.<name>`; namespaced ones are private and
+            // reached through their namespace root.
+            let is_namespaced = enum_.js_namespace.is_some();
+            let value = format!("Object.freeze({{\n{variants}}})");
+            self.hoist_emscripten_export(
+                &identifier,
+                &value,
+                &[],
+                "",
+                !is_namespaced && !enum_.private,
+            );
+            if is_namespaced {
+                define_export(
+                    &mut self.exports,
+                    &enum_.name,
+                    enum_.js_namespace.as_deref().unwrap_or_default(),
+                    ExportEntry::Definition(ExportDefinition {
+                        identifier: identifier.clone(),
+                        comments: None,
+                        definition: String::new(),
+                        ts_definition,
+                        ts_comments: None,
+                        private: enum_.private,
+                        parent_identifier: None,
+                    }),
+                )?;
+            }
+            return Ok(());
+        }
+
         define_export(
             &mut self.exports,
             &enum_.name,
@@ -6471,11 +6580,23 @@ addToLibrary({
 
         if self.used_string_enums.contains(&string_enum.name) {
             // only generate the internal string enum array if it's actually used
-            self.global(&format!(
-                "\nconst __wbindgen_enum_{name} = [{values}];\n",
-                name = string_enum.name,
-                values = variants.join(", ")
-            ));
+            let name = &string_enum.name;
+            let values = variants.join(", ");
+            if matches!(self.config.mode, OutputMode::Emscripten) {
+                // The array is referenced by hoisted function/class bodies, so
+                // it must be a module-scope library symbol (not a `const`
+                // inside `$initBindgen`). Register it as an adapter dep so
+                // `$initBindgen` — which the hoisted symbols depend on — keeps
+                // it alive.
+                self.export_to_emscripten(
+                    &format!("__wbindgen_enum_{name}"),
+                    &format!("[{values}]"),
+                    &[],
+                );
+                self.adapter_deps.insert(format!("__wbindgen_enum_{name}"));
+            } else {
+                self.global(&format!("\nconst __wbindgen_enum_{name} = [{values}];\n"));
+            }
         }
 
         Ok(())

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -195,14 +195,9 @@ pub struct Context<'a> {
     /// before generating each import and diffing afterwards.
     emscripten_import_deps: BTreeMap<ImportId, BTreeSet<String>>,
 
-    /// Clean public export identifiers (free functions, classes, enums, and
-    /// namespace roots) that have been hoisted into top-level `addToLibrary`
-    /// symbols in emscripten mode. Used to self-register them at compile time
-    /// (in `generate_emscripten_wasm_loading`) via `extraLibraryFuncs`
-    /// (force-keep the symbol) and `EXPORTED_FUNCTIONS` (the `export` prefix
-    /// under `MODULARIZE=instance`), so emscripten emits the clean named
-    /// exports itself. Factory-mode `Module.<name>` attachment is handled
-    /// separately by each symbol's `__postset`.
+    /// Public exports hoisted into top-level `addToLibrary` symbols, recorded
+    /// so they can be added to `EXPORTED_FUNCTIONS` in
+    /// `generate_emscripten_wasm_loading`.
     emscripten_runtime_exports: Vec<String>,
 
     /// `true` when the module's memory is a memory64 (wasm64) memory.
@@ -382,9 +377,8 @@ impl<'a> Context<'a> {
             return;
         }
         if matches!(self.config.mode, OutputMode::Emscripten) {
-            // Hoisted classes live in top-level `addToLibrary` symbols, so the
-            // sentinel their constructors compare against must also be a
-            // module-scope library symbol (not a `const` inside `$initBindgen`).
+            // Hoisted classes reference the sentinel at module scope, so it
+            // must be a library symbol rather than a `$initBindgen` local.
             self.export_to_emscripten("__wbgSuperSkip", "Symbol('wasm-bindgen.super-skip')", &[]);
             self.adapter_deps.insert("__wbgSuperSkip".to_string());
         } else {
@@ -479,29 +473,15 @@ impl<'a> Context<'a> {
         ));
     }
 
-    /// Hoist a clean public export (a free function or class) into its own
-    /// top-level `addToLibrary({ $id: <value>, ... })` library symbol so
-    /// emscripten can turn it into a named ESM export under
-    /// `MODULARIZE=instance`. Public symbols are recorded in
-    /// `emscripten_runtime_exports` and self-registered in
-    /// `generate_emscripten_wasm_loading`.
+    /// Hoist a clean export into its own top-level `addToLibrary` symbol so
+    /// emscripten can emit it as a named ESM export.
     ///
-    /// `value` is the right-hand side expression — a named function expression
-    /// (`function add(a, b) { ... }`), class expression (`class Counter
-    /// { ... }`), or `{}` for a namespace root. `extra_deps` lists additional
-    /// `$`-less library symbols the value/postset references (a class's
-    /// `<id>Finalization` and its `extends` parent; a namespace root's leaf
-    /// symbols); every hoisted symbol also depends on `$initBindgen`, which
-    /// aggregates `$wasm` plus all intrinsic deps, so nothing referenced by
-    /// bare name is tree-shaken. `postset_extra` is JS run right after the
-    /// symbol is defined (the class `Symbol.dispose` wiring, or a namespace
-    /// root's nested assembly).
-    ///
-    /// `public` marks a top-level export: it adds the `Module.<id> = <id>`
-    /// attachment (factory mode) and records the name for self-registration
-    /// into `EXPORTED_FUNCTIONS` (named ESM export under instance mode).
-    /// Namespace *leaves* are hoisted with `public = false`: they're reachable
-    /// only through their namespace root, which is the public export.
+    /// `value` is the right-hand side (a function/class expression, or `{}`
+    /// for a namespace root). `extra_deps` lists `$`-less library symbols the
+    /// body references; every symbol also depends on `$initBindgen`.
+    /// `postset_extra` runs after the symbol is defined. `public` adds the
+    /// `Module.<id>` attachment and records the name for `EXPORTED_FUNCTIONS`;
+    /// namespace leaves are hoisted privately (`public = false`).
     fn hoist_emscripten_export(
         &mut self,
         identifier: &str,
@@ -1766,16 +1746,8 @@ if (require('worker_threads').isMainThread) {{
             ""
         };
 
-        // Self-register the hoisted public exports at compile time. emscripten
-        // runs `--js-library` files in the compiler context, so we can push
-        // straight onto its settings. Adding each name to `EXPORTED_FUNCTIONS`
-        // does double duty in `jsifier`: membership forces the `$<id>` library
-        // symbol to be included (`EXPORTED_FUNCTIONS.has(mangleCSymbolName(key))`
-        // at jsifier.mjs:419) *and* makes it prepend `export` to the symbol's
-        // declaration under `MODULARIZE=instance` (jsifier.mjs:802) — a named
-        // ESM export. Factory mode gets `Module.<id>` via the symbol's
-        // `__postset`. So no separate `extraLibraryFuncs` force-keep is needed;
-        // the transitive closure is pulled in by each symbol's `__deps`.
+        // Adding each name to `EXPORTED_FUNCTIONS` forces jsifier to include the
+        // `$<id>` symbol and prefix it with `export` under `MODULARIZE=instance`.
         let self_register = self
             .emscripten_runtime_exports
             .iter()
@@ -2282,12 +2254,8 @@ if (require('worker_threads').isMainThread) {{
             )
         };
 
-        // In emscripten mode every class is hoisted into top-level
-        // `addToLibrary` symbols, so its finalization registry must be a
-        // sibling library symbol rather than a `const` inside `$initBindgen`.
-        // A non-namespaced class is a *public* export (named ESM export /
-        // `Module.<name>`); a namespaced class is hoisted privately and reached
-        // through its namespace root (the public export).
+        // Hoisted classes need their finalization registry as a sibling library
+        // symbol rather than a `$initBindgen` local.
         let hoist = matches!(self.config.mode, OutputMode::Emscripten);
         let is_namespaced = class.js_namespace.is_some();
         let finalization_value = format!(
@@ -2296,14 +2264,9 @@ if (require('worker_threads').isMainThread) {{
                 : new FinalizationRegistry({finalization_callback})"
         );
         if hoist {
-            // Construct the registry in a `__postset` rather than as the
-            // member's value. emscripten evaluates non-string library values
-            // while loading the library file, then re-serializes them from the
-            // live object; a `FinalizationRegistry` instance has no enumerable
-            // own properties, so that round-trip collapses it to `{}` and drops
-            // `register`/`unregister`. `__postset` text is emitted verbatim, so
-            // the initializer source is preserved. The callback closes over the
-            // module-scope `wasm` global.
+            // Build the registry in a `__postset` (emitted verbatim). As a
+            // member value emscripten would re-serialize the live instance and
+            // collapse it to `{}`, losing `register`/`unregister`.
             let postset = format!("{identifier}Finalization = {finalization_value};");
             self.emscripten_library(&format!(
                 "addToLibrary({{\n    ${identifier}Finalization: undefined,\n    \
@@ -2496,21 +2459,16 @@ if (require('worker_threads').isMainThread) {{
         );
 
         if hoist {
-            // `dst` is the bare `class {identifier} { ... }` expression; the
-            // `Symbol.dispose` wiring is a follow-up statement, so it goes in
-            // the `__postset`. Deps: the sibling finalization registry and, if
-            // present, the `extends` parent (also a hoisted library symbol).
+            // The `Symbol.dispose` wiring follows the class expression, so it
+            // goes in the `__postset`. Deps: the finalization registry and any
+            // `extends` parent (also a hoisted symbol).
             let identifier = identifier.clone();
             let mut extra_deps: Vec<String> = vec![format!("{identifier}Finalization")];
             if let Some(parent) = &parent_identifier {
                 extra_deps.push(parent.clone());
             }
             let extra_dep_refs: Vec<&str> = extra_deps.iter().map(String::as_str).collect();
-            // A `#[wasm_bindgen(private)]` class is declared but never exposed
-            // as a runtime value in other modes (`export_def` returns early on
-            // `private`); keep it module-internal here too — hoist it as a
-            // library symbol but don't attach it to `Module` or self-register
-            // it as a named export.
+            // Private classes are hoisted but not exposed as a runtime value.
             self.hoist_emscripten_export(
                 &identifier,
                 dst.trim_end(),
@@ -2518,11 +2476,8 @@ if (require('worker_threads').isMainThread) {{
                 &format!("{dispose_wiring} "),
                 !is_namespaced && !class.private,
             );
-            // A namespaced class still needs a namespace-tree entry so its root
-            // assembles `ns.Class = <identifier>` and the `.d.ts` namespace
-            // shape resolves `typeof <identifier>`. The declaration itself is
-            // the hoisted library symbol above, so the tree entry carries an
-            // empty definition.
+            // Namespaced classes still need a tree entry (empty definition) so
+            // the root assembles `ns.Class = <identifier>`.
             if is_namespaced {
                 define_export(
                     &mut self.exports,
@@ -2725,11 +2680,9 @@ if (require('worker_threads').isMainThread) {{
                         String::new()
                     };
                     if matches!(self.config.mode, OutputMode::Emscripten) {
-                        // The namespace root is the public export: a top-level
-                        // `{}` library symbol. Its leaves are hoisted private
-                        // library symbols listed as deps (so emscripten emits
-                        // them first), and `ns_dst` assembles the nested shape
-                        // (`root.a.b = <leaf>`) in the root's `__postset`.
+                        // The namespace root is a public `{}` symbol; its
+                        // hoisted leaves are deps and `ns_dst` assembles the
+                        // nested shape in the root's `__postset`.
                         if self.config.typescript {
                             self.typescript
                                 .push_str(&format!("{identifier}: {ts_dst};\n"));
@@ -2793,11 +2746,8 @@ if (require('worker_threads').isMainThread) {{
                     output.push_str(&self.write_namespace(&full_name, &ns.ns, existing, leaf_ids)?);
                 }
                 ExportEntry::Definition(def) => {
-                    // In emscripten mode the leaf's declaration is its own
-                    // hoisted library symbol (see `write_class` / the function
-                    // export branch), so we only wire `ns.leaf = <identifier>`
-                    // here and record the symbol so the namespace root can list
-                    // it as a dep. Other modes inline the declaration.
+                    // In emscripten mode the leaf is its own hoisted symbol, so
+                    // record it as a root dep; other modes inline the decl.
                     if emscripten {
                         leaf_ids.push(def.identifier.clone());
                     } else {
@@ -5316,13 +5266,9 @@ addToLibrary({
                         };
 
                         if matches!(self.config.mode, OutputMode::Emscripten) {
-                            // Hoist into a top-level library symbol. Non-namespaced
-                            // functions are public (named ESM export in instance
-                            // mode, `Module.<name>` in factory mode). Namespaced
-                            // functions are hoisted privately and still recorded in
-                            // the namespace tree (with an empty definition, since
-                            // the declaration is now the library symbol) so the
-                            // namespace root assembles `ns.fn = <identifier>`.
+                            // Hoist into a library symbol. Namespaced functions
+                            // are hoisted privately and recorded in the tree
+                            // (empty definition) so the root wires `ns.fn`.
                             let value = format!("function {identifier}{code}");
                             self.hoist_emscripten_export(
                                 &identifier,
@@ -6502,16 +6448,11 @@ addToLibrary({
         };
 
         if matches!(self.config.mode, OutputMode::Emscripten) {
-            // Hoist the frozen enum object into its own library symbol, like
-            // functions and classes. Non-namespaced public enums become named
-            // ESM exports / `Module.<name>`; namespaced ones are private and
-            // reached through their namespace root.
+            // Hoist the frozen enum into a library symbol like functions and
+            // classes.
             let is_namespaced = enum_.js_namespace.is_some();
-            // String-valued member so the `Object.freeze(...)` source is
-            // emitted verbatim. As a live value it would be evaluated while
-            // loading the library and re-serialized to a plain object, losing
-            // `Object.freeze` (see the finalization-registry note in
-            // `write_class`).
+            // String-valued so the `Object.freeze(...)` source is emitted
+            // verbatim (see the finalization-registry note in `write_class`).
             let value = format!("{:?}", format!("Object.freeze({{\n{variants}}})"));
             self.hoist_emscripten_export(
                 &identifier,
@@ -6593,11 +6534,8 @@ addToLibrary({
             let name = &string_enum.name;
             let values = variants.join(", ");
             if matches!(self.config.mode, OutputMode::Emscripten) {
-                // The array is referenced by hoisted function/class bodies, so
-                // it must be a module-scope library symbol (not a `const`
-                // inside `$initBindgen`). Register it as an adapter dep so
-                // `$initBindgen` — which the hoisted symbols depend on — keeps
-                // it alive.
+                // Referenced by hoisted bodies at module scope, so it must be a
+                // library symbol; register as an adapter dep to keep it alive.
                 self.export_to_emscripten(
                     &format!("__wbindgen_enum_{name}"),
                     &format!("[{values}]"),

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -195,12 +195,14 @@ pub struct Context<'a> {
     /// before generating each import and diffing afterwards.
     emscripten_import_deps: BTreeMap<ImportId, BTreeSet<String>>,
 
-    /// Clean public export identifiers (free functions and classes) that have
-    /// been hoisted into top-level `addToLibrary` symbols in emscripten mode.
-    /// Used to self-register them at compile time via `EXPORTED_RUNTIME_METHODS`
-    /// (inclusion + `Module.<name>` in factory mode) and `EXPORTED_FUNCTIONS`
-    /// (the `export` prefix under `MODULARIZE=instance`), so emscripten emits
-    /// the clean named exports itself.
+    /// Clean public export identifiers (free functions, classes, enums, and
+    /// namespace roots) that have been hoisted into top-level `addToLibrary`
+    /// symbols in emscripten mode. Used to self-register them at compile time
+    /// (in `generate_emscripten_wasm_loading`) via `extraLibraryFuncs`
+    /// (force-keep the symbol) and `EXPORTED_FUNCTIONS` (the `export` prefix
+    /// under `MODULARIZE=instance`), so emscripten emits the clean named
+    /// exports itself. Factory-mode `Module.<name>` attachment is handled
+    /// separately by each symbol's `__postset`.
     emscripten_runtime_exports: Vec<String>,
 
     /// `true` when the module's memory is a memory64 (wasm64) memory.
@@ -480,7 +482,9 @@ impl<'a> Context<'a> {
     /// Hoist a clean public export (a free function or class) into its own
     /// top-level `addToLibrary({ $id: <value>, ... })` library symbol so
     /// emscripten can turn it into a named ESM export under
-    /// `MODULARIZE=instance` (see `self_register_emscripten_exports`).
+    /// `MODULARIZE=instance`. Public symbols are recorded in
+    /// `emscripten_runtime_exports` and self-registered in
+    /// `generate_emscripten_wasm_loading`.
     ///
     /// `value` is the right-hand side expression — a named function expression
     /// (`function add(a, b) { ... }`), class expression (`class Counter
@@ -2305,19 +2309,19 @@ if (require('worker_threads').isMainThread) {{
                 : new FinalizationRegistry({finalization_callback})"
         );
         if hoist {
-            // Emit the registry's *source* as a string-valued library member.
-            // emscripten evaluates non-string library values while loading the
-            // library file, then re-serializes them from the live object. A
-            // `FinalizationRegistry` instance has no enumerable own properties,
-            // so that round-trip would collapse it to `{}` and drop
-            // `register`/`unregister`. A string member is emitted verbatim as
-            // `var XFinalization = <source>` (same as intrinsic values like
-            // `$cachedTextDecoder: "new TextDecoder()"`). The callback closes
-            // over the module-scope `wasm` global.
-            let value_lit = format!("{finalization_value:?}");
+            // Construct the registry in a `__postset` rather than as the
+            // member's value. emscripten evaluates non-string library values
+            // while loading the library file, then re-serializes them from the
+            // live object; a `FinalizationRegistry` instance has no enumerable
+            // own properties, so that round-trip collapses it to `{}` and drops
+            // `register`/`unregister`. `__postset` text is emitted verbatim, so
+            // the initializer source is preserved. The callback closes over the
+            // module-scope `wasm` global.
+            let postset = format!("{identifier}Finalization = {finalization_value};");
             self.emscripten_library(&format!(
-                "addToLibrary({{\n    ${identifier}Finalization: {value_lit},\n    \
-                 ${identifier}Finalization__deps: ['$wasm']\n}});"
+                "addToLibrary({{\n    ${identifier}Finalization: undefined,\n    \
+                 ${identifier}Finalization__deps: ['$wasm'],\n    \
+                 ${identifier}Finalization__postset: {postset:?}\n}});"
             ));
         } else {
             self.globals.push_str(&format!(
@@ -2515,12 +2519,17 @@ if (require('worker_threads').isMainThread) {{
                 extra_deps.push(parent.clone());
             }
             let extra_dep_refs: Vec<&str> = extra_deps.iter().map(String::as_str).collect();
+            // A `#[wasm_bindgen(private)]` class is declared but never exposed
+            // as a runtime value in other modes (`export_def` returns early on
+            // `private`); keep it module-internal here too — hoist it as a
+            // library symbol but don't attach it to `Module` or self-register
+            // it as a named export.
             self.hoist_emscripten_export(
                 &identifier,
                 dst.trim_end(),
                 &extra_dep_refs,
                 &format!("{dispose_wiring} "),
-                !is_namespaced,
+                !is_namespaced && !class.private,
             );
             // A namespaced class still needs a namespace-tree entry so its root
             // assembles `ns.Class = <identifier>` and the `.d.ts` namespace

--- a/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
+++ b/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
@@ -2,6 +2,9 @@
     var elem = document.querySelector('#output');
     window.extraLibraryFuncs = [];
     window.mergedLibrary = {};
+    // emscripten settings the library file self-registers into at compile time.
+    window.EXPORTED_FUNCTIONS = new Set();
+    window.EXPORTED_RUNTIME_METHODS = new Set();
 
     window.wasmExports = {
         __wbindgen_start: () => {},
@@ -22,8 +25,26 @@
             if (typeof window.mergedLibrary.$initBindgen !== 'function') {
                 throw new Error("$initBindgen not found in the merged library.");
             }
-            // Execute the initialization
+            // emscripten emits each `$Name` library symbol as a module-scope
+            // `var Name = <value>`. Simulate that so the hoisted exports and
+            // their `__postset` wiring (which reference bare names) resolve.
+            for (const key of Object.keys(window.mergedLibrary)) {
+                const name = key.slice(1);
+                if (key.startsWith('$') && !key.includes('__') && window[name] === undefined) {
+                    window[name] = window.mergedLibrary[key];
+                }
+            }
+            // Execute the initialization (assigns `wasm`, runs start).
             window.mergedLibrary.$initBindgen();
+            // Run each symbol's `__postset` — this is where exports attach to
+            // `Module` (factory mode) and namespace roots are assembled. Skip
+            // emscripten's own `$initBindgen__postset` (an `addOnInit(...)`
+            // registration that isn't modelled by this harness).
+            for (const key of Object.keys(window.mergedLibrary)) {
+                if (key.endsWith('__postset') && key !== '$initBindgen__postset') {
+                    (0, eval)(window.mergedLibrary[key]);
+                }
+            }
         } catch (e) {
             elem.textContent += 'test setup failed: ' + e;
             return;
@@ -46,6 +67,13 @@
             }
             if (typeof Module.Interval !== 'function') {
                 return { status: false, e: 'test result: Interval is not found in Module' };
+            }
+            // The hoisted exports must self-register so emscripten emits them as
+            // named ESM exports under -sMODULARIZE=instance.
+            for (const name of ['hello', 'Interval']) {
+                if (!window.EXPORTED_FUNCTIONS.has(name)) {
+                    return { status: false, e: `test result: ${name} not registered in EXPORTED_FUNCTIONS` };
+                }
             }
 
             // Search the accumulated library object for the specific imports

--- a/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
+++ b/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
@@ -24,33 +24,16 @@
             if (typeof window.mergedLibrary.$initBindgen !== 'function') {
                 throw new Error("$initBindgen not found in the merged library.");
             }
-            // emscripten emits each `$Name` library symbol as a module-scope
-            // `var Name = <value>`. Simulate that so the hoisted exports and
-            // their `__postset` wiring (which reference bare names) resolve.
-            // A symbol's name may itself contain `__` (e.g. `__wbgtest_*` or a
-            // namespaced `app__math__Calc`), so exclude only the `__deps` /
-            // `__postset` decorator keys, which are suffixes.
-            for (const key of Object.keys(window.mergedLibrary)) {
-                const name = key.slice(1);
-                if (
-                    key.startsWith('$') &&
-                    !key.endsWith('__deps') &&
-                    !key.endsWith('__postset') &&
-                    window[name] === undefined
-                ) {
-                    window[name] = window.mergedLibrary[key];
-                }
-            }
             // Execute the initialization (assigns `wasm`, runs start).
             window.mergedLibrary.$initBindgen();
-            // Run each symbol's `__postset` — this is where exports attach to
-            // `Module` (factory mode) and namespace roots are assembled. Skip
-            // emscripten's own `$initBindgen__postset` (an `addOnInit(...)`
-            // registration that isn't modelled by this harness).
-            for (const key of Object.keys(window.mergedLibrary)) {
-                if (key.endsWith('__postset') && key !== '$initBindgen__postset') {
-                    (0, eval)(window.mergedLibrary[key]);
-                }
+            // Each clean export is a hoisted `$<name>` library symbol that
+            // self-registers into `EXPORTED_FUNCTIONS`. Under emscripten that
+            // makes it a named ESM export (instance mode) and, via the symbol's
+            // `Module['<name>'] = <name>` __postset, a `Module` property
+            // (factory mode). Simulate the latter directly from the symbols
+            // rather than evaluating postset source.
+            for (const name of window.EXPORTED_FUNCTIONS) {
+                window.Module[name] = window.mergedLibrary['$' + name];
             }
         } catch (e) {
             elem.textContent += 'test setup failed: ' + e;

--- a/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
+++ b/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
@@ -28,9 +28,17 @@
             // emscripten emits each `$Name` library symbol as a module-scope
             // `var Name = <value>`. Simulate that so the hoisted exports and
             // their `__postset` wiring (which reference bare names) resolve.
+            // A symbol's name may itself contain `__` (e.g. `__wbgtest_*` or a
+            // namespaced `app__math__Calc`), so exclude only the `__deps` /
+            // `__postset` decorator keys, which are suffixes.
             for (const key of Object.keys(window.mergedLibrary)) {
                 const name = key.slice(1);
-                if (key.startsWith('$') && !key.includes('__') && window[name] === undefined) {
+                if (
+                    key.startsWith('$') &&
+                    !key.endsWith('__deps') &&
+                    !key.endsWith('__postset') &&
+                    window[name] === undefined
+                ) {
                     window[name] = window.mergedLibrary[key];
                 }
             }

--- a/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
+++ b/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
@@ -2,9 +2,8 @@
     var elem = document.querySelector('#output');
     window.extraLibraryFuncs = [];
     window.mergedLibrary = {};
-    // emscripten settings the library file self-registers into at compile time.
+    // emscripten setting the library file self-registers into at compile time.
     window.EXPORTED_FUNCTIONS = new Set();
-    window.EXPORTED_RUNTIME_METHODS = new Set();
 
     window.wasmExports = {
         __wbindgen_start: () => {},

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2469,9 +2469,16 @@ fn emscripten_exports_hoisted_to_library_symbols() {
             "{name} should be self-registered into EXPORTED_FUNCTIONS:\n{lib}"
         );
     }
+    // No separate force-keep: EXPORTED_FUNCTIONS membership already includes
+    // each public symbol (jsifier.mjs:419), and the finalization registry is
+    // retained purely as a dependency of its class.
     assert!(
-        lib.contains("extraLibraryFuncs.push('$add', '$Color', '$Counter')"),
-        "hoisted exports should be force-kept via extraLibraryFuncs:\n{lib}"
+        !lib.contains("extraLibraryFuncs.push('$add'"),
+        "public exports should rely on EXPORTED_FUNCTIONS, not a redundant force-keep:\n{lib}"
+    );
+    assert!(
+        lib.contains("$Counter__deps: ['$initBindgen', '$CounterFinalization']"),
+        "Counter must keep its finalization registry via __deps:\n{lib}"
     );
     // A private class is hoisted but must NOT be exposed as a public export.
     assert!(

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2368,6 +2368,21 @@ fn emscripten_exports_hoisted_to_library_symbols() {
                 Green = 1,
             }
 
+            // A private class must stay module-internal: hoisted, but not
+            // attached to Module nor self-registered as a public export.
+            #[wasm_bindgen(private)]
+            pub struct Secret {
+                value: i32,
+            }
+
+            #[wasm_bindgen]
+            impl Secret {
+                #[wasm_bindgen(constructor)]
+                pub fn new() -> Secret {
+                    Secret { value: 0 }
+                }
+            }
+
             #[wasm_bindgen]
             pub struct Counter {
                 value: i32,
@@ -2437,11 +2452,15 @@ fn emscripten_exports_hoisted_to_library_symbols() {
         lib.contains(r#"$Color: "Object.freeze("#),
         "Color enum should be a hoisted string-valued library symbol:\n{lib}"
     );
-    // The finalization registry is likewise emitted as source via a string
-    // member, so it survives emscripten's evaluate-then-reserialize.
+    // The finalization registry is constructed in a __postset (emitted
+    // verbatim) so the live FinalizationRegistry isn't evaluated then
+    // re-serialized to `{}` by emscripten.
     assert!(
-        lib.contains(r#"$CounterFinalization: "(typeof FinalizationRegistry"#),
-        "CounterFinalization should be emitted as source (string member):\n{lib}"
+        lib.contains("$CounterFinalization: undefined,")
+            && lib.contains(
+                r#"$CounterFinalization__postset: "CounterFinalization = (typeof FinalizationRegistry"#
+            ),
+        "CounterFinalization should be constructed in a __postset:\n{lib}"
     );
     // Self-registration so emscripten exports them itself.
     for name in ["add", "Counter", "Color"] {
@@ -2453,6 +2472,19 @@ fn emscripten_exports_hoisted_to_library_symbols() {
     assert!(
         lib.contains("extraLibraryFuncs.push('$add', '$Color', '$Counter')"),
         "hoisted exports should be force-kept via extraLibraryFuncs:\n{lib}"
+    );
+    // A private class is hoisted but must NOT be exposed as a public export.
+    assert!(
+        lib.contains("$Secret: class Secret"),
+        "private class should still be hoisted as a library symbol:\n{lib}"
+    );
+    assert!(
+        !lib.contains("EXPORTED_FUNCTIONS.add('Secret')"),
+        "private class must not self-register as a named export:\n{lib}"
+    );
+    assert!(
+        !lib.contains("Module['Secret']"),
+        "private class must not attach to Module:\n{lib}"
     );
     // They must no longer be inlined inside the $initBindgen closure.
     let init = lib

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2430,10 +2430,18 @@ fn emscripten_exports_hoisted_to_library_symbols() {
         lib.contains("$Counter__deps: ['$initBindgen', '$CounterFinalization']"),
         "Counter should depend on $initBindgen + its finalizer:\n{lib}"
     );
-    // Enum hoisted to its own frozen-object library symbol.
+    // Enum hoisted to its own library symbol. The `Object.freeze(...)` source
+    // is a string-valued member so emscripten emits it verbatim (a live value
+    // would be re-serialized to a plain object, losing the freeze).
     assert!(
-        lib.contains("$Color: Object.freeze("),
-        "Color enum should be a hoisted library symbol:\n{lib}"
+        lib.contains(r#"$Color: "Object.freeze("#),
+        "Color enum should be a hoisted string-valued library symbol:\n{lib}"
+    );
+    // The finalization registry is likewise emitted as source via a string
+    // member, so it survives emscripten's evaluate-then-reserialize.
+    assert!(
+        lib.contains(r#"$CounterFinalization: "(typeof FinalizationRegistry"#),
+        "CounterFinalization should be emitted as source (string member):\n{lib}"
     );
     // Self-registration so emscripten exports them itself.
     for name in ["add", "Counter", "Color"] {

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2363,6 +2363,12 @@ fn emscripten_exports_hoisted_to_library_symbols() {
             }
 
             #[wasm_bindgen]
+            pub enum Color {
+                Red = 0,
+                Green = 1,
+            }
+
+            #[wasm_bindgen]
             pub struct Counter {
                 value: i32,
             }
@@ -2424,14 +2430,20 @@ fn emscripten_exports_hoisted_to_library_symbols() {
         lib.contains("$Counter__deps: ['$initBindgen', '$CounterFinalization']"),
         "Counter should depend on $initBindgen + its finalizer:\n{lib}"
     );
-    // Self-registration so emscripten exports them itself.
+    // Enum hoisted to its own frozen-object library symbol.
     assert!(
-        lib.contains("EXPORTED_FUNCTIONS.add('add');")
-            && lib.contains("EXPORTED_FUNCTIONS.add('Counter');"),
-        "exports should be self-registered into EXPORTED_FUNCTIONS:\n{lib}"
+        lib.contains("$Color: Object.freeze("),
+        "Color enum should be a hoisted library symbol:\n{lib}"
     );
+    // Self-registration so emscripten exports them itself.
+    for name in ["add", "Counter", "Color"] {
+        assert!(
+            lib.contains(&format!("EXPORTED_FUNCTIONS.add('{name}');")),
+            "{name} should be self-registered into EXPORTED_FUNCTIONS:\n{lib}"
+        );
+    }
     assert!(
-        lib.contains("extraLibraryFuncs.push('$add', '$Counter')"),
+        lib.contains("extraLibraryFuncs.push('$add', '$Color', '$Counter')"),
         "hoisted exports should be force-kept via extraLibraryFuncs:\n{lib}"
     );
     // They must no longer be inlined inside the $initBindgen closure.

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2345,6 +2345,110 @@ fn emscripten_namespaced_exports_valid_ts() {
     }
 }
 
+#[test]
+fn emscripten_exports_hoisted_to_library_symbols() {
+    // Non-namespaced clean exports are hoisted out of the `$initBindgen`
+    // closure into top-level `addToLibrary` symbols and self-registered, so
+    // emscripten emits them as named ESM exports (instance mode) / `Module`
+    // properties (factory mode) on its own.
+    let mut project = Project::new("emscripten_exports_hoisted_to_library_symbols");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub fn add(a: i32, b: i32) -> i32 {
+                a + b
+            }
+
+            #[wasm_bindgen]
+            pub struct Counter {
+                value: i32,
+            }
+
+            #[wasm_bindgen]
+            impl Counter {
+                #[wasm_bindgen(constructor)]
+                pub fn new(start: i32) -> Counter {
+                    Counter { value: start }
+                }
+                pub fn inc(&mut self) -> i32 {
+                    self.value += 1;
+                    self.value
+                }
+            }
+        "#,
+    );
+
+    let built = project.build();
+    let mut module = ModuleConfig::new().parse_file(&built).unwrap();
+    module.customs.add(RawCustomSection {
+        name: "__wasm_bindgen_emscripten_marker".into(),
+        data: vec![1],
+    });
+    let emscripten_wasm = project.root.join("emscripten_input.wasm");
+    module.emit_wasm_file(&emscripten_wasm).unwrap();
+
+    let out_dir = project.root.join("pkg-emscripten");
+    fs::create_dir_all(&out_dir).unwrap();
+    wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir.as_os_str(),
+        emscripten_wasm.as_os_str(),
+    ])
+    .unwrap();
+
+    let lib = fs::read_to_string(out_dir.join("library_bindgen.js")).unwrap();
+
+    // Free function hoisted to its own library symbol with Module attachment.
+    assert!(
+        lib.contains("$add: function add("),
+        "add should be a hoisted library function:\n{lib}"
+    );
+    assert!(
+        lib.contains("$add__postset: \"Module['add'] = add;\""),
+        "add should attach to Module via __postset:\n{lib}"
+    );
+    // Class + its finalization registry hoisted to library symbols.
+    assert!(
+        lib.contains("$Counter: class Counter"),
+        "Counter should be a hoisted library class:\n{lib}"
+    );
+    assert!(
+        lib.contains("$CounterFinalization:"),
+        "Counter's finalization registry should be a sibling library symbol:\n{lib}"
+    );
+    assert!(
+        lib.contains("$Counter__deps: ['$initBindgen', '$CounterFinalization']"),
+        "Counter should depend on $initBindgen + its finalizer:\n{lib}"
+    );
+    // Self-registration so emscripten exports them itself.
+    assert!(
+        lib.contains("EXPORTED_FUNCTIONS.add('add');")
+            && lib.contains("EXPORTED_FUNCTIONS.add('Counter');"),
+        "exports should be self-registered into EXPORTED_FUNCTIONS:\n{lib}"
+    );
+    assert!(
+        lib.contains("extraLibraryFuncs.push('$add', '$Counter')"),
+        "hoisted exports should be force-kept via extraLibraryFuncs:\n{lib}"
+    );
+    // They must no longer be inlined inside the $initBindgen closure.
+    let init = lib
+        .split_once("$initBindgen: () =>")
+        .map(|(_, rest)| rest)
+        .expect("$initBindgen present");
+    let init_body = init
+        .split_once("\n            });")
+        .map(|(b, _)| b)
+        .unwrap_or(init);
+    assert!(
+        !init_body.contains("class Counter") && !init_body.contains("function add("),
+        "exports must not be inlined in $initBindgen:\n{init_body}"
+    );
+}
+
 /// Look up an executable on `PATH`. Used so the test can opportunistically
 /// validate the generated .d.ts with `tsc` without hard-requiring it.
 fn which(name: &str) -> Option<PathBuf> {

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2347,10 +2347,8 @@ fn emscripten_namespaced_exports_valid_ts() {
 
 #[test]
 fn emscripten_exports_hoisted_to_library_symbols() {
-    // Non-namespaced clean exports are hoisted out of the `$initBindgen`
-    // closure into top-level `addToLibrary` symbols and self-registered, so
-    // emscripten emits them as named ESM exports (instance mode) / `Module`
-    // properties (factory mode) on its own.
+    // Clean exports are hoisted into top-level `addToLibrary` symbols and
+    // self-registered so emscripten emits them itself.
     let mut project = Project::new("emscripten_exports_hoisted_to_library_symbols");
     project.file(
         "src/lib.rs",
@@ -2445,16 +2443,12 @@ fn emscripten_exports_hoisted_to_library_symbols() {
         lib.contains("$Counter__deps: ['$initBindgen', '$CounterFinalization']"),
         "Counter should depend on $initBindgen + its finalizer:\n{lib}"
     );
-    // Enum hoisted to its own library symbol. The `Object.freeze(...)` source
-    // is a string-valued member so emscripten emits it verbatim (a live value
-    // would be re-serialized to a plain object, losing the freeze).
+    // Enum hoisted as a string-valued symbol so the freeze is emitted verbatim.
     assert!(
         lib.contains(r#"$Color: "Object.freeze("#),
         "Color enum should be a hoisted string-valued library symbol:\n{lib}"
     );
-    // The finalization registry is constructed in a __postset (emitted
-    // verbatim) so the live FinalizationRegistry isn't evaluated then
-    // re-serialized to `{}` by emscripten.
+    // Finalization registry built in a __postset to avoid re-serialization.
     assert!(
         lib.contains("$CounterFinalization: undefined,")
             && lib.contains(
@@ -2469,9 +2463,7 @@ fn emscripten_exports_hoisted_to_library_symbols() {
             "{name} should be self-registered into EXPORTED_FUNCTIONS:\n{lib}"
         );
     }
-    // No separate force-keep: EXPORTED_FUNCTIONS membership already includes
-    // each public symbol (jsifier.mjs:419), and the finalization registry is
-    // retained purely as a dependency of its class.
+    // No force-keep: EXPORTED_FUNCTIONS membership already retains each symbol.
     assert!(
         !lib.contains("extraLibraryFuncs.push('$add'"),
         "public exports should rely on EXPORTED_FUNCTIONS, not a redundant force-keep:\n{lib}"

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2500,6 +2500,87 @@ fn emscripten_exports_hoisted_to_library_symbols() {
     );
 }
 
+#[test]
+fn emscripten_user_imports_are_prefixed() {
+    // User module imports land in the `--extern-pre-js` sidecar at module top
+    // level alongside emcc's runtime, and the imported names come verbatim from
+    // the user's JS. They're prefixed with `__wbg_` so arbitrary names (e.g. a
+    // function literally called `Module`) can't collide with emcc globals. The
+    // public export (`run`) stays unprefixed.
+    let mut project = Project::new("emscripten_user_imports_are_prefixed");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            // A name that would collide with emscripten's runtime if unprefixed.
+            #[wasm_bindgen(module = "imports")]
+            extern "C" {
+                fn Module() -> i32;
+            }
+
+            #[wasm_bindgen(inline_js = "export function snippet_value() { return 7; }")]
+            extern "C" {
+                fn snippet_value() -> i32;
+            }
+
+            #[wasm_bindgen]
+            pub fn run() -> i32 {
+                Module() + snippet_value()
+            }
+        "#,
+    );
+
+    let built = project.build();
+    let mut module = ModuleConfig::new().parse_file(&built).unwrap();
+    module.customs.add(RawCustomSection {
+        name: "__wasm_bindgen_emscripten_marker".into(),
+        data: vec![1],
+    });
+    let emscripten_wasm = project.root.join("emscripten_input.wasm");
+    module.emit_wasm_file(&emscripten_wasm).unwrap();
+
+    let out_dir = project.root.join("pkg-emscripten");
+    fs::create_dir_all(&out_dir).unwrap();
+    wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir.as_os_str(),
+        emscripten_wasm.as_os_str(),
+    ])
+    .unwrap();
+
+    // ESM imports live in the extern-pre sidecar, aliased to a `__wbg_` local.
+    let extern_pre = fs::read_to_string(out_dir.join("library_bindgen.extern-pre.js")).unwrap();
+    assert!(
+        extern_pre.contains("Module as __wbg_Module"),
+        "module import should be aliased to a __wbg_-prefixed local:\n{extern_pre}"
+    );
+    assert!(
+        extern_pre.contains("snippet_value as __wbg_snippet_value"),
+        "inline-js snippet import should be aliased to a __wbg_-prefixed local:\n{extern_pre}"
+    );
+    // The bare user name must NOT bind at module scope (no collision with emcc).
+    assert!(
+        !extern_pre.contains("import { Module }")
+            && !extern_pre.contains("import { Module,")
+            && !extern_pre.contains(", Module }"),
+        "the unprefixed `Module` must not be imported into module scope:\n{extern_pre}"
+    );
+
+    // The library shims reference the prefixed locals.
+    let lib = fs::read_to_string(out_dir.join("library_bindgen.js")).unwrap();
+    assert!(
+        lib.contains("__wbg_Module(") && lib.contains("__wbg_snippet_value("),
+        "shims should call the prefixed import locals:\n{lib}"
+    );
+    // The public export keeps its clean name.
+    assert!(
+        lib.contains("$run: function run("),
+        "the public export `run` must stay unprefixed:\n{lib}"
+    );
+}
+
 /// Look up an executable on `PATH`. Used so the test can opportunistically
 /// validate the generated .d.ts with `tsc` without hard-requiring it.
 fn which(name: &str) -> Option<PathBuf> {


### PR DESCRIPTION
This makes the clean wasm-bindgen API reachable for emscripten builds without any sidecar files, by letting emscripten emit the exports itself. It supersedes the sidecar approaches in #5207 (post-js) and #5208 (marker comment), which can be closed.

Background: under `-sMODULARIZE=instance` the consumer receives ESM named exports + a default `init`, never `Module`, so the `Module.<name> = <name>;` writes wasm-bindgen put inside the `$initBindgen` init closure were dead. Those wrappers couldn't be plain top-level declarations because e.g. `Counter` closes over a `FinalizationRegistry` built at init.

The fix follows how emscripten already exports JS library symbols: a `--js-library` runs in the compiler context, and in instance mode `jsifier` prepends `export` to any `$`-prefixed library symbol whose name is in `EXPORTED_FUNCTIONS` (which also forces its inclusion). So every clean export is hoisted into its own top-level `addToLibrary` symbol and self-registered.

Before, inside `$initBindgen`:

```js
$initBindgen: () => {
  wasm = wasmExports;
  const CounterFinalization = new FinalizationRegistry(...);
  class Counter { ... }
  Module.Counter = Counter;          // dead under instance mode
  function add(a, b) { return wasm.add(a, b); }
  Module.add = add;                  // dead under instance mode
}
```

After, as top-level library symbols:

```js
addToLibrary({
  $add: function add(a, b) { return wasm.add(a, b); },
  $add__deps: ['$initBindgen'],
  $add__postset: "Module['add'] = add;",
});
addToLibrary({
  $CounterFinalization: undefined,
  $CounterFinalization__deps: ['$wasm'],
  $CounterFinalization__postset: "CounterFinalization = (typeof FinalizationRegistry === 'undefined') ? {...} : new FinalizationRegistry(ptr => wasm.__wbg_counter_free(ptr, 1));",
});
addToLibrary({
  $Counter: class Counter { ... },
  $Counter__deps: ['$initBindgen', '$CounterFinalization'],
  $Counter__postset: "if (Symbol.dispose) Counter.prototype[Symbol.dispose] = Counter.prototype.free; Module['Counter'] = Counter;",
});

EXPORTED_FUNCTIONS.add('add');
EXPORTED_FUNCTIONS.add('Counter');
```

giving consumers:

```js
import init, { add, Counter } from './out.mjs';
await init();
add(17, 25);            // 42
new Counter(40).inc();  // 41
```

What's covered:

* **Functions, classes, enums** are hoisted; each depends on `$initBindgen` (which aggregates `$wasm` + all intrinsic deps, so nothing is tree-shaken). Factory-mode `Module.<name>` attachment is done in each symbol's `__postset`; instance-mode named export comes from `EXPORTED_FUNCTIONS`. No separate `extraLibraryFuncs` force-keep is needed — `EXPORTED_FUNCTIONS` membership already forces inclusion.
* **`#[wasm_bindgen(private)]`** classes/enums are hoisted but not attached to `Module` or self-registered (they stay module-internal, matching every other output mode).
* **Source-preservation**: `FinalizationRegistry` instances and `Object.freeze(...)` enums are emitted via `__postset` / string members, because emscripten evaluates the `--js-library` and re-serializes live values (a `FinalizationRegistry` would collapse to `{}`).
* **Namespaced exports** (`js_namespace`): the namespace root (e.g. `app`) is the public export — a `{}` library symbol whose private leaf symbols are listed in its `__deps`, with the nested shape (`app.math.Calc = ...`) assembled in the root's `__postset`.
* **User module / inline-js imports**: these were silently dropped in emscripten (the direct-import elision points a wasm import straight at the user's module, which emcc can't resolve — it only resolves against `env`). They're now wired as `addToLibrary` shims that call the ESM-imported binding, and those bindings are `__wbg_`-prefixed (`import { Module as __wbg_Module } from 'imports'`) so user-chosen names can't collide with emcc runtime globals.
* The `__wbgSuperSkip` subclass sentinel and used string-enum tables are hoisted to library symbols too, since hoisted bodies reference them at module scope.

Testing:

* New CLI codegen tests assert the generated `library_bindgen.js` shape: hoisting + `__postset` Module attachment + `EXPORTED_FUNCTIONS` self-registration + no `$initBindgen` inlining (`emscripten_exports_hoisted_to_library_symbols`); private-class exclusion; the namespaced `.d.ts`/shape (`emscripten_namespaced_exports_valid_ts`, validated with `tsc --strict`); and module + inline-js import prefixing (`emscripten_user_imports_are_prefixed`).
* The wasm-bindgen-test-runner emscripten harness was updated to model the new mechanism (symbols self-register into `EXPORTED_FUNCTIONS` and attach to `Module`), and passes in CI.
* Validated end-to-end against a real `emcc` link (`-sMODULARIZE=instance`): `add(17,25) === 42`, `Counter` exported and usable, finalizers intact.
