### PR TITLE
Update WebGPU API to 2026-08-02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   `GPUCommandEncoder::copy_buffer_to_buffer` overloads and `setImmediates`.
   [#5246](https://github.com/wasm-bindgen/wasm-bindgen/pull/5246)
 
+* Unstable API overload names now elide name tokens shared by every overload
+  variant: `LockManager::request_with_callback` is now `request`, and
+  `request_with_options_and_callback` is now `request_with_options`.
+  [#5246](https://github.com/wasm-bindgen/wasm-bindgen/pull/5246)
+
 ### Fixed
 
 * The `name` property of the JS error thrown for `panic=unwind` is now set from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   reachable through `__deps`. Requires an emscripten with `__export`/`__force`
   symbol-attribute support.
 
+* Updated WebGPU bindings to the August 2026 spec. `GPUCommandEncoder::copy_buffer_to_buffer_*` signatures changed.
+  [#5246](https://github.com/wasm-bindgen/wasm-bindgen/pull/5246)
+
 ### Fixed
 
 * The `name` property of the JS error thrown for `panic=unwind` is now set from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,6 @@
   `GPUCommandEncoder::copy_buffer_to_buffer` overloads and `setImmediates`.
   [#5246](https://github.com/wasm-bindgen/wasm-bindgen/pull/5246)
 
-* Overloaded WebIDL methods marked `[WbgGeneric]` now elide name tokens shared
-  by every overload variant when doing so keeps all names distinct, avoiding
-  redundant type names in generated overload names.
-  [#5246](https://github.com/wasm-bindgen/wasm-bindgen/pull/5246)
-
 ### Fixed
 
 * The `name` property of the JS error thrown for `panic=unwind` is now set from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@
   reachable through `__deps`. Requires an emscripten with `__export`/`__force`
   symbol-attribute support.
 
-* Updated WebGPU bindings to the August 2026 spec. `GPUCommandEncoder::copy_buffer_to_buffer_*` signatures changed.
+* Updated WebGPU bindings to the August 2026 spec, including the new
+  `GPUCommandEncoder::copy_buffer_to_buffer` overloads and `setImmediates`.
+  [#5246](https://github.com/wasm-bindgen/wasm-bindgen/pull/5246)
+
+* Overloaded WebIDL methods marked `[WbgGeneric]` now elide name tokens shared
+  by every overload variant when doing so keeps all names distinct, avoiding
+  redundant type names in generated overload names.
   [#5246](https://github.com/wasm-bindgen/wasm-bindgen/pull/5246)
 
 ### Fixed

--- a/crates/web-sys/src/features/gen_GpuCommandEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuCommandEncoder.rs
@@ -212,7 +212,72 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_u32(
+    pub fn copy_buffer_to_buffer_with_gpu_buffer(
+        this: &GpuCommandEncoder,
+        source: &GpuBuffer,
+        destination: &GpuBuffer,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "GpuBuffer")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUCommandEncoder",
+        js_name = "copyBufferToBuffer"
+    )]
+    #[doc = "The `copyBufferToBuffer()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuBuffer`, `GpuCommandEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn copy_buffer_to_buffer_with_gpu_buffer_and_u32(
+        this: &GpuCommandEncoder,
+        source: &GpuBuffer,
+        destination: &GpuBuffer,
+        size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "GpuBuffer")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUCommandEncoder",
+        js_name = "copyBufferToBuffer"
+    )]
+    #[doc = "The `copyBufferToBuffer()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuBuffer`, `GpuCommandEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn copy_buffer_to_buffer_with_gpu_buffer_and_f64(
+        this: &GpuCommandEncoder,
+        source: &GpuBuffer,
+        destination: &GpuBuffer,
+        size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "GpuBuffer")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUCommandEncoder",
+        js_name = "copyBufferToBuffer"
+    )]
+    #[doc = "The `copyBufferToBuffer()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuBuffer`, `GpuCommandEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -235,7 +300,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_u32(
+    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -258,7 +323,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_f64(
+    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -281,7 +346,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_f64(
+    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -304,7 +369,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_u32_and_u32(
+    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_u32_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -328,7 +393,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_u32_and_u32(
+    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_u32_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -352,7 +417,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_f64_and_u32(
+    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_f64_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -376,7 +441,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_f64_and_u32(
+    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_f64_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -400,7 +465,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_u32_and_f64(
+    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_u32_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -424,7 +489,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_u32_and_f64(
+    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_u32_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -448,7 +513,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_f64_and_f64(
+    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_f64_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -472,7 +537,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_f64_and_f64(
+    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_f64_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,

--- a/crates/web-sys/src/features/gen_GpuCommandEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuCommandEncoder.rs
@@ -212,7 +212,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_gpu_buffer(
+    pub fn copy_buffer_to_buffer(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         destination: &GpuBuffer,
@@ -233,7 +233,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_gpu_buffer_and_u32(
+    pub fn copy_buffer_to_buffer_with_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         destination: &GpuBuffer,
@@ -255,7 +255,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_gpu_buffer_and_f64(
+    pub fn copy_buffer_to_buffer_with_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         destination: &GpuBuffer,
@@ -277,7 +277,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_u32(
+    pub fn copy_buffer_to_buffer_with_u32_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -300,7 +300,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_u32(
+    pub fn copy_buffer_to_buffer_with_f64_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -323,7 +323,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_f64(
+    pub fn copy_buffer_to_buffer_with_u32_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -346,7 +346,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_f64(
+    pub fn copy_buffer_to_buffer_with_f64_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -369,7 +369,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_u32_and_u32(
+    pub fn copy_buffer_to_buffer_with_u32_and_u32_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -393,7 +393,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_u32_and_u32(
+    pub fn copy_buffer_to_buffer_with_f64_and_u32_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -417,7 +417,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_f64_and_u32(
+    pub fn copy_buffer_to_buffer_with_u32_and_f64_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -441,7 +441,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_f64_and_u32(
+    pub fn copy_buffer_to_buffer_with_f64_and_f64_and_u32(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -465,7 +465,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_u32_and_f64(
+    pub fn copy_buffer_to_buffer_with_u32_and_u32_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -489,7 +489,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_u32_and_f64(
+    pub fn copy_buffer_to_buffer_with_f64_and_u32_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,
@@ -513,7 +513,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_u32_and_gpu_buffer_and_f64_and_f64(
+    pub fn copy_buffer_to_buffer_with_u32_and_f64_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: u32,
@@ -537,7 +537,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_buffer_to_buffer_with_f64_and_gpu_buffer_and_f64_and_f64(
+    pub fn copy_buffer_to_buffer_with_f64_and_f64_and_f64(
         this: &GpuCommandEncoder,
         source: &GpuBuffer,
         source_offset: f64,

--- a/crates/web-sys/src/features/gen_GpuComputePassEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuComputePassEncoder.rs
@@ -290,6 +290,456 @@ extern "C" {
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64_and_u32(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPUComputePassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuComputePassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64_and_f64(
+        this: &GpuComputePassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
         method,
         js_class = "GPUComputePassEncoder",
         js_name = "insertDebugMarker"

--- a/crates/web-sys/src/features/gen_GpuFeatureName.rs
+++ b/crates/web-sys/src/features/gen_GpuFeatureName.rs
@@ -33,4 +33,5 @@ pub enum GpuFeatureName {
     TextureFormatsTier2 = "texture-formats-tier2",
     PrimitiveIndex = "primitive-index",
     TextureComponentSwizzle = "texture-component-swizzle",
+    SubgroupSizeControl = "subgroup-size-control",
 }

--- a/crates/web-sys/src/features/gen_GpuPipelineLayoutDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuPipelineLayoutDescriptor.rs
@@ -57,6 +57,24 @@ extern "C" {
         this: &GpuPipelineLayoutDescriptor,
         val: &[::js_sys::JsOption<GpuBindGroupLayout>],
     );
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `immediateSize` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuPipelineLayoutDescriptor`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "immediateSize")]
+    pub fn get_immediate_size(this: &GpuPipelineLayoutDescriptor) -> Option<u32>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `immediateSize` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuPipelineLayoutDescriptor`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "immediateSize")]
+    pub fn set_immediate_size(this: &GpuPipelineLayoutDescriptor, val: u32);
 }
 #[cfg(web_sys_unstable_apis)]
 impl GpuPipelineLayoutDescriptor {
@@ -87,6 +105,12 @@ impl GpuPipelineLayoutDescriptor {
         val: &[::js_sys::JsOption<GpuBindGroupLayout>],
     ) -> &mut Self {
         self.set_bind_group_layouts(val);
+        self
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_immediate_size()` instead."]
+    pub fn immediate_size(&mut self, val: u32) -> &mut Self {
+        self.set_immediate_size(val);
         self
     }
 }

--- a/crates/web-sys/src/features/gen_GpuRenderBundleEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderBundleEncoder.rs
@@ -200,6 +200,456 @@ extern "C" {
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64_and_u32(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderBundleEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderBundleEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64_and_f64(
+        this: &GpuRenderBundleEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
         method,
         js_class = "GPURenderBundleEncoder",
         js_name = "insertDebugMarker"

--- a/crates/web-sys/src/features/gen_GpuRenderPassEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassEncoder.rs
@@ -310,6 +310,456 @@ extern "C" {
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64_and_u32(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+        data_size: u32,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_u32_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_u32_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_u32_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: u32,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_buffer_source_and_f64_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Object,
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_slice_and_f64_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &mut [u8],
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "GPURenderPassEncoder",
+        js_name = "setImmediates"
+    )]
+    #[doc = "The `setImmediates()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setImmediates)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuRenderPassEncoder`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn set_immediates_with_u8_array_and_f64_and_f64(
+        this: &GpuRenderPassEncoder,
+        range_offset: u32,
+        data: &::js_sys::Uint8Array,
+        data_offset: f64,
+        data_size: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
         method,
         js_class = "GPURenderPassEncoder",
         js_name = "insertDebugMarker"

--- a/crates/web-sys/src/features/gen_GpuSupportedLimits.rs
+++ b/crates/web-sys/src/features/gen_GpuSupportedLimits.rs
@@ -121,6 +121,22 @@ extern "C" {
         method,
         getter,
         js_class = "GPUSupportedLimits",
+        js_name = "maxImmediateSize"
+    )]
+    #[doc = "Getter for the `maxImmediateSize` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedLimits/maxImmediateSize)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuSupportedLimits`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn max_immediate_size(this: &GpuSupportedLimits) -> u32;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(
+        method,
+        getter,
+        js_class = "GPUSupportedLimits",
         js_name = "maxBindingsPerBindGroup"
     )]
     #[doc = "Getter for the `maxBindingsPerBindGroup` field of this object."]

--- a/crates/web-sys/src/features/gen_LockManager.rs
+++ b/crates/web-sys/src/features/gen_LockManager.rs
@@ -34,7 +34,7 @@ extern "C" {
     pub fn query(this: &LockManager) -> ::js_sys::Promise<LockManagerSnapshot>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Lock")]
-    #[wasm_bindgen(method, js_class = "LockManager", js_name = "request")]
+    #[wasm_bindgen(method, js_class = "LockManager")]
     #[doc = "The `request()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request)"]
@@ -43,7 +43,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn request_with_callback(
+    pub fn request(
         this: &LockManager,
         name: &str,
         callback: &::js_sys::Function<fn(::js_sys::JsOption<Lock>) -> ::js_sys::Promise>,
@@ -59,7 +59,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn request_with_options_and_callback(
+    pub fn request_with_options(
         this: &LockManager,
         name: &str,
         options: &LockOptions,

--- a/crates/web-sys/webidls/unstable/WebGPU.webidl
+++ b/crates/web-sys/webidls/unstable/WebGPU.webidl
@@ -1,5 +1,5 @@
 // https://gpuweb.github.io/gpuweb/#idl-index
-// 12 February 2026
+// 2 August 2026
 
 interface mixin GPUObjectBase {
     attribute USVString label;
@@ -17,6 +17,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
     readonly attribute unsigned long maxBindGroupsPlusVertexBuffers;
+    readonly attribute unsigned long maxImmediateSize;
     readonly attribute unsigned long maxBindingsPerBindGroup;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
@@ -133,6 +134,7 @@ enum GPUFeatureName {
     "texture-formats-tier2",
     "primitive-index",
     "texture-component-swizzle",
+    "subgroup-size-control",
 };
 
 [Exposed=(Window, Worker), SecureContext]
@@ -609,6 +611,7 @@ GPUPipelineLayout includes GPUObjectBase;
 dictionary GPUPipelineLayoutDescriptor
          : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayout?> bindGroupLayouts;
+    GPUSize32 immediateSize = 0;
 };
 
 [Exposed=(Window, Worker), SecureContext]
@@ -970,11 +973,11 @@ interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
-    // This overload changes other signatures (see #4508)
-    // undefined copyBufferToBuffer(
-    //     GPUBuffer source,
-    //     GPUBuffer destination,
-    //     optional GPUSize64 size);
+    [Throws]
+    undefined copyBufferToBuffer(
+        GPUBuffer source,
+        GPUBuffer destination,
+        optional GPUSize64 size);
 
     [Throws]
     undefined copyBufferToBuffer(
@@ -1033,6 +1036,10 @@ interface mixin GPUBindingCommandsMixin {
         [AllowShared] Uint32Array dynamicOffsetsData,
         GPUSize64 dynamicOffsetsDataStart,
         GPUSize32 dynamicOffsetsDataLength);
+
+    [Throws]
+    undefined setImmediates(GPUSize32 rangeOffset, AllowSharedBufferSource data,
+        optional GPUSize64 dataOffset = 0, optional GPUSize64 dataSize);
 };
 
 interface mixin GPUDebugCommandsMixin {

--- a/crates/web-sys/webidls/unstable/WebGPU.webidl
+++ b/crates/web-sys/webidls/unstable/WebGPU.webidl
@@ -973,13 +973,13 @@ interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
-    [Throws]
+    [Throws, WbgGeneric]
     undefined copyBufferToBuffer(
         GPUBuffer source,
         GPUBuffer destination,
         optional GPUSize64 size);
 
-    [Throws]
+    [Throws, WbgGeneric]
     undefined copyBufferToBuffer(
         GPUBuffer source,
         GPUSize64 sourceOffset,

--- a/crates/web-sys/webidls/unstable/WebGPU.webidl
+++ b/crates/web-sys/webidls/unstable/WebGPU.webidl
@@ -973,13 +973,13 @@ interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
-    [Throws, WbgGeneric]
+    [Throws]
     undefined copyBufferToBuffer(
         GPUBuffer source,
         GPUBuffer destination,
         optional GPUSize64 size);
 
-    [Throws, WbgGeneric]
+    [Throws]
     undefined copyBufferToBuffer(
         GPUBuffer source,
         GPUSize64 sourceOffset,

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -836,12 +836,15 @@ impl<'src> FirstPassRecord<'src> {
                                 deconflict_names: &HashSet<String>|
          -> Vec<InterfaceMethod<'_>> {
             let mut methods = Vec::new();
-            // Simplified overload naming is only enabled for [WbgGeneric] (the
-            // modern bindgen style), keeping legacy generated names stable.
+            // Simplified overload naming is only enabled for typed-generic
+            // operations ([WbgGeneric] or unstable IDL, matching the signature
+            // expansion rule above), keeping legacy generated names stable.
             let simplify = wbg_generic
-                || disambiguate_against
-                    .iter()
-                    .any(|&idx| is_wbg_generic(actual_signatures[idx].orig.attrs.as_ref()));
+                || unstable
+                || disambiguate_against.iter().any(|&idx| {
+                    let orig = actual_signatures[idx].orig;
+                    orig.stability.is_unstable() || is_wbg_generic(orig.attrs.as_ref())
+                });
             let rust_names =
                 compute_rust_names(disambiguate_against, &actual_signatures, js_name, simplify);
             for &sig_idx in sig_indices {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
@@ -568,14 +568,12 @@ impl<'src> FirstPassRecord<'src> {
             Some(output)
         }
 
-        fn compute_rust_name<'a>(
+        fn compute_name_tokens<'a>(
             signature: &ExpandedSig<'a>,
             disambiguate_against: &[usize],
             all_signatures: &[ExpandedSig<'a>],
-            js_name: &str,
-        ) -> String {
-            let mut rust_name = snake_case_ident(js_name);
-            let mut first = true;
+        ) -> Vec<String> {
+            let mut tokens = Vec::new();
 
             for (i, arg) in signature
                 .args
@@ -609,21 +607,100 @@ impl<'src> FirstPassRecord<'src> {
                 if !any_different {
                     continue;
                 }
-                if first {
-                    rust_name.push_str("_with_");
-                    first = false;
+
+                let mut token = String::new();
+                if any_same_name && any_different_type {
+                    arg.push_snake_case_name(&mut token);
                 } else {
-                    rust_name.push_str("_and_");
+                    token.push_str(&snake_case_ident(arg_name));
+                }
+                tokens.push(token);
+            }
+
+            tokens
+        }
+
+        // Computes the Rust names for all signatures in `disambiguate_against` at
+        // once so that, when `simplify` is set, name tokens shared by every
+        // overload variant can be elided when doing so keeps all names distinct.
+        fn compute_rust_names<'a>(
+            disambiguate_against: &[usize],
+            all_signatures: &[ExpandedSig<'a>],
+            js_name: &str,
+            simplify: bool,
+        ) -> HashMap<usize, String> {
+            let mut token_lists: Vec<(usize, Vec<String>)> = disambiguate_against
+                .iter()
+                .map(|&idx| {
+                    (
+                        idx,
+                        compute_name_tokens(
+                            &all_signatures[idx],
+                            disambiguate_against,
+                            all_signatures,
+                        ),
+                    )
+                })
+                .collect();
+
+            fn distinct_count(lists: &[(usize, Vec<String>)]) -> usize {
+                lists
+                    .iter()
+                    .map(|(_, tokens)| tokens.as_slice())
+                    .collect::<HashSet<_>>()
+                    .len()
+            }
+
+            while simplify {
+                let mut candidates = Vec::new();
+                for (_, tokens) in &token_lists {
+                    for token in tokens {
+                        if !candidates.contains(token) {
+                            candidates.push(token.clone());
+                        }
+                    }
                 }
 
-                if any_same_name && any_different_type {
-                    arg.push_snake_case_name(&mut rust_name);
-                } else {
-                    rust_name.push_str(&snake_case_ident(arg_name));
+                let before = distinct_count(&token_lists);
+                let mut removed = false;
+                for candidate in candidates {
+                    if !token_lists
+                        .iter()
+                        .all(|(_, tokens)| tokens.contains(&candidate))
+                    {
+                        continue;
+                    }
+                    let simplified: Vec<(usize, Vec<String>)> = token_lists
+                        .iter()
+                        .map(|(idx, tokens)| {
+                            let mut tokens = tokens.clone();
+                            let pos = tokens.iter().position(|t| t == &candidate).unwrap();
+                            tokens.remove(pos);
+                            (*idx, tokens)
+                        })
+                        .collect();
+                    if distinct_count(&simplified) == before {
+                        token_lists = simplified;
+                        removed = true;
+                        break;
+                    }
+                }
+                if !removed {
+                    break;
                 }
             }
 
-            rust_name
+            token_lists
+                .into_iter()
+                .map(|(idx, tokens)| {
+                    let mut rust_name = snake_case_ident(js_name);
+                    for (i, token) in tokens.iter().enumerate() {
+                        rust_name.push_str(if i == 0 { "_with_" } else { "_and_" });
+                        rust_name.push_str(token);
+                    }
+                    (idx, rust_name)
+                })
+                .collect()
         }
 
         fn create_method<'a>(
@@ -737,10 +814,17 @@ impl<'src> FirstPassRecord<'src> {
                                 deconflict_names: &HashSet<String>|
          -> Vec<InterfaceMethod<'_>> {
             let mut methods = Vec::new();
+            // Simplified overload naming is only enabled for [WbgGeneric] (the
+            // modern bindgen style), keeping legacy generated names stable.
+            let simplify = wbg_generic
+                || disambiguate_against
+                    .iter()
+                    .any(|&idx| is_wbg_generic(actual_signatures[idx].orig.attrs.as_ref()));
+            let rust_names =
+                compute_rust_names(disambiguate_against, &actual_signatures, js_name, simplify);
             for &sig_idx in sig_indices {
                 let signature = &actual_signatures[sig_idx];
-                let mut rust_name =
-                    compute_rust_name(signature, disambiguate_against, &actual_signatures, js_name);
+                let mut rust_name = rust_names[&sig_idx].clone();
 
                 // If the computed name collides with a name from another expansion
                 // (e.g. a stable expansion name colliding with an unstable IDL override

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -568,11 +568,13 @@ impl<'src> FirstPassRecord<'src> {
             Some(output)
         }
 
+        // Returns the disambiguation name tokens for a signature, each paired
+        // with the index of the argument it was derived from.
         fn compute_name_tokens<'a>(
             signature: &ExpandedSig<'a>,
             disambiguate_against: &[usize],
             all_signatures: &[ExpandedSig<'a>],
-        ) -> Vec<String> {
+        ) -> Vec<(usize, String)> {
             let mut tokens = Vec::new();
 
             for (i, arg) in signature
@@ -614,7 +616,7 @@ impl<'src> FirstPassRecord<'src> {
                 } else {
                     token.push_str(&snake_case_ident(arg_name));
                 }
-                tokens.push(token);
+                tokens.push((i, token));
             }
 
             tokens
@@ -623,13 +625,15 @@ impl<'src> FirstPassRecord<'src> {
         // Computes the Rust names for all signatures in `disambiguate_against` at
         // once so that, when `simplify` is set, name tokens shared by every
         // overload variant can be elided when doing so keeps all names distinct.
+        // A token is only elided if, within each overload, it comes from the
+        // same argument in every expanded variant of that overload.
         fn compute_rust_names<'a>(
             disambiguate_against: &[usize],
             all_signatures: &[ExpandedSig<'a>],
             js_name: &str,
             simplify: bool,
         ) -> HashMap<usize, String> {
-            let mut token_lists: Vec<(usize, Vec<String>)> = disambiguate_against
+            let mut token_lists: Vec<(usize, Vec<(usize, String)>)> = disambiguate_against
                 .iter()
                 .map(|&idx| {
                     (
@@ -643,49 +647,67 @@ impl<'src> FirstPassRecord<'src> {
                 })
                 .collect();
 
-            fn distinct_count(lists: &[(usize, Vec<String>)]) -> usize {
+            fn distinct_count(lists: &[(usize, Vec<(usize, String)>)]) -> usize {
                 lists
                     .iter()
-                    .map(|(_, tokens)| tokens.as_slice())
+                    .map(|(_, tokens)| tokens.iter().map(|(_, t)| t.as_str()).collect::<Vec<_>>())
                     .collect::<HashSet<_>>()
                     .len()
             }
 
-            while simplify {
-                let mut candidates = Vec::new();
-                for (_, tokens) in &token_lists {
-                    for token in tokens {
-                        if !candidates.contains(token) {
-                            candidates.push(token.clone());
-                        }
+            if simplify {
+                // Group expanded variants by the overload they came from.
+                let mut groups: Vec<(*const (), Vec<usize>)> = Vec::new();
+                for (pos, (idx, _)) in token_lists.iter().enumerate() {
+                    let orig = all_signatures[*idx].orig as *const _ as *const ();
+                    match groups.iter_mut().find(|(o, _)| *o == orig) {
+                        Some((_, members)) => members.push(pos),
+                        None => groups.push((orig, vec![pos])),
                     }
                 }
 
-                let before = distinct_count(&token_lists);
-                let mut removed = false;
-                for candidate in candidates {
-                    if !token_lists
-                        .iter()
-                        .all(|(_, tokens)| tokens.contains(&candidate))
-                    {
-                        continue;
+                'elide: loop {
+                    let mut candidates = Vec::new();
+                    for (_, tokens) in &token_lists {
+                        for (_, token) in tokens {
+                            if !candidates.contains(token) {
+                                candidates.push(token.clone());
+                            }
+                        }
                     }
-                    let simplified: Vec<(usize, Vec<String>)> = token_lists
-                        .iter()
-                        .map(|(idx, tokens)| {
-                            let mut tokens = tokens.clone();
-                            let pos = tokens.iter().position(|t| t == &candidate).unwrap();
+
+                    let before = distinct_count(&token_lists);
+                    'candidates: for candidate in candidates {
+                        // For each overload, find an argument that yields this
+                        // token in every variant of that overload.
+                        let mut removals = Vec::new();
+                        for (_, members) in &groups {
+                            let arg = token_lists[members[0]].1.iter().find_map(|(a, t)| {
+                                (t == &candidate
+                                    && members.iter().all(|&m| {
+                                        token_lists[m]
+                                            .1
+                                            .iter()
+                                            .any(|(a2, t2)| a2 == a && t2 == &candidate)
+                                    }))
+                                .then_some(*a)
+                            });
+                            match arg {
+                                Some(arg) => removals.extend(members.iter().map(|&m| (m, arg))),
+                                None => continue 'candidates,
+                            }
+                        }
+                        let mut simplified = token_lists.clone();
+                        for (m, arg) in removals {
+                            let tokens = &mut simplified[m].1;
+                            let pos = tokens.iter().position(|(a, _)| *a == arg).unwrap();
                             tokens.remove(pos);
-                            (*idx, tokens)
-                        })
-                        .collect();
-                    if distinct_count(&simplified) == before {
-                        token_lists = simplified;
-                        removed = true;
-                        break;
+                        }
+                        if distinct_count(&simplified) == before {
+                            token_lists = simplified;
+                            continue 'elide;
+                        }
                     }
-                }
-                if !removed {
                     break;
                 }
             }
@@ -694,7 +716,7 @@ impl<'src> FirstPassRecord<'src> {
                 .into_iter()
                 .map(|(idx, tokens)| {
                     let mut rust_name = snake_case_ident(js_name);
-                    for (i, token) in tokens.iter().enumerate() {
+                    for (i, (_, token)) in tokens.iter().enumerate() {
                         rust_name.push_str(if i == 0 { "_with_" } else { "_and_" });
                         rust_name.push_str(token);
                     }


### PR DESCRIPTION
### Description
Updates the WebGPU bindings to the latest IDL (2026-08-02) at https://gpuweb.github.io/gpuweb/#idl-index

### Checklist

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
