### PR TITLE
Bump library MSRV to 1.81

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -588,7 +588,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.77
+          - 1.81
           - stable
         target:
           - x86_64-unknown-linux-gnu
@@ -614,7 +614,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.77
+          - 1.81
           - 1.86
         target:
           - x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Changed
 
 * Library MSRV bumped from 1.77 to 1.81, per the 2-year MSRV policy.
-  [#5256](https://github.com/wasm-bindgen/wasm-bindgen/pull/5256)
+  [#5257](https://github.com/wasm-bindgen/wasm-bindgen/pull/5257)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### Changed
 
+* Library MSRV bumped from 1.77 to 1.81, per the 2-year MSRV policy.
+  [#5256](https://github.com/wasm-bindgen/wasm-bindgen/pull/5256)
+
 ### Fixed
 
 * Fixed `async` imports with non-JS-handle resolved types (e.g.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen"
 readme = "README.md"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.2.126"
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ greet("World!");
 
 ## MSRV Policy
 
-* Libraries that are released on [crates.io](https://crates.io) have a MSRV of v1.77.
+* Libraries that are released on [crates.io](https://crates.io) have a MSRV of v1.81.
 * CLI tools and their corresponding support libraries have a MSRV of v1.86.
 
 The project aims to maintain a 2-year MSRV policy for libraries (meaning we support Rust versions released within the last 2 years), but with a shorter MSRV policy for the CLI. Changes to the MSRV may be made in patch versions, and will be logged in the CHANGELOG and MSRV history below.
@@ -116,6 +116,7 @@ The project aims to maintain a 2-year MSRV policy for libraries (meaning we supp
 
 | Version | Library MSRV | CLI MSRV | Date       |
 |---------|--------------|----------|------------|
+| 0.2.127 | 1.81         | 1.86     | 2026-09-05 |
 | 0.2.118 | 1.77         | 1.86     | 2026-04-10 |
 | 0.2.106 | 1.71         | 1.82     | 2025-11-27 |
 | 0.2.103 | 1.57         | 1.82     | 2025-09-17 |

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The wasm-bindgen Developers"]
 edition = "2021"
 name = "wasm-bindgen-benchmark"
 publish = false
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.0.0"
 
 [dependencies]

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-futures"
 readme = "./README.md"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.4.76"
 
 [package.metadata.docs.rs]

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "js-sys"
 readme = "./README.md"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.3.103"
 
 [lib]

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -8,7 +8,7 @@ include = ["/LICENSE-*", "/src"]
 license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-macro-support"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.2.126"
 
 [features]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -10,7 +10,7 @@ include = ["/LICENSE-*", "/src"]
 license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-macro"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.2.126"
 
 [lib]

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -11,7 +11,7 @@ include = ["/build.rs", "/LICENSE-*", "/src"]
 license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-shared"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.2.126"
 
 # Because only a single `wasm_bindgen` version can be used in a dependency

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -6,7 +6,7 @@ include = ["/LICENSE-*", "/src"]
 license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-test-macro"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.3.76"
 
 [lib]

--- a/crates/test-shared/Cargo.toml
+++ b/crates/test-shared/Cargo.toml
@@ -11,7 +11,7 @@ include = ["/LICENSE-*", "/src"]
 license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-test-shared"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/test-shared"
-rust-version = "1.77"
+rust-version = "1.81"
 
 version = "0.2.126"
 

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -6,7 +6,7 @@ include = ["/LICENSE-*", "/src"]
 license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-test"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.3.76"
 
 [features]

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "web-sys"
 readme = "./README.md"
 repository = "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys"
-rust-version = "1.77"
+rust-version = "1.81"
 version = "0.3.103"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This bumps the library MSRV from 1.77 to 1.81, resolves #5255.

Per the 2-year MSRV policy, Rust 1.81 (released 2024-09-05) becomes eligible on 2026-09-05, so this should land in September and not before.

* Updates `rust-version` across the library crates and benchmarks
* Updates the MSRV CI matrix, README policy and MSRV history

This unblocks #5029, switching the `JsError` blanket `From` impl to `core::error::Error` and removing its `std` feature gate (resolving #5025, #5236). Note #5209 requires 1.82 (eligible ~2026-10-17) and remains blocked.