### PR TITLE
Drop the emscripten marker static from wasm exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@
   call sites, e.g. `__wbindgen_start is not defined`).
 
 * The emscripten detection marker static is no longer leaked as public API.
-  It is `#[used]` so its custom section survives linking for detection, but that
-  also left it as a stray wasm export that emscripten's `EMSCRIPTEN_KEEPALIVE`
-  heuristic surfaced as public API. `cli-support` now drops the export once it
-  has consumed the section to switch into emscripten mode.
   [#5220](https://github.com/wasm-bindgen/wasm-bindgen/pull/5220)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@
   `-O3`/`-Os` (previously the export names were minified without updating the JS
   call sites, e.g. `__wbindgen_start is not defined`).
 
+* The emscripten detection marker static is no longer leaked as public API.
+  It is `#[used]` so its custom section survives linking for detection, but that
+  also left it as a stray wasm export that emscripten's `EMSCRIPTEN_KEEPALIVE`
+  heuristic surfaced as public API. `cli-support` now drops the export once it
+  has consumed the section to switch into emscripten mode.
+  [#5220](https://github.com/wasm-bindgen/wasm-bindgen/pull/5220)
+
 ### Removed
 
 ## [0.2.126](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.125...0.2.126)

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -351,6 +351,19 @@ impl Bindgen {
         {
             // Force the internal configuration to Emscripten mode.
             self.mode = OutputMode::Emscripten;
+
+            // The marker static is `#[used]` so its section survives linking for
+            // the detection above, but that also leaves it as a wasm export that
+            // nothing references. Drop it here so emscripten's
+            // EMSCRIPTEN_KEEPALIVE heuristic doesn't surface it as public API.
+            let marker_export = module
+                .exports
+                .iter()
+                .find(|e| e.name.contains("__WASM_BINDGEN_EMSCRIPTEN_MARKER"))
+                .map(|e| e.id());
+            if let Some(id) = marker_export {
+                module.exports.delete(id);
+            }
         }
 
         // Enable reference type transformations if the module is already using it.


### PR DESCRIPTION
Emscripten detection relies on a marker static that wasm-bindgen defines in the
guest crate:

```rs
#[used]
#[link_section = "__wasm_bindgen_emscripten_marker"]
static __WASM_BINDGEN_EMSCRIPTEN_MARKER: [u8; 1] = [1];
```

The `#[used]` attribute keeps the static alive through linking so that
`cli-support` can detect emscripten output from its custom section. But
`#[used]` also leaves it behind as a wasm export that nothing references. Under
emscripten's `EMSCRIPTEN_KEEPALIVE` heuristic that stray export gets surfaced as
public API, leaking an internal detection detail into the generated bindings.

This drops the marker export in `cli-support` right after we consume the section
to switch into emscripten mode, so the detection still works but the export no
longer escapes into the public surface.
