### PR TITLE
Reserve threads bookkeeping page contiguously past allocator heap bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ### Fixed
 
+* Fixed threaded Wasm worker startup stalling with a large linker-provided
+  initial memory. Allocators such as dlmalloc (>= 0.2.13) donate the
+  linker-provided `[__heap_base, __heap_end)` range as a preexisting heap chunk,
+  reading both bounds as constants inlined at link time. The threads transform
+  reserved its bookkeeping page at `__heap_base` and only bumped the
+  `__heap_base` *global*, which those allocators don't read, so the reserved page
+  could be handed out and corrupted. The transform now also shifts the
+  allocator's inlined `[__heap_base, __heap_end)` bounds up past the reserved
+  page, keeping the heap a single contiguous region.
+  [#5223](https://github.com/wasm-bindgen/wasm-bindgen/issues/5223)
+
 * Emscripten output now reaches wasm exports through emscripten's `wasmExports`
   object using bracket (string-literal) access (`wasmExports['__wbindgen_start']`)
   instead of a local `wasm` alias with dot access. `wasmExports['name']` is the

--- a/crates/cli-support/src/transforms/threads/mod.rs
+++ b/crates/cli-support/src/transforms/threads/mod.rs
@@ -1,7 +1,7 @@
 use crate::wasm_conventions;
 use anyhow::{anyhow, bail, Error};
 use std::cmp;
-use walrus::ir::Value;
+use walrus::ir::{dfs_pre_order_mut, Const, Value, VisitorMut};
 use walrus::FunctionBuilder;
 use walrus::{
     ir::MemArg, ConstExpr, ExportItem, FunctionId, GlobalId, GlobalKind, InstrSeqBuilder, MemoryId,
@@ -59,6 +59,20 @@ pub fn run(module: &mut Module) -> Result<Option<ThreadCount>, Error> {
 
     let memory = wasm_conventions::get_memory(module)?;
 
+    let mem = module.memories.get(memory);
+    assert!(mem.shared); // guaranteed by `is_enabled`
+    if mem.import.is_none() {
+        bail!("threading requires imported memory; build with `-Clink-arg=--import-memory`");
+    }
+    if !mem.data_segments.is_empty() {
+        bail!("expected data segments to be passive before running the threads transform");
+    }
+
+    // The original end of linear memory, i.e. LLD's `__heap_end`. Captured before
+    // `allocate_static_data` grows the memory below.
+    let heap_end = u32::try_from(mem.initial * u64::from(PAGE_SIZE))
+        .map_err(|_| anyhow!("initial memory size exceeds the wasm32 address space"))?;
+
     // Now we need to allocate extra static memory for:
     // - A thread id counter.
     // - A temporary stack for calls to `malloc()` and `free()`.
@@ -69,10 +83,13 @@ pub fn run(module: &mut Module) -> Result<Option<ThreadCount>, Error> {
     let static_data_pages = 1;
     let (base, addr) = allocate_static_data(module, memory, static_data_pages, static_data_align)?;
 
-    let mem = module.memories.get(memory);
-    assert!(mem.shared);
-    assert!(mem.import.is_some());
-    assert!(mem.data_segments.is_empty());
+    // Some allocators (e.g. dlmalloc >= 0.2.13) treat the linker-provided range
+    // `[__heap_base, __heap_end)` as a preexisting heap chunk, reading both
+    // symbols as constants baked in at link time. Bumping the `__heap_base`
+    // *global* above doesn't move those constants, so such an allocator would
+    // hand out the page we just reserved at the old `__heap_base`. Shift its view
+    // up past the reserved page, keeping the heap a single contiguous region.
+    reserve_preexisting_chunk(module, base, heap_end, static_data_pages * PAGE_SIZE);
 
     let tls = Tls {
         init: delete_synthetic_func(module, "__wasm_init_tls")?,
@@ -237,6 +254,81 @@ fn allocate_static_data(
     memory.maximum = memory.maximum.map(|m| cmp::max(m, memory.initial));
 
     Ok((base as u32, address))
+}
+
+/// Shifts an allocator's linker-provided preexisting heap chunk up past the
+/// reserved page.
+///
+/// Allocators such as dlmalloc (>= 0.2.13) donate the range
+/// `[__heap_base, __heap_end)` before falling back to `memory.grow`. Both bounds
+/// are resolved by the linker and inlined into the allocator's code as
+/// constants, so [`allocate_static_data`]'s bump of the `__heap_base` *global*
+/// is invisible to them and they would reuse the page we reserved there.
+///
+/// The reader of that chunk computes its length at runtime as
+/// `__heap_end - __heap_base` from the two inlined constants, so shifting *both*
+/// bounds up by `reserved` moves the chunk above the reserved page while
+/// preserving its length. The result is a single contiguous heap:
+/// `[data][reserved page][heap chunk][memory.grow ...]`.
+///
+/// The function is identified as the one referencing *both* bounds; anything
+/// merely reusing one of the two addresses is left untouched.
+fn reserve_preexisting_chunk(module: &mut Module, heap_base: u32, heap_end: u32, reserved: u32) {
+    // An empty (or absent) preexisting chunk can never overlap the reserved page.
+    if heap_end <= heap_base {
+        return;
+    }
+
+    struct Scan {
+        heap_base: u32,
+        heap_end: u32,
+        has_base: bool,
+        has_end: bool,
+    }
+    impl VisitorMut for Scan {
+        fn visit_const_mut(&mut self, c: &mut Const) {
+            if let Value::I32(v) = c.value {
+                let v = v as u32;
+                self.has_base |= v == self.heap_base;
+                self.has_end |= v == self.heap_end;
+            }
+        }
+    }
+
+    struct Bump {
+        heap_base: u32,
+        heap_end: u32,
+        reserved: u32,
+    }
+    impl VisitorMut for Bump {
+        fn visit_const_mut(&mut self, c: &mut Const) {
+            if let Value::I32(v) = c.value {
+                let v = v as u32;
+                if v == self.heap_base || v == self.heap_end {
+                    c.value = Value::I32(v.wrapping_add(self.reserved) as i32);
+                }
+            }
+        }
+    }
+
+    for (_, func) in module.funcs.iter_local_mut() {
+        let entry = func.entry_block();
+        let mut scan = Scan {
+            heap_base,
+            heap_end,
+            has_base: false,
+            has_end: false,
+        };
+        dfs_pre_order_mut(&mut scan, func, entry);
+        if scan.has_base && scan.has_end {
+            let mut bump = Bump {
+                heap_base,
+                heap_end,
+                reserved,
+            };
+            dfs_pre_order_mut(&mut bump, func, entry);
+        }
+    }
 }
 
 struct Tls {

--- a/crates/cli-support/src/transforms/threads/tests/preexisting_chunk.wat
+++ b/crates/cli-support/src/transforms/threads/tests/preexisting_chunk.wat
@@ -1,0 +1,184 @@
+(module
+  (import "env" "memory" (memory 10 1024 shared))
+  (func $__wasm_init_tls (export "__wasm_init_tls") (param i32)
+    (i32.const 232323)
+    drop
+  )
+  (func $__wbindgen_malloc (export "__wbindgen_malloc") (param i32 i32) (result i32)
+    call $preexisting_chunk
+  )
+  ;; Mimics dlmalloc reading the linker-provided `[__heap_base, __heap_end)`
+  ;; range as two inlined constants and computing its length at runtime. The
+  ;; transform must shift both bounds up past the reserved page.
+  (func $preexisting_chunk (export "preexisting_chunk") (result i32)
+    i32.const 655360 ;; &__heap_end (initial memory = 10 pages)
+    i32.const 327680 ;; &__heap_base
+    i32.sub
+  )
+  (func $start
+    i32.const 101010
+    drop
+  )
+  (func $__wbindgen_free (export "__wbindgen_free") (param i32 i32 i32))
+  (global (export "__heap_base") i32 (i32.const 327680))
+  (global (export "__tls_size") i32 (i32.const 128))
+  (global (export "__tls_align") i32 (i32.const 4))
+  (global (export "__tls_base") (mut i32) (i32.const 0))
+  ;; stack pointer
+  (global (mut i32) (i32.const 65536))
+  (start $start)
+)
+
+(; CHECK-ALL:
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (result i32)))
+  (type (;2;) (func (param i32)))
+  (type (;3;) (func (param i32 i32) (result i32)))
+  (type (;4;) (func (param i32 i32 i32)))
+  (import "env" "memory" (memory (;0;) 11 1024 shared))
+  (global (;0;) i32 i32.const 393216)
+  (global (;1;) (mut i32) i32.const 0)
+  (global (;2;) (mut i32) i32.const 65536)
+  (global (;3;) (mut i32) i32.const 0)
+  (global (;4;) (mut i32) i32.const 2097152)
+  (export "__wbindgen_malloc" (func $__wbindgen_malloc))
+  (export "preexisting_chunk" (func $preexisting_chunk))
+  (export "__wbindgen_free" (func $__wbindgen_free))
+  (export "__heap_base" (global 0))
+  (export "__tls_base" (global 1))
+  (export "__stack_alloc" (global 3))
+  (export "__wbindgen_thread_destroy" (func $__wbindgen_thread_destroy))
+  (export "__wbindgen_start" (func 1))
+  (func $__wbindgen_thread_destroy (;0;) (type 4) (param i32 i32 i32)
+    local.get 0
+    if ;; label = @1
+      local.get 0
+      i32.const 128
+      i32.const 4
+      call $__wbindgen_free
+    else
+      global.get 1
+      i32.const 128
+      i32.const 4
+      call $__wbindgen_free
+      i32.const -2147483648
+      global.set 1
+    end
+    local.get 1
+    if ;; label = @1
+      local.get 1
+      local.get 2
+      i32.const 2097152
+      local.get 2
+      select
+      i32.const 16
+      call $__wbindgen_free
+    else
+      i32.const 393216
+      global.set 2
+      loop ;; label = @2
+        i32.const 327684
+        i32.const 0
+        i32.const 1
+        i32.atomic.rmw.cmpxchg
+        if ;; label = @3
+          i32.const 327684
+          i32.const 1
+          i64.const -1
+          memory.atomic.wait32
+          drop
+          br 1 (;@2;)
+        else
+        end
+      end
+      global.get 3
+      global.get 4
+      i32.const 16
+      call $__wbindgen_free
+      i32.const 327684
+      i32.const 0
+      i32.atomic.store
+      i32.const 327684
+      i32.const 1
+      memory.atomic.notify
+      drop
+      i32.const 0
+      global.set 3
+    end
+  )
+  (func (;1;) (type 2) (param i32)
+    (local i32 i32)
+    call $start
+    i32.const 327680
+    i32.const 1
+    i32.atomic.rmw.add
+    local.tee 2
+    if ;; label = @1
+      local.get 0
+      if ;; label = @2
+        local.get 0
+        global.set 4
+      else
+      end
+      i32.const 393216
+      global.set 2
+      loop ;; label = @2
+        i32.const 327684
+        i32.const 0
+        i32.const 1
+        i32.atomic.rmw.cmpxchg
+        if ;; label = @3
+          i32.const 327684
+          i32.const 1
+          i64.const -1
+          memory.atomic.wait32
+          drop
+          br 1 (;@2;)
+        else
+        end
+      end
+      global.get 4
+      i32.const 16
+      call $__wbindgen_malloc
+      local.tee 1
+      i32.const 327684
+      i32.const 0
+      i32.atomic.store
+      i32.const 327684
+      i32.const 1
+      memory.atomic.notify
+      drop
+      global.set 3
+      global.get 3
+      global.get 4
+      i32.add
+      global.set 2
+    else
+    end
+    i32.const 128
+    i32.const 4
+    call $__wbindgen_malloc
+    global.set 1
+    global.get 1
+    call $__wasm_init_tls
+  )
+  (func $preexisting_chunk (;2;) (type 1) (result i32)
+    i32.const 720896
+    i32.const 393216
+    i32.sub
+  )
+  (func $__wasm_init_tls (;3;) (type 2) (param i32)
+    i32.const 232323
+    drop
+  )
+  (func $start (;4;) (type 0)
+    i32.const 101010
+    drop
+  )
+  (func $__wbindgen_malloc (;5;) (type 3) (param i32 i32) (result i32)
+    call $preexisting_chunk
+  )
+  (func $__wbindgen_free (;6;) (type 4) (param i32 i32 i32))
+)
+;)


### PR DESCRIPTION
This fixes threaded Wasm worker startup stalling when the module is linked with a large `--initial-memory` and imported shared memory, resolves #5223. It's an alternative approach to #5225 for the same issue.

Since dlmalloc 0.2.13, the allocator donates the linker-provided `[__heap_base, __heap_end)` range as a preexisting heap chunk before falling back to `memory.grow`. Both bounds are resolved by the linker and inlined into the allocator's code as constants:

```rust
let heap_base = &__heap_base as *const u8 as usize;
let heap_end  = &__heap_end  as *const u8 as usize;
let len = heap_end - heap_base;
Some((heap_base, len))
```

The threads transform reserves a bookkeeping page (thread-id counter, lock, temporary malloc/free stack) at `__heap_base` and bumps the `__heap_base` *global*. But the allocator never reads that global — it uses the inlined constant — so it happily hands out the exact page the transform reserved, corrupting worker bootstrap state.

#5225 solves this by reserving the page *after* the module's initial memory instead. That works, but it leaves the reserved page as untracked space between the allocator's preexisting chunk and its first grown segment, i.e. non-contiguous allocator ownership. This instead keeps the heap a single contiguous region by moving the allocator's view of the chunk up past the reserved page:

* the reserved page stays at the old `__heap_base` (bookkeeping addresses unchanged),
* the transform locates the function that reads *both* `__heap_base` and `__heap_end` (the preexisting-chunk reader) and shifts *both* inlined constants up by the reserved size.

Because the length is computed at runtime as `__heap_end - __heap_base`, shifting both bounds by the same amount preserves it, so the chunk simply slides up above the reserved page. Every other use of the constants (`heap_base == 0`, `heap_end <= heap_base`) stays correct for the same reason. The resulting layout is fully contiguous:

```
[static data][reserved page][heap chunk][memory.grow ...]
```

Identification requires *both* bounds in the same function, a near-zero-false-positive signal; the patch runs before the start/destroy functions are injected, so the transform's own bookkeeping constants (which reuse `__heap_base`) are never touched. If no such function exists (allocator doesn't consume the preexisting chunk), behavior is unchanged and remains correct for grow-only allocators. This also keeps requiring the `__heap_base` export, so the example build scripts don't change and there's no cross-release breakage window.

Also converts the imported-memory / passive-data-segment checks from raw `assert!`s to `bail!`s with actionable messages (e.g. missing `--import-memory` now reports a real error instead of panicking).

Tested with a new `preexisting_chunk.wat` reference fixture that models the dlmalloc chunk reader and asserts both bounds are shifted while length is preserved; existing `basic.wat`/`unaligned.wat` outputs are unchanged.

_Made with AI assistance under my review_
