### PR TITLE
Mention tarpaulin in the docs

### DIFF
--- a/guide/src/wasm-bindgen-test/coverage.md
+++ b/guide/src/wasm-bindgen-test/coverage.md
@@ -37,12 +37,15 @@ This feature relies on the [minicov] crate, which provides a profiling runtime f
 
 _Requires rust >= 1.87.0 and wasm-bindgen-test >= 0.3.57._
 
-Install [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) and run with:
+Install [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov)  or [cargo-tarpaulin](https://github.com/xd009642/tarpaulin) and run with:
 
 ```sh
 CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
 CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime -Clink-args=--no-gc-sections --cfg=wasm_bindgen_unstable_test_coverage" \
+# cargo-llvm-cov 
 cargo +nightly llvm-cov test --target wasm32-unknown-unknown
+# cargo tarpaulin 
+cargo +nightly tarpaulin --target wasm32-unknown-unknown
 ```
 
 ## Attribution


### PR DESCRIPTION
### Description

As of the release 0.37.0, cargo-tarpaulin supports coverage of wasm projects the same as cargo-llvm-cov. As I have gotten issues and comments before about wasm coverage I figured it would be a useful addition to the docs for tarpaulin users who want wasm coverage and don't want to switch to cargo-llvm-cov (or can't, cargo-llvm-cov and cargo-tarpaulin have overlapping but disjoint feature sets).

FYI Currently, this version is on crates.io with github releases uploading.

### Checklist

I'm going to assume this doesn't need a changelog entry.
