### PR TITLE
Emscripten: use __export/__force symbol attributes for public exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Changed
 
+* Emscripten output now marks public exports (free functions, classes, enums,
+  and namespace roots) with the `__export: true` and `__force: true` symbol
+  attributes on their `addToLibrary` entries, instead of mutating
+  `EXPORTED_FUNCTIONS` and pushing to `extraLibraryFuncs` at library-load time.
+  The `$initBindgen` init closure is kept via `__force: true`, and private
+  symbols (including namespace leaves) carry neither attribute — they remain
+  reachable through `__deps`. Requires an emscripten with `__export`/`__force`
+  symbol-attribute support.
+
 ### Fixed
 
 * Fixed threaded Wasm memory layout to reserve wasm-bindgen's internal thread

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -188,17 +188,12 @@ pub struct Context<'a> {
     /// the emscripten library file (e.g. `$heap`, `$WASM_VECTOR_LEN`,
     /// `$HEAP_DATA_VIEW`). Drives the top-of-library `addToLibrary({...})`
     /// block in `generate_emscripten_imports` and is unioned into
-    /// `extraLibraryFuncs` so emcc keeps them.
+    /// `$initBindgen__deps` (which is `__force`d) so emcc keeps them.
     emscripten_global_deps: BTreeSet<String>,
 
     /// Per-import `__deps` arrays, computed by snapshotting `adapter_deps`
     /// before generating each import and diffing afterwards.
     emscripten_import_deps: BTreeMap<ImportId, BTreeSet<String>>,
-
-    /// Public exports hoisted into top-level `addToLibrary` symbols, recorded
-    /// so they can be added to `EXPORTED_FUNCTIONS` in
-    /// `generate_emscripten_wasm_loading`.
-    emscripten_runtime_exports: Vec<String>,
 
     /// `true` when the module's memory is a memory64 (wasm64) memory.
     memory64: bool,
@@ -363,7 +358,6 @@ impl<'a> Context<'a> {
             adapter_deps: Default::default(),
             emscripten_global_deps: Default::default(),
             emscripten_import_deps: Default::default(),
-            emscripten_runtime_exports: Default::default(),
             memory64,
             super_skip_sentinel_emitted: false,
         })
@@ -480,8 +474,10 @@ impl<'a> Context<'a> {
     /// for a namespace root). `extra_deps` lists `$`-less library symbols the
     /// body references; every symbol also depends on `$initBindgen`.
     /// `postset_extra` runs after the symbol is defined. `public` adds the
-    /// `Module.<id>` attachment and records the name for `EXPORTED_FUNCTIONS`;
-    /// namespace leaves are hoisted privately (`public = false`).
+    /// `Module.<id>` attachment plus the `__export`/`__force` attributes so
+    /// emscripten includes the symbol and emits it as a named export;
+    /// namespace leaves are hoisted privately (`public = false`) and stay
+    /// reachable through the root's `__deps`.
     fn hoist_emscripten_export(
         &mut self,
         identifier: &str,
@@ -504,14 +500,16 @@ impl<'a> Context<'a> {
         } else {
             format!(",\n    ${identifier}__postset: {postset:?}")
         };
+        let export_attrs = if public {
+            format!(",\n    ${identifier}__export: true,\n    ${identifier}__force: true")
+        } else {
+            String::new()
+        };
         self.emscripten_library(&format!(
             "addToLibrary({{\n    ${identifier}: {value},\n    \
-             ${identifier}__deps: [{}]{postset_field}\n}});",
+             ${identifier}__deps: [{}]{postset_field}{export_attrs}\n}});",
             deps_fmt.join(", "),
         ));
-        if public {
-            self.emscripten_runtime_exports.push(identifier.to_string());
-        }
     }
 
     /// Hoist a clean export (free function, class, or enum) to a library symbol
@@ -1775,31 +1773,24 @@ if (require('worker_threads').isMainThread) {{
             .collect();
         let init_dep_refs: Vec<String> = init_deps.iter().map(|d| format!("'${d}'")).collect();
 
-        let global_dep_refs: Vec<String> = self
-            .emscripten_global_deps
-            .iter()
-            .map(|dep| format!("'${dep}'"))
-            .collect();
-
         let start_logic = if needs_manual_start {
             "wasmExports['__wbindgen_start']();"
         } else {
             ""
         };
 
-        // Adding each name to `EXPORTED_FUNCTIONS` forces jsifier to include the
-        // `$<id>` symbol and prefix it with `export` under `MODULARIZE=instance`.
-        let self_register = self
-            .emscripten_runtime_exports
-            .iter()
-            .map(|id| format!("EXPORTED_FUNCTIONS.add('{id}');\n"))
-            .collect::<String>();
-
+        // `__force` keeps `$initBindgen` (and, via its `__deps`, every global
+        // helper) in the build even though no compiled code references it.
+        // Public exports carry their own `__export`/`__force` attributes at
+        // their `addToLibrary` definitions, which makes jsifier include the
+        // `$<id>` symbol and prefix it with `export` under
+        // `MODULARIZE=instance`.
         format!(
             r#"
             addToLibrary({{
                 $initBindgen__deps: [{init_deps}],
                 $initBindgen__postset: 'addOnInit(initBindgen);',
+                $initBindgen__force: true,
                 $initBindgen: () => {{
                     // Call emscripten's _initialize to run static constructors
                     // (needed for --no-entry builds)
@@ -1809,12 +1800,8 @@ if (require('worker_threads').isMainThread) {{
                     {start_logic}
                     {classes_and_exports}
                 }}
-            }});
-
-            extraLibraryFuncs.push('$initBindgen', '$addOnInit', {global_deps});
-            {self_register}"#,
+            }});"#,
             init_deps = init_dep_refs.join(", "),
-            global_deps = global_dep_refs.join(", "),
         )
     }
 

--- a/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
+++ b/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
@@ -1,9 +1,6 @@
 (function() {
     var elem = document.querySelector('#output');
-    window.extraLibraryFuncs = [];
     window.mergedLibrary = {};
-    // emscripten setting the library file self-registers into at compile time.
-    window.EXPORTED_FUNCTIONS = new Set();
 
     window.wasmExports = {
         __wbindgen_start: () => {},
@@ -18,6 +15,14 @@
         Object.assign(window.mergedLibrary, obj);
     };
 
+    // Symbol attribute (decorator) suffixes: `$name__deps`, `$name__postset`,
+    // `$name__export`, `$name__force` are attributes of `$name`, not library
+    // symbols in their own right.
+    var DECORATORS = ['__deps', '__postset', '__export', '__force'];
+    function isDecorator(key) {
+        return DECORATORS.some(function(d) { return key.endsWith(d); });
+    }
+
     // Defer test execution to allow library_bindgen.js to finish evaluating
     setTimeout(function() {
         try {
@@ -26,13 +31,21 @@
             }
             // Execute the initialization (assigns `wasm`, runs start).
             window.mergedLibrary.$initBindgen();
-            // Each clean export is a hoisted `$<name>` library symbol that
-            // self-registers into `EXPORTED_FUNCTIONS`. Under emscripten that
+            // Each clean export is a hoisted `$<name>` library symbol carrying
+            // `$<name>__export: true` (and `__force`). Under emscripten that
             // makes it a named ESM export (instance mode) and, via the symbol's
             // `Module['<name>'] = <name>` __postset, a `Module` property
-            // (factory mode). Simulate the latter directly from the symbols
-            // rather than evaluating postset source.
-            for (const name of window.EXPORTED_FUNCTIONS) {
+            // (factory mode). Discover the exports from the `__export`
+            // attributes and simulate the Module attachment directly from the
+            // symbols rather than evaluating postset source.
+            window.exportedSymbols = new Set();
+            for (const key of Object.keys(window.mergedLibrary)) {
+                if (!key.startsWith('$') || isDecorator(key)) continue;
+                if (window.mergedLibrary[key + '__export'] === true) {
+                    window.exportedSymbols.add(key.slice(1));
+                }
+            }
+            for (const name of window.exportedSymbols) {
                 window.Module[name] = window.mergedLibrary['$' + name];
             }
         } catch (e) {
@@ -40,11 +53,18 @@
             return;
         }
 
-        function testExtraLibraryFuncs() {
-            const required = ['$initBindgen', '$addOnInit', '$CLOSURE_DTORS', '$WASM_VECTOR_LEN'];
+        function testInitBindgenForced() {
+            // `$initBindgen` roots the library graph: it must be `__force`d
+            // and its `__deps` must carry the global helper symbols
+            // (previously kept via `extraLibraryFuncs`).
+            if (window.mergedLibrary.$initBindgen__force !== true) {
+                return { status: false, e: 'test result: $initBindgen is not __force: true' };
+            }
+            const deps = window.mergedLibrary.$initBindgen__deps || [];
+            const required = ['$addOnInit', '$CLOSURE_DTORS', '$WASM_VECTOR_LEN'];
             for (const value of required) {
-                if (!window.extraLibraryFuncs.includes(value)) {
-                    return { status: false, e: `test result: ${value} not found in extraLibraryFuncs` };
+                if (!deps.includes(value)) {
+                    return { status: false, e: `test result: ${value} not found in $initBindgen__deps` };
                 }
             }
             return { status: true, e: 'test result: ok' };
@@ -58,11 +78,14 @@
             if (typeof Module.Interval !== 'function') {
                 return { status: false, e: 'test result: Interval is not found in Module' };
             }
-            // The hoisted exports must self-register so emscripten emits them as
-            // named ESM exports under -sMODULARIZE=instance.
+            // The hoisted exports must carry both attributes so emscripten
+            // emits them as named ESM exports under -sMODULARIZE=instance.
             for (const name of ['hello', 'Interval']) {
-                if (!window.EXPORTED_FUNCTIONS.has(name)) {
-                    return { status: false, e: `test result: ${name} not registered in EXPORTED_FUNCTIONS` };
+                if (!window.exportedSymbols.has(name)) {
+                    return { status: false, e: `test result: ${name} does not carry __export: true` };
+                }
+                if (window.mergedLibrary['$' + name + '__force'] !== true) {
+                    return { status: false, e: `test result: ${name} does not carry __force: true` };
                 }
             }
 
@@ -80,7 +103,7 @@
             return { status: true, e: 'test result: ok' };      
         }
 
-        const tests = [testExtraLibraryFuncs(), testModuleExports()];
+        const tests = [testInitBindgenForced(), testModuleExports()];
         for (const res of tests) {
             if (!res.status) {
                 elem.textContent += res.e;

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2347,6 +2347,34 @@ fn emscripten_namespaced_exports_valid_ts() {
     ])
     .unwrap();
 
+    // Only the public namespace roots carry the `__export`/`__force`
+    // attributes; the hoisted leaves stay private, reachable through the
+    // root's `__deps`.
+    let lib = fs::read_to_string(out_dir.join("library_bindgen.js")).unwrap();
+    for root in ["app", "foo", "bar"] {
+        assert!(
+            lib.contains(&format!("${root}__export: true"))
+                && lib.contains(&format!("${root}__force: true")),
+            "namespace root {root} should carry __export/__force:\n{lib}"
+        );
+    }
+    for leaf in [
+        "app__math__Calc",
+        "app__math__Op",
+        "app__math__pi",
+        "foo__Point",
+        "bar__Point",
+    ] {
+        assert!(
+            !lib.contains(&format!("${leaf}__export")) && !lib.contains(&format!("${leaf}__force")),
+            "namespace leaf {leaf} must not carry __export/__force:\n{lib}"
+        );
+        assert!(
+            lib.contains(&format!("'${leaf}'")),
+            "namespace leaf {leaf} must be reachable via __deps:\n{lib}"
+        );
+    }
+
     let d_ts_path = out_dir.join("emscripten_input.d.ts");
     let d_ts = fs::read_to_string(&d_ts_path).unwrap();
 
@@ -2494,8 +2522,8 @@ fn emscripten_namespaced_exports_valid_ts() {
 
 #[test]
 fn emscripten_exports_hoisted_to_library_symbols() {
-    // Clean exports are hoisted into top-level `addToLibrary` symbols and
-    // self-registered so emscripten emits them itself.
+    // Clean exports are hoisted into top-level `addToLibrary` symbols carrying
+    // `__export`/`__force` attributes so emscripten emits them itself.
     let mut project = Project::new("emscripten_exports_hoisted_to_library_symbols");
     project.file(
         "src/lib.rs",
@@ -2603,17 +2631,32 @@ fn emscripten_exports_hoisted_to_library_symbols() {
             ),
         "CounterFinalization should be constructed in a __postset:\n{lib}"
     );
-    // Self-registration so emscripten exports them itself.
+    // Public exports carry the `__export`/`__force` symbol attributes so
+    // emscripten includes and exports them itself.
     for name in ["add", "Counter", "Color"] {
         assert!(
-            lib.contains(&format!("EXPORTED_FUNCTIONS.add('{name}');")),
-            "{name} should be self-registered into EXPORTED_FUNCTIONS:\n{lib}"
+            lib.contains(&format!("${name}__export: true")),
+            "{name} should carry __export: true:\n{lib}"
+        );
+        assert!(
+            lib.contains(&format!("${name}__force: true")),
+            "{name} should carry __force: true:\n{lib}"
         );
     }
-    // No force-keep: EXPORTED_FUNCTIONS membership already retains each symbol.
+    // No EXPORTED_FUNCTIONS mutation and no extraLibraryFuncs force-keep:
+    // the symbol attributes replace both mechanisms.
     assert!(
-        !lib.contains("extraLibraryFuncs.push('$add'"),
-        "public exports should rely on EXPORTED_FUNCTIONS, not a redundant force-keep:\n{lib}"
+        !lib.contains("EXPORTED_FUNCTIONS"),
+        "generated library must not mutate EXPORTED_FUNCTIONS:\n{lib}"
+    );
+    assert!(
+        !lib.contains("extraLibraryFuncs"),
+        "generated library must not push to extraLibraryFuncs:\n{lib}"
+    );
+    // The init closure roots the graph via __force instead.
+    assert!(
+        lib.contains("$initBindgen__force: true"),
+        "$initBindgen must be force-included:\n{lib}"
     );
     assert!(
         lib.contains("$Counter__deps: ['$initBindgen', '$CounterFinalization']"),
@@ -2625,8 +2668,8 @@ fn emscripten_exports_hoisted_to_library_symbols() {
         "private class should still be hoisted as a library symbol:\n{lib}"
     );
     assert!(
-        !lib.contains("EXPORTED_FUNCTIONS.add('Secret')"),
-        "private class must not self-register as a named export:\n{lib}"
+        !lib.contains("$Secret__export") && !lib.contains("$Secret__force"),
+        "private class must not carry __export/__force attributes:\n{lib}"
     );
     assert!(
         !lib.contains("Module['Secret']"),


### PR DESCRIPTION
This updates emscripten JS-library generation to declare public exports through emscripten symbol attributes rather than mutating `EXPORTED_FUNCTIONS` at library load time, matching the symbol-attribute support added in https://github.com/emscripten-core/emscripten/pull/27436.

Each public hoisted export now carries metadata on its own library symbol:

```js
addToLibrary({
  $Counter: class Counter { ... },
  $Counter__deps: ['$initBindgen', '$CounterFinalization'],
  $Counter__export: true,
  $Counter__force: true,
});
```

* Public functions, classes, enums, and namespace roots receive both `__export` and `__force`; private exports receive neither.
* For namespaced APIs only the public namespace root carries the attributes; its private leaves stay reachable through the root's `__deps`.
* `$initBindgen` is kept via `__force: true` instead of `extraLibraryFuncs`; its `__deps` continue to carry the global helper symbols.
* All generated `EXPORTED_FUNCTIONS.add(...)` statements and the `extraLibraryFuncs.push(...)` are removed.
* Existing `__deps`, `__postset`, finalizer, enum, import-shim, and `Module[name]` behavior is preserved.

Test coverage: the CLI expectations assert public symbols carry both attributes and private symbols neither, namespace roots vs leaves behave as above, and the generated library contains no `EXPORTED_FUNCTIONS`/`extraLibraryFuncs` references. The emscripten test harness now discovers exports from the `__export` attributes (with decorator filtering recognizing `__export`/`__force`) and preserves the factory-mode `Module.<name>` assertions.

Requires an emscripten with `__export`/`__force` symbol-attribute support. Once released, emscripten #27208 can bump its crate and CLI pins from 0.2.126.