### PR TITLE
Fix compilation with (feature = "std", panic = "unwind", target_feature = "atomics") plus prevent a memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 * Relaxed alignment requirement for 8-byte types.
   [#5204](https://github.com/wasm-bindgen/wasm-bindgen/pull/5204)
+* Fixed compilation with `(feature = "std", panic = "unwind", target_feature = "atomics")`.
+  [#5214](https://github.com/wasm-bindgen/wasm-bindgen/pull/5214)
 
 * Headless Chrome/Edge tests now surface the WebDriver's own error message when
   session creation fails (e.g. a chromedriver/Chrome version mismatch) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@
 
 * Relaxed alignment requirement for 8-byte types.
   [#5204](https://github.com/wasm-bindgen/wasm-bindgen/pull/5204)
-* Fixed compilation with `(feature = "std", panic = "unwind", target_feature = "atomics")`.
+* Fixed compilation with `(feature = "std", panic = "unwind", target_feature = "atomics")`
+  and prevented a `Task` leak when a future unwinds out of `poll` (via a Rust
+  panic or a foreign JS exception) in both the single-threaded and
+  multi-threaded executors.
   [#5214](https://github.com/wasm-bindgen/wasm-bindgen/pull/5214)
 
 * Headless Chrome/Edge tests now surface the WebDriver's own error message when

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -1025,6 +1025,153 @@ describe('nested unreachable', () => {
         .success();
 }
 
+/// Regression test for a `Task` leak in the futures executor: when a spawned
+/// future panics during `poll`, the executor must drop the future (and
+/// everything it owns) rather than leaving it alive via the
+/// `Task -> Inner -> future -> Waker -> Rc<Task>` reference cycle. The panic
+/// propagates out of the microtask that drives the first poll, so the Node
+/// script installs an `uncaughtException` handler to observe it while checking
+/// that the future's `DropGuard` ran.
+#[test]
+fn spawn_local_panic_frees_future() {
+    let mut project = Project::new("spawn_local_panic_frees_future");
+    project
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+                use wasm_bindgen_futures::spawn_local;
+                use std::future::Future;
+                use std::pin::Pin;
+                use std::task::{Context, Poll, Waker};
+
+                #[wasm_bindgen(inline_js = "
+                    export function set_was_dropped(v) { globalThis.was_dropped = v; }
+                ")]
+                extern "C" {
+                    fn set_was_dropped(v: bool);
+                }
+
+                struct DropGuard;
+
+                impl Drop for DropGuard {
+                    fn drop(&mut self) {
+                        set_was_dropped(true);
+                    }
+                }
+
+                // Retains its own waker before panicking, forming the
+                // `future -> Waker -> Rc<Task>` cycle that the single-threaded
+                // executor would otherwise leak on a panicking poll.
+                struct PanicFuture {
+                    _guard: DropGuard,
+                    waker: Option<Waker>,
+                }
+
+                impl Future for PanicFuture {
+                    type Output = ();
+                    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+                        self.waker = Some(cx.waker().clone());
+                        panic!("spawned future panic");
+                    }
+                }
+
+                #[wasm_bindgen]
+                pub fn spawn_panicking_future() {
+                    set_was_dropped(false);
+                    spawn_local(PanicFuture {
+                        _guard: DropGuard,
+                        waker: None,
+                    });
+                }
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            &format!(
+                "
+                    [package]
+                    name = \"spawn_local_panic_frees_future\"
+                    authors = []
+                    version = \"1.0.0\"
+                    edition = '2021'
+
+                    [dependencies]
+                    wasm-bindgen = {{ path = '{root}' }}
+                    wasm-bindgen-futures = {{ path = '{root}/crates/futures' }}
+
+                    [lib]
+                    crate-type = ['cdylib']
+
+                    [workspace]
+
+                    [profile.dev]
+                    codegen-units = 1
+                ",
+                root = REPO_ROOT.display(),
+            ),
+        );
+
+    // The leak fix matters when a poll unwinds, which requires building with
+    // nightly build-std under `panic = "unwind"`.
+    project
+        .cargo_cmd
+        .env("RUSTUP_TOOLCHAIN", "nightly")
+        .env("RUSTFLAGS", "-Cpanic=unwind")
+        .arg("-Zbuild-std=std,panic_unwind");
+
+    let out_dir = project.wasm_bindgen("--target nodejs").unwrap();
+
+    fs::write(
+        out_dir.join("test_spawn_panic.js"),
+        r#"
+const assert = require('node:assert/strict');
+const wasm = require('./spawn_local_panic_frees_future.js');
+
+// The spawned future's panic propagates out of the microtask that drives its
+// first poll, surfacing as an uncaught exception. That's expected here; record
+// it and swallow only that specific panic so the process keeps running.
+let sawPanic = false;
+process.on('uncaughtException', (e) => {
+    const msg = (e && e.message) || String(e);
+    if (/spawned future panic/.test(msg)) {
+        sawPanic = true;
+    } else {
+        throw e;
+    }
+});
+
+wasm.spawn_panicking_future();
+
+// A macrotask runs after the microtask queue, so by now the spawned task has
+// been polled (and panicked).
+setTimeout(() => {
+    try {
+        assert.ok(sawPanic, 'expected the spawned future to panic');
+        assert.strictEqual(
+            globalThis.was_dropped,
+            true,
+            'spawned future must be dropped after a panicking poll, not leaked',
+        );
+        console.log('PASS');
+        process.exit(0);
+    } catch (e) {
+        console.error(e);
+        process.exit(1);
+    }
+}, 50);
+"#,
+    )
+    .unwrap();
+
+    Command::new("node")
+        .arg("test_spawn_panic.js")
+        .current_dir(&out_dir)
+        .assert()
+        .success()
+        .stdout(str::contains("PASS"));
+}
+
 #[test]
 fn termination_reset_state() {
     let mut project = Project::new("termination_reset_state");

--- a/crates/js-sys/src/futures/task/multithread.rs
+++ b/crates/js-sys/src/futures/task/multithread.rs
@@ -100,12 +100,14 @@ impl Task {
         let closure = {
             let this = Rc::clone(&this);
 
+            // `own_assert_unwind_safe` is required because the closure captures
+            // `Rc<Task>`, which isn't `UnwindSafe`. A poll unwinding out of
+            // `run` frees the `Task` via a drop guard to avoid a leak.
             Closure::own_assert_unwind_safe(move |_| {
-                #[cfg(all(feature = "std", panic = "unwind"))]
-                this.catch_unwind_wake_and_run();
-
-                #[cfg(not(all(feature = "std", panic = "unwind")))]
-                this.wake_and_run();
+                // The promise resolution acts like a wake, so ensure the state
+                // transitions to AWAKE before entering `run`.
+                this.atomic.wake_by_ref();
+                this.run();
             })
         };
         *this.inner.borrow_mut() = Some(Inner {
@@ -117,31 +119,33 @@ impl Task {
         crate::futures::queue::Queue::with(move |queue| queue.schedule_task(this));
     }
 
-    #[cfg(all(feature = "std", panic = "unwind"))]
-    fn catch_unwind_wake_and_run(&self) {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.wake_and_run()));
-        if let Err(payload) = result {
-            // Make sure that Task is freed after a panic.
-            *self.inner.borrow_mut() = None;
-            std::panic::resume_unwind(payload);
-        }
-    }
-
-    fn wake_and_run(&self) {
-        // The promise resolution acts like a wake, so ensure the state
-        // transitions to AWAKE before entering `run`.
-        self.atomic.wake_by_ref();
-        self.run();
-    }
-
     pub(crate) fn run(&self) {
+        // A poll can unwind via either a Rust panic or a foreign (JS)
+        // exception. `catch_unwind` only catches the former, but both run
+        // drops, so a drop guard covers both: if a poll unwinds we drop
+        // `Inner`, releasing the future and breaking the
+        // `Inner -> closure -> Rc<Task>` cycle that would otherwise leak the
+        // `Task`. This covers both the first poll (driven by the queue) and
+        // wakeup polls (driven by the per-task closure). The guard is disarmed
+        // (forgotten) on a normal return.
+        struct ClearOnUnwind<'a>(&'a RefCell<Option<Inner>>);
+        impl Drop for ClearOnUnwind<'_> {
+            fn drop(&mut self) {
+                *self.0.borrow_mut() = None;
+            }
+        }
+        let clear_on_unwind = ClearOnUnwind(&self.inner);
+
         let mut borrow = self.inner.borrow_mut();
 
         // Same as `singlethread.rs`, handle spurious wakeups happening after we
         // finished.
         let inner = match borrow.as_mut() {
             Some(inner) => inner,
-            None => return,
+            None => {
+                core::mem::forget(clear_on_unwind);
+                return;
+            }
         };
 
         loop {
@@ -189,6 +193,8 @@ impl Task {
             }
             break;
         }
+
+        core::mem::forget(clear_on_unwind);
     }
 }
 

--- a/crates/js-sys/src/futures/task/multithread.rs
+++ b/crates/js-sys/src/futures/task/multithread.rs
@@ -99,11 +99,13 @@ impl Task {
 
         let closure = {
             let this = Rc::clone(&this);
-            Closure::new(move |_| {
-                // The promise resolution acts like a wake, so ensure the state
-                // transitions to AWAKE before entering `run`.
-                this.atomic.wake_by_ref();
-                this.run();
+
+            Closure::own_assert_unwind_safe(move |_| {
+                #[cfg(all(feature = "std", panic = "unwind"))]
+                this.catch_unwind_wake_and_run();
+
+                #[cfg(not(all(feature = "std", panic = "unwind")))]
+                this.wake_and_run();
             })
         };
         *this.inner.borrow_mut() = Some(Inner {
@@ -113,6 +115,23 @@ impl Task {
 
         // Queue up the Future's work to happen on the next microtask tick.
         crate::futures::queue::Queue::with(move |queue| queue.schedule_task(this));
+    }
+
+    #[cfg(all(feature = "std", panic = "unwind"))]
+    fn catch_unwind_wake_and_run(&self) {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.wake_and_run()));
+        if let Err(payload) = result {
+            // Make sure that Task is freed after a panic.
+            *self.inner.borrow_mut() = None;
+            std::panic::resume_unwind(payload);
+        }
+    }
+
+    fn wake_and_run(&self) {
+        // The promise resolution acts like a wake, so ensure the state
+        // transitions to AWAKE before entering `run`.
+        self.atomic.wake_by_ref();
+        self.run();
     }
 
     pub(crate) fn run(&self) {

--- a/crates/js-sys/src/futures/task/multithread.rs
+++ b/crates/js-sys/src/futures/task/multithread.rs
@@ -120,14 +120,12 @@ impl Task {
     }
 
     pub(crate) fn run(&self) {
-        // A poll can unwind via either a Rust panic or a foreign (JS)
+        // A poll can unwind via either a Rust panic or a JS
         // exception. `catch_unwind` only catches the former, but both run
         // drops, so a drop guard covers both: if a poll unwinds we drop
         // `Inner`, releasing the future and breaking the
         // `Inner -> closure -> Rc<Task>` cycle that would otherwise leak the
-        // `Task`. This covers both the first poll (driven by the queue) and
-        // wakeup polls (driven by the per-task closure). The guard is disarmed
-        // (forgotten) on a normal return.
+        // `Task`. The guard is forgotten on a normal return.
         struct ClearOnUnwind<'a>(&'a RefCell<Option<Inner>>);
         impl Drop for ClearOnUnwind<'_> {
             fn drop(&mut self) {

--- a/crates/js-sys/src/futures/task/singlethread.rs
+++ b/crates/js-sys/src/futures/task/singlethread.rs
@@ -139,13 +139,30 @@ impl Task {
     }
 
     pub(crate) fn run(&self) {
+        // A poll can unwind via either a Rust panic or a foreign (JS)
+        // exception. `catch_unwind` only catches the former, but both run
+        // drops, so a drop guard covers both: if a poll unwinds we drop
+        // `Inner`, releasing the future and breaking the
+        // `Inner -> Waker -> Rc<Task>` cycle that would otherwise leak the
+        // `Task`. The guard is disarmed (forgotten) on a normal return.
+        struct ClearOnUnwind<'a>(&'a RefCell<Option<Inner>>);
+        impl Drop for ClearOnUnwind<'_> {
+            fn drop(&mut self) {
+                *self.0.borrow_mut() = None;
+            }
+        }
+        let clear_on_unwind = ClearOnUnwind(&self.inner);
+
         let mut borrow = self.inner.borrow_mut();
 
         // Wakeups can come in after a Future has finished and been destroyed,
         // so handle this gracefully by just ignoring the request to run.
         let inner = match borrow.as_mut() {
             Some(inner) => inner,
-            None => return,
+            None => {
+                core::mem::forget(clear_on_unwind);
+                return;
+            }
         };
 
         // Ensure that if poll calls `waker.wake()` we can get enqueued back on
@@ -158,7 +175,8 @@ impl Task {
         let is_ready = match self.console.as_ref() {
             // Wrap `inner` in AssertUnwindSafe before capturing it, so the closure
             // satisfies MaybeUnwindSafe (required when panic=unwind). This is safe:
-            // console.run's poll callback is not invoked inside a panic-catching context.
+            // a panic from `is_ready` propagates as usual and is handled by the
+            // `ClearOnUnwind` guard above.
             Some(console) => {
                 let mut inner = core::panic::AssertUnwindSafe(inner);
                 console.run(&mut move || inner.is_ready())
@@ -180,5 +198,7 @@ impl Task {
         if is_ready {
             *borrow = None;
         }
+
+        core::mem::forget(clear_on_unwind);
     }
 }


### PR DESCRIPTION
### Description

This fixes a compilation failure and also prevents a memory leak after a panic.

I think that the same memory leak exists in singlethread.rs too but I am not entirely sure.

Fixes https://github.com/wasm-bindgen/wasm-bindgen/issues/5213

### Checklist

- [X] Verified changelog requirement
