### PR TITLE
fix: correct typos in code comments

### DIFF
--- a/crates/cli-support/src/interpreter/mod.rs
+++ b/crates/cli-support/src/interpreter/mod.rs
@@ -484,7 +484,7 @@ impl Frame<'_> {
                     let index = address as usize / 4;
                     if width == 8 {
                         // Oops our stack is of i32s so we can't really handle a
-                        // store of width 8. Just treat the more signifcant 4
+                        // store of width 8. Just treat the more significant 4
                         // bytes as 0.
                         self.interp.mem[index] = value;
                         self.interp.mem[index + 1] = 0;

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -7001,7 +7001,7 @@ addToLibrary({
 /// This is different from [`AdapterKind`] and is only used internally in the
 /// code generation process.
 enum ContextAdapterKind<'a> {
-    /// An exported function, method, constrctor, or getter/setter.
+    /// An exported function, method, constructor, or getter/setter.
     Export(&'a AuxExport),
     /// An imported function or intrinsic.
     Import(walrus::ImportId),

--- a/crates/test/src/rt/web_time/instant.rs
+++ b/crates/test/src/rt/web_time/instant.rs
@@ -107,7 +107,7 @@ impl F64 {
     ///   in [`Instant::now()`].
     /// - We only round the fractional part after multiplying it by `1e6`. A
     ///   fraction always has a negative exponent. `1e6` has an exponent of
-    ///   `19`. Therefor the resulting exponent can at most be `19`.
+    ///   `19`. Therefore the resulting exponent can at most be `19`.
     ///
     /// [`f64::round_ties_even()`]: https://doc.rust-lang.org/1.83.0/std/primitive.f64.html#method.round_ties_even
     fn internal_round_ties_even(self) -> f64 {


### PR DESCRIPTION
Fix three spelling mistakes found in code comments (not generated files):

- `Therefor` → `Therefore` in `crates/test/src/rt/web_time/instant.rs` (doc comment)
- `signifcant` → `significant` in `crates/cli-support/src/interpreter/mod.rs` (inline comment)
- `constrctor` → `constructor` in `crates/cli-support/src/js/mod.rs` (doc comment)