### PR TITLE
Add JsNullable for WebIDL nullable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@
 * Added `riscv64gc-unknown-linux-gnu` release artifacts.
   [#5265](https://github.com/wasm-bindgen/wasm-bindgen/pull/5265)
 
+* Added `JsNullable<T>`, modeling WebIDL nullable types (`T | null`). Both
+  `null` and `undefined` are treated as absent, per WebIDL's ECMAScript
+  conversion rules; the canonical empty value produced from Rust is `null`.
+  `web-sys` now uses `JsNullable<T>` instead of `JsOption<T>` for nullable
+  types nested inside generics (e.g. `Promise<GpuError?>` from
+  `GPUDevice.popErrorScope()`), fixing spec-defined `null` resolutions being
+  treated as present values under `JsOption<T>`'s strict undefined-only
+  semantics.
+  [#5234](https://github.com/wasm-bindgen/wasm-bindgen/issues/5234)
+
 ### Changed
 
 * Emscripten output now marks public exports (free functions, classes, enums,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@
   treated as present values under `JsOption<T>`'s strict undefined-only
   semantics. `JsNullable<T>` participates in the same upcast lattice as
   `JsOption<T>` (including contravariant closure argument casts), and
-  additionally upcasts from `Null` and from `JsOption<T>` itself.
+  additionally upcasts from `Null` and from `JsOption<T>` itself. Imported
+  extern types now also upcast into `JsOption<JsValue>` and
+  `JsNullable<JsValue>`, so catch-all nullable closures can be used where a
+  typed callback is expected.
   [#5234](https://github.com/wasm-bindgen/wasm-bindgen/issues/5234)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
   types nested inside generics (e.g. `Promise<GpuError?>` from
   `GPUDevice.popErrorScope()`), fixing spec-defined `null` resolutions being
   treated as present values under `JsOption<T>`'s strict undefined-only
-  semantics.
+  semantics. `JsNullable<T>` participates in the same upcast lattice as
+  `JsOption<T>` (including contravariant closure argument casts), and
+  additionally upcasts from `Null` and from `JsOption<T>` itself.
   [#5234](https://github.com/wasm-bindgen/wasm-bindgen/issues/5234)
 
 ### Changed

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -52,7 +52,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsError;
 
 // Re-export sys types as js-sys types
-pub use wasm_bindgen::sys::{JsOption, Null, Promising, Undefined};
+pub use wasm_bindgen::sys::{JsNullable, JsOption, Null, Promising, Undefined};
 pub use wasm_bindgen::{IntoJsGeneric, JsGeneric};
 
 // When adding new imports:

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1816,6 +1816,10 @@ macro_rules! impl_tuple_covariance {
         where
             $(Target: UpcastFrom<$T>,)+
         {}
+        impl<$($T,)+ Target> UpcastFrom<ArrayTuple<($($T,)+)>> for JsNullable<Array<Target>>
+        where
+            $(Target: UpcastFrom<$T>,)+
+        {}
     };
 }
 
@@ -1832,6 +1836,7 @@ impl_tuple_covariance!([T1 T2 T3 T4 T5 T6 T7 T8] [Target1 Target2 Target3 Target
 impl<T: JsTuple, U: JsTuple> UpcastFrom<ArrayTuple<T>> for ArrayTuple<U> where U: UpcastFrom<T> {}
 impl<T: JsTuple> UpcastFrom<ArrayTuple<T>> for JsValue {}
 impl<T: JsTuple> UpcastFrom<ArrayTuple<T>> for JsOption<JsValue> {}
+impl<T: JsTuple> UpcastFrom<ArrayTuple<T>> for JsNullable<JsValue> {}
 
 /// Iterator returned by `Array::into_iter`
 #[derive(Debug, Clone)]
@@ -4578,8 +4583,10 @@ extern "C" {
 // Basic UpcastFrom impls for Function<T>
 impl<T: JsFunction> UpcastFrom<Function<T>> for JsValue {}
 impl<T: JsFunction> UpcastFrom<Function<T>> for JsOption<JsValue> {}
+impl<T: JsFunction> UpcastFrom<Function<T>> for JsNullable<JsValue> {}
 impl<T: JsFunction> UpcastFrom<Function<T>> for Object {}
 impl<T: JsFunction> UpcastFrom<Function<T>> for JsOption<Object> {}
+impl<T: JsFunction> UpcastFrom<Function<T>> for JsNullable<Object> {}
 
 // Blanket trait for Function upcast
 // Function<T> upcasts to Function<U> when the underlying fn type T upcasts to U.

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -1492,7 +1492,7 @@ impl TryToTokens for ast::ImportType {
             })
             .to_tokens(tokens);
 
-            // 2. For non-generic types: generate identity upcast (UpcastFrom<Self> for Self, UpcastFrom<Self> for JsOption<Self>)
+            // 2. For non-generic types: generate identity upcast (UpcastFrom<Self> for Self, UpcastFrom<Self> for JsOption<Self>/JsNullable<Self>)
             // 3. For generic types: generate structural covariance
             let type_params: Vec<_> = self.generics.type_params().collect();
             if type_params.is_empty() {
@@ -1508,6 +1508,12 @@ impl TryToTokens for ast::ImportType {
                     #[automatically_derived]
                     impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #wasm_bindgen::sys::JsOption<#rust_name #ty_generics>
+                    #where_clause
+                    {
+                    }
+                    #[automatically_derived]
+                    impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                        for #wasm_bindgen::sys::JsNullable<#rust_name #ty_generics>
                     #where_clause
                     {
                     }
@@ -1576,6 +1582,12 @@ impl TryToTokens for ast::ImportType {
                     #where_clause_extended
                     {
                     }
+                    #[automatically_derived]
+                    impl #impl_generics_split #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                        for #wasm_bindgen::sys::JsNullable<#rust_name #target_ty_generics>
+                    #where_clause_extended
+                    {
+                    }
                 })
                 .to_tokens(tokens);
             }
@@ -1592,6 +1604,12 @@ impl TryToTokens for ast::ImportType {
                     #[automatically_derived]
                     impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                         for #wasm_bindgen::sys::JsOption<#superclass>
+                    #where_clause
+                    {
+                    }
+                    #[automatically_derived]
+                    impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                        for #wasm_bindgen::sys::JsNullable<#superclass>
                     #where_clause
                     {
                     }

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -1481,11 +1481,24 @@ impl TryToTokens for ast::ImportType {
 
         // Generate UpcastFrom implementations (unless no_upcast is set)
         if !self.no_upcast {
-            // 1. Always generate UpcastFrom<Self> for JsValue
+            // 1. Always generate UpcastFrom<Self> for JsValue, including its
+            // JsOption/JsNullable wrappers (like superclass targets below)
             (quote! {
                 #[automatically_derived]
                 impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
                     for #wasm_bindgen::JsValue
+                #where_clause
+                {
+                }
+                #[automatically_derived]
+                impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    for #wasm_bindgen::sys::JsOption<#wasm_bindgen::JsValue>
+                #where_clause
+                {
+                }
+                #[automatically_derived]
+                impl #impl_generics #wasm_bindgen::convert::UpcastFrom<#rust_name #ty_generics>
+                    for #wasm_bindgen::sys::JsNullable<#wasm_bindgen::JsValue>
                 #where_clause
                 {
                 }

--- a/crates/macro/ui-tests/missing-catch.stderr
+++ b/crates/macro/ui-tests/missing-catch.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             Box<[T]>
             Clamped<T>
             JsError
-            JsOption<T>
+            JsNullable<T>
           and $N others
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -33,7 +33,7 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             Box<[T]>
             Clamped<T>
             JsError
-            JsOption<T>
+            JsNullable<T>
           and $N others
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -51,5 +51,5 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             Box<[T]>
             Clamped<T>
             JsError
-            JsOption<T>
+            JsNullable<T>
           and $N others

--- a/crates/macro/ui-tests/traits-not-implemented.stderr
+++ b/crates/macro/ui-tests/traits-not-implemented.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
   | ^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `A`
   |
   = help: the following other types implement trait `IntoWasmAbi`:
+            &'a JsNullable<T>
             &'a JsOption<T>
             &'a Undefined
             &'a [MaybeUninit<f32>]
@@ -12,7 +13,6 @@ error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
             &'a [MaybeUninit<i16>]
             &'a [MaybeUninit<i32>]
             &'a [MaybeUninit<i64>]
-            &'a [MaybeUninit<i8>]
           and $N others
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -23,6 +23,7 @@ error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
   |                   ^ the trait `IntoWasmAbi` is not implemented for `A`
   |
   = help: the following other types implement trait `IntoWasmAbi`:
+            &'a JsNullable<T>
             &'a JsOption<T>
             &'a Undefined
             &'a [MaybeUninit<f32>]
@@ -30,5 +31,4 @@ error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
             &'a [MaybeUninit<i16>]
             &'a [MaybeUninit<i32>]
             &'a [MaybeUninit<i64>]
-            &'a [MaybeUninit<i8>]
           and $N others

--- a/crates/web-sys/src/features/gen_DataTransferItem.rs
+++ b/crates/web-sys/src/features/gen_DataTransferItem.rs
@@ -55,7 +55,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn get_as_file_system_handle(
         this: &DataTransferItem,
-    ) -> ::js_sys::Promise<::js_sys::JsOption<FileSystemHandle>>;
+    ) -> ::js_sys::Promise<::js_sys::JsNullable<FileSystemHandle>>;
     #[wasm_bindgen(catch, method, js_class = "DataTransferItem", js_name = "getAsString")]
     #[doc = "The `getAsString()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_Gpu.rs
+++ b/crates/web-sys/src/features/gen_Gpu.rs
@@ -51,7 +51,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn request_adapter(this: &Gpu) -> ::js_sys::Promise<::js_sys::JsOption<GpuAdapter>>;
+    pub fn request_adapter(this: &Gpu) -> ::js_sys::Promise<::js_sys::JsNullable<GpuAdapter>>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "GpuAdapter", feature = "GpuRequestAdapterOptions",))]
     #[wasm_bindgen(method, js_class = "GPU", js_name = "requestAdapter")]
@@ -66,5 +66,5 @@ extern "C" {
     pub fn request_adapter_with_options(
         this: &Gpu,
         options: &GpuRequestAdapterOptions,
-    ) -> ::js_sys::Promise<::js_sys::JsOption<GpuAdapter>>;
+    ) -> ::js_sys::Promise<::js_sys::JsNullable<GpuAdapter>>;
 }

--- a/crates/web-sys/src/features/gen_GpuDevice.rs
+++ b/crates/web-sys/src/features/gen_GpuDevice.rs
@@ -429,7 +429,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn pop_error_scope(this: &GpuDevice) -> ::js_sys::Promise<::js_sys::JsOption<GpuError>>;
+    pub fn pop_error_scope(this: &GpuDevice) -> ::js_sys::Promise<::js_sys::JsNullable<GpuError>>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuErrorFilter")]
     #[wasm_bindgen(method, js_class = "GPUDevice", js_name = "pushErrorScope")]

--- a/crates/web-sys/src/features/gen_GpuFragmentState.rs
+++ b/crates/web-sys/src/features/gen_GpuFragmentState.rs
@@ -81,7 +81,7 @@ extern "C" {
     #[wasm_bindgen(method, getter = "targets")]
     pub fn get_targets(
         this: &GpuFragmentState,
-    ) -> ::js_sys::Array<::js_sys::JsOption<GpuColorTargetState>>;
+    ) -> ::js_sys::Array<::js_sys::JsNullable<GpuColorTargetState>>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuColorTargetState")]
     #[doc = "Change the `targets` field of this object."]
@@ -91,7 +91,7 @@ extern "C" {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     #[wasm_bindgen(method, setter = "targets")]
-    pub fn set_targets(this: &GpuFragmentState, val: &[::js_sys::JsOption<GpuColorTargetState>]);
+    pub fn set_targets(this: &GpuFragmentState, val: &[::js_sys::JsNullable<GpuColorTargetState>]);
 }
 #[cfg(web_sys_unstable_apis)]
 impl GpuFragmentState {
@@ -104,7 +104,7 @@ impl GpuFragmentState {
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(
         module: &GpuShaderModule,
-        targets: &[::js_sys::JsOption<GpuColorTargetState>],
+        targets: &[::js_sys::JsNullable<GpuColorTargetState>],
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
@@ -134,7 +134,7 @@ impl GpuFragmentState {
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuColorTargetState")]
     #[deprecated = "Use `set_targets()` instead."]
-    pub fn targets(&mut self, val: &[::js_sys::JsOption<GpuColorTargetState>]) -> &mut Self {
+    pub fn targets(&mut self, val: &[::js_sys::JsNullable<GpuColorTargetState>]) -> &mut Self {
         self.set_targets(val);
         self
     }

--- a/crates/web-sys/src/features/gen_GpuPipelineLayoutDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuPipelineLayoutDescriptor.rs
@@ -43,7 +43,7 @@ extern "C" {
     #[wasm_bindgen(method, getter = "bindGroupLayouts")]
     pub fn get_bind_group_layouts(
         this: &GpuPipelineLayoutDescriptor,
-    ) -> ::js_sys::Array<::js_sys::JsOption<GpuBindGroupLayout>>;
+    ) -> ::js_sys::Array<::js_sys::JsNullable<GpuBindGroupLayout>>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuBindGroupLayout")]
     #[doc = "Change the `bindGroupLayouts` field of this object."]
@@ -55,7 +55,7 @@ extern "C" {
     #[wasm_bindgen(method, setter = "bindGroupLayouts")]
     pub fn set_bind_group_layouts(
         this: &GpuPipelineLayoutDescriptor,
-        val: &[::js_sys::JsOption<GpuBindGroupLayout>],
+        val: &[::js_sys::JsNullable<GpuBindGroupLayout>],
     );
     #[cfg(web_sys_unstable_apis)]
     #[doc = "Get the `immediateSize` field of this object."]
@@ -85,7 +85,7 @@ impl GpuPipelineLayoutDescriptor {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn new(bind_group_layouts: &[::js_sys::JsOption<GpuBindGroupLayout>]) -> Self {
+    pub fn new(bind_group_layouts: &[::js_sys::JsNullable<GpuBindGroupLayout>]) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_bind_group_layouts(bind_group_layouts);
@@ -102,7 +102,7 @@ impl GpuPipelineLayoutDescriptor {
     #[deprecated = "Use `set_bind_group_layouts()` instead."]
     pub fn bind_group_layouts(
         &mut self,
-        val: &[::js_sys::JsOption<GpuBindGroupLayout>],
+        val: &[::js_sys::JsNullable<GpuBindGroupLayout>],
     ) -> &mut Self {
         self.set_bind_group_layouts(val);
         self

--- a/crates/web-sys/src/features/gen_GpuRenderBundleEncoderDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderBundleEncoderDescriptor.rs
@@ -45,7 +45,7 @@ extern "C" {
     #[wasm_bindgen(method, getter = "colorFormats")]
     pub fn get_color_formats(
         this: &GpuRenderBundleEncoderDescriptor,
-    ) -> ::js_sys::Array<::js_sys::JsOption<::js_sys::JsString>>;
+    ) -> ::js_sys::Array<::js_sys::JsNullable<::js_sys::JsString>>;
     #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `colorFormats` field of this object."]
     #[doc = ""]
@@ -56,7 +56,7 @@ extern "C" {
     #[wasm_bindgen(method, setter = "colorFormats")]
     pub fn set_color_formats(
         this: &GpuRenderBundleEncoderDescriptor,
-        val: &[::js_sys::JsOption<::js_sys::JsString>],
+        val: &[::js_sys::JsNullable<::js_sys::JsString>],
     );
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuTextureFormat")]
@@ -143,7 +143,7 @@ impl GpuRenderBundleEncoderDescriptor {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn new(color_formats: &[::js_sys::JsOption<::js_sys::JsString>]) -> Self {
+    pub fn new(color_formats: &[::js_sys::JsNullable<::js_sys::JsString>]) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_color_formats(color_formats);
@@ -157,7 +157,7 @@ impl GpuRenderBundleEncoderDescriptor {
     }
     #[cfg(web_sys_unstable_apis)]
     #[deprecated = "Use `set_color_formats()` instead."]
-    pub fn color_formats(&mut self, val: &[::js_sys::JsOption<::js_sys::JsString>]) -> &mut Self {
+    pub fn color_formats(&mut self, val: &[::js_sys::JsNullable<::js_sys::JsString>]) -> &mut Self {
         self.set_color_formats(val);
         self
     }

--- a/crates/web-sys/src/features/gen_GpuRenderPassDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassDescriptor.rs
@@ -43,7 +43,7 @@ extern "C" {
     #[wasm_bindgen(method, getter = "colorAttachments")]
     pub fn get_color_attachments(
         this: &GpuRenderPassDescriptor,
-    ) -> ::js_sys::Array<::js_sys::JsOption<GpuRenderPassColorAttachment>>;
+    ) -> ::js_sys::Array<::js_sys::JsNullable<GpuRenderPassColorAttachment>>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuRenderPassColorAttachment")]
     #[doc = "Change the `colorAttachments` field of this object."]
@@ -55,7 +55,7 @@ extern "C" {
     #[wasm_bindgen(method, setter = "colorAttachments")]
     pub fn set_color_attachments(
         this: &GpuRenderPassDescriptor,
-        val: &[::js_sys::JsOption<GpuRenderPassColorAttachment>],
+        val: &[::js_sys::JsNullable<GpuRenderPassColorAttachment>],
     );
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuRenderPassDepthStencilAttachment")]
@@ -161,7 +161,7 @@ impl GpuRenderPassDescriptor {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn new(color_attachments: &[::js_sys::JsOption<GpuRenderPassColorAttachment>]) -> Self {
+    pub fn new(color_attachments: &[::js_sys::JsNullable<GpuRenderPassColorAttachment>]) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_color_attachments(color_attachments);
@@ -178,7 +178,7 @@ impl GpuRenderPassDescriptor {
     #[deprecated = "Use `set_color_attachments()` instead."]
     pub fn color_attachments(
         &mut self,
-        val: &[::js_sys::JsOption<GpuRenderPassColorAttachment>],
+        val: &[::js_sys::JsNullable<GpuRenderPassColorAttachment>],
     ) -> &mut Self {
         self.set_color_attachments(val);
         self

--- a/crates/web-sys/src/features/gen_GpuRenderPassLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassLayout.rs
@@ -42,7 +42,7 @@ extern "C" {
     #[wasm_bindgen(method, getter = "colorFormats")]
     pub fn get_color_formats(
         this: &GpuRenderPassLayout,
-    ) -> ::js_sys::Array<::js_sys::JsOption<::js_sys::JsString>>;
+    ) -> ::js_sys::Array<::js_sys::JsNullable<::js_sys::JsString>>;
     #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `colorFormats` field of this object."]
     #[doc = ""]
@@ -53,7 +53,7 @@ extern "C" {
     #[wasm_bindgen(method, setter = "colorFormats")]
     pub fn set_color_formats(
         this: &GpuRenderPassLayout,
-        val: &[::js_sys::JsOption<::js_sys::JsString>],
+        val: &[::js_sys::JsNullable<::js_sys::JsString>],
     );
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuTextureFormat")]
@@ -102,7 +102,7 @@ impl GpuRenderPassLayout {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn new(color_formats: &[::js_sys::JsOption<::js_sys::JsString>]) -> Self {
+    pub fn new(color_formats: &[::js_sys::JsNullable<::js_sys::JsString>]) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_color_formats(color_formats);
@@ -116,7 +116,7 @@ impl GpuRenderPassLayout {
     }
     #[cfg(web_sys_unstable_apis)]
     #[deprecated = "Use `set_color_formats()` instead."]
-    pub fn color_formats(&mut self, val: &[::js_sys::JsOption<::js_sys::JsString>]) -> &mut Self {
+    pub fn color_formats(&mut self, val: &[::js_sys::JsNullable<::js_sys::JsString>]) -> &mut Self {
         self.set_color_formats(val);
         self
     }

--- a/crates/web-sys/src/features/gen_GpuVertexState.rs
+++ b/crates/web-sys/src/features/gen_GpuVertexState.rs
@@ -81,7 +81,7 @@ extern "C" {
     #[wasm_bindgen(method, getter = "buffers")]
     pub fn get_buffers(
         this: &GpuVertexState,
-    ) -> Option<::js_sys::Array<::js_sys::JsOption<GpuVertexBufferLayout>>>;
+    ) -> Option<::js_sys::Array<::js_sys::JsNullable<GpuVertexBufferLayout>>>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuVertexBufferLayout")]
     #[doc = "Change the `buffers` field of this object."]
@@ -91,7 +91,7 @@ extern "C" {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     #[wasm_bindgen(method, setter = "buffers")]
-    pub fn set_buffers(this: &GpuVertexState, val: &[::js_sys::JsOption<GpuVertexBufferLayout>]);
+    pub fn set_buffers(this: &GpuVertexState, val: &[::js_sys::JsNullable<GpuVertexBufferLayout>]);
 }
 #[cfg(web_sys_unstable_apis)]
 impl GpuVertexState {
@@ -130,7 +130,7 @@ impl GpuVertexState {
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "GpuVertexBufferLayout")]
     #[deprecated = "Use `set_buffers()` instead."]
-    pub fn buffers(&mut self, val: &[::js_sys::JsOption<GpuVertexBufferLayout>]) -> &mut Self {
+    pub fn buffers(&mut self, val: &[::js_sys::JsNullable<GpuVertexBufferLayout>]) -> &mut Self {
         self.set_buffers(val);
         self
     }

--- a/crates/web-sys/src/features/gen_LockManager.rs
+++ b/crates/web-sys/src/features/gen_LockManager.rs
@@ -46,7 +46,7 @@ extern "C" {
     pub fn request(
         this: &LockManager,
         name: &str,
-        callback: &::js_sys::Function<fn(::js_sys::JsOption<Lock>) -> ::js_sys::Promise>,
+        callback: &::js_sys::Function<fn(::js_sys::JsNullable<Lock>) -> ::js_sys::Promise>,
     ) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "Lock", feature = "LockOptions",))]
@@ -63,6 +63,6 @@ extern "C" {
         this: &LockManager,
         name: &str,
         options: &LockOptions,
-        callback: &::js_sys::Function<fn(::js_sys::JsOption<Lock>) -> ::js_sys::Promise>,
+        callback: &::js_sys::Function<fn(::js_sys::JsNullable<Lock>) -> ::js_sys::Promise>,
     ) -> ::js_sys::Promise;
 }

--- a/crates/webidl-tests/globals.js
+++ b/crates/webidl-tests/globals.js
@@ -549,6 +549,9 @@ global.TestPromises = class {
   anyPromise() {
     return new Promise(r => r({ foo: "bar", num: 42 }));
   }
+  optionalStringPromise(isNull) {
+    return new Promise(r => r(isNull ? null : "abc"));
+  }
 };
 
 global.SignatureStability = class {

--- a/crates/webidl-tests/promise.rs
+++ b/crates/webidl-tests/promise.rs
@@ -21,6 +21,41 @@ async fn return_promise() {
     }
 }
 
+/// Test that `Promise<T?>` resolving to JS `null` decodes as absent
+/// (https://github.com/wasm-bindgen/wasm-bindgen/issues/5234)
+#[wasm_bindgen_test]
+async fn return_nullable_promise() {
+    let f = TestPromises::new().unwrap();
+
+    #[cfg(not(wbg_next_unstable))]
+    {
+        let v = JsFuture::from(f.optional_string_promise(true))
+            .await
+            .unwrap();
+        assert!(v.is_null());
+
+        let v = JsFuture::from(f.optional_string_promise(false))
+            .await
+            .unwrap();
+        assert_eq!(v.as_string().unwrap(), "abc");
+    }
+
+    #[cfg(wbg_next_unstable)]
+    {
+        let v: js_sys::JsNullable<js_sys::JsString> =
+            JsFuture::from(f.optional_string_promise(true))
+                .await
+                .unwrap();
+        assert!(v.is_empty());
+        assert!(v.into_option().is_none());
+
+        let v = JsFuture::from(f.optional_string_promise(false))
+            .await
+            .unwrap();
+        assert_eq!(v.into_option().unwrap(), "abc");
+    }
+}
+
 /// Test that `Promise<any>` returns just `Promise` (not `Promise<JsValue>`)
 /// and that both generics and non-generics variants are identical (no cfg branching needed)
 #[wasm_bindgen_test]

--- a/crates/webidl-tests/webidls/enabled/promise.webidl
+++ b/crates/webidl-tests/webidls/enabled/promise.webidl
@@ -2,5 +2,5 @@
 interface TestPromises {
   Promise<DOMString> stringPromise();
   Promise<any> anyPromise();
-  Promise<DOMString?> optionalStringPromise();
+  Promise<DOMString?> optionalStringPromise(boolean isNull);
 };

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -47,6 +47,7 @@ pub(crate) static BUILTIN_IDENTS: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
         // Generic js-sys types
         "JsString",
         "JsOption",
+        "JsNullable",
         "ArrayTuple",
         "Symbol",
         "BigInt",

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -585,7 +585,7 @@ impl<'src> FirstPassRecord<'src> {
         // With generics enabled, the types are precise (e.g. Option<&[T]>) so no collapse needed.
         let is_js_value_ref_option_type = generics_compat
             && match &wbg_type {
-                wbg_type::WbgType::JsOption(ty) => match **ty {
+                wbg_type::WbgType::Nullable(ty) => match **ty {
                     wbg_type::WbgType::Any => true,
                     wbg_type::WbgType::FrozenArray(..) | wbg_type::WbgType::Sequence(..) => true,
                     wbg_type::WbgType::Union(ref types) => !types.iter().all(|wbg_type| {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -215,11 +215,11 @@ pub(crate) fn option_ty(t: syn::Type) -> syn::Type {
     ty.into()
 }
 
-/// From `T` create `::js_sys::JsOption<T>`
+/// From `T` create `::js_sys::JsNullable<T>`
 ///
-/// Used for nullable types nested inside generic containers (e.g., `Promise<JsOption<Foo>>`).
-/// Unlike `Option<T>` which is a Rust ABI, `JsOption<T>` is a valid erasable generic type.
-pub(crate) fn js_option_ty(t: syn::Type) -> syn::Type {
+/// Used for nullable types nested inside generic containers (e.g., `Promise<JsNullable<Foo>>`).
+/// Unlike `Option<T>` which is a Rust ABI, `JsNullable<T>` is a valid erasable generic type.
+pub(crate) fn js_nullable_ty(t: syn::Type) -> syn::Type {
     let arguments = syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
         colon2_token: None,
         lt_token: Default::default(),
@@ -227,7 +227,7 @@ pub(crate) fn js_option_ty(t: syn::Type) -> syn::Type {
         gt_token: Default::default(),
     });
 
-    let ident = raw_ident("JsOption");
+    let ident = raw_ident("JsNullable");
     let seg = syn::PathSegment { ident, arguments };
     let path = syn::Path {
         leading_colon: Some(Default::default()),
@@ -290,7 +290,7 @@ pub enum Direction {
 ///
 /// This models where a type appears, which affects how it's converted to Rust:
 /// - Top-level positions (`inner: false`) can use Rust-native types (`String`, `Option<T>`)
-/// - Inner positions (`inner: true`) must use JS-compatible types (`JsString`, `JsOption<T>`)
+/// - Inner positions (`inner: true`) must use JS-compatible types (`JsString`, `JsNullable<T>`)
 ///
 /// Inner positions include:
 /// - Nested inside generic type parameters (e.g., inside `Promise<T>`, `Array<T>`)
@@ -762,12 +762,12 @@ impl<'src> FirstPassRecord<'src> {
             let deprecated = get_rust_deprecated(signature.orig.attrs);
             let ret_ty = if id == &OperationId::IndexingGetter {
                 match ret_ty {
-                    WbgType::JsOption(_) => ret_ty,
+                    WbgType::Nullable(_) => ret_ty,
                     ref ty => {
                         if catch {
                             ret_ty
                         } else {
-                            WbgType::JsOption(Box::new(ty.clone()))
+                            WbgType::Nullable(Box::new(ty.clone()))
                         }
                     }
                 }
@@ -1177,7 +1177,7 @@ fn arg_throws(ty: &WbgType<'_>) -> bool {
                 | IdentifierType::Float64Slice { allow_shared, .. },
             ..
         } => !allow_shared,
-        WbgType::JsOption(item) => arg_throws(item),
+        WbgType::Nullable(item) => arg_throws(item),
         WbgType::Union(list) => list.iter().any(arg_throws),
         // catch-all for everything else like Object
         _ => false,
@@ -1231,7 +1231,7 @@ fn flag_slices_immutable(ty: &mut WbgType) {
             ty: IdentifierType::AllowSharedBufferSource { immutable },
             ..
         } => *immutable = true,
-        WbgType::JsOption(item) => flag_slices_immutable(item),
+        WbgType::Nullable(item) => flag_slices_immutable(item),
         WbgType::Union(list) => {
             for item in list {
                 flag_slices_immutable(item);
@@ -1256,7 +1256,7 @@ fn flag_slices_allow_shared(ty: &mut WbgType) {
         | WbgType::Float64Array { allow_shared, .. }
         | WbgType::ArrayBufferView { allow_shared, .. }
         | WbgType::BufferSource { allow_shared, .. } => *allow_shared = true,
-        WbgType::JsOption(item) => flag_slices_allow_shared(item),
+        WbgType::Nullable(item) => flag_slices_allow_shared(item),
         WbgType::FrozenArray(item) => flag_slices_allow_shared(item),
         WbgType::Sequence(item) => flag_slices_allow_shared(item),
         WbgType::ObservableArray(item) => flag_slices_allow_shared(item),

--- a/crates/webidl/src/wbg_type.rs
+++ b/crates/webidl/src/wbg_type.rs
@@ -8,7 +8,7 @@ use weedle::types::*;
 
 use crate::first_pass::FirstPassRecord;
 use crate::util::{
-    array, camel_case_ident, generic_ty, js_option_ty, option_ty, shared_ref, slice_ty,
+    array, camel_case_ident, generic_ty, js_nullable_ty, option_ty, shared_ref, slice_ty,
     snake_case_ident, Direction, TypePosition,
 };
 
@@ -85,7 +85,7 @@ pub(crate) enum WbgType<'a> {
         immutable: bool,
     },
 
-    JsOption(Box<WbgType<'a>>),
+    Nullable(Box<WbgType<'a>>),
     FrozenArray(Box<WbgType<'a>>),
     ObservableArray(Box<WbgType<'a>>),
     Sequence(Box<WbgType<'a>>),
@@ -260,7 +260,7 @@ impl<'a, T: ToWbgType<'a>> ToWbgType<'a> for MayBeNull<T> {
     fn to_wbg_type(&self, record: &FirstPassRecord<'a>) -> WbgType<'a> {
         let inner_wbg_type = self.type_.to_wbg_type(record);
         if self.q_mark.is_some() {
-            WbgType::JsOption(Box::new(inner_wbg_type))
+            WbgType::Nullable(Box::new(inner_wbg_type))
         } else {
             inner_wbg_type
         }
@@ -586,7 +586,7 @@ impl<'a> WbgType<'a> {
 
             WbgType::UnknownIdentifier(name) => dst.push_str(&snake_case_ident(name)),
 
-            WbgType::JsOption(wbg_type) => {
+            WbgType::Nullable(wbg_type) => {
                 dst.push_str("opt_");
                 wbg_type.push_snake_case_name(dst);
             }
@@ -739,12 +739,12 @@ impl<'a> WbgType<'a> {
                     Ok(js_sys("JsString"))
                 }
 
-                // JsOption must use JsOption<T> for inner positions (not Rust Option<T>)
-                WbgType::JsOption(wbg_type) => {
+                // Nullable must use JsNullable<T> for inner positions (not Rust Option<T>)
+                WbgType::Nullable(wbg_type) => {
                     let inner = wbg_type.to_syn_type(pos, legacy, no_generics)?;
                     match inner {
                         Some(inner) => {
-                            // JsOption<JsValue> isn't well-supported, just use JsValue
+                            // JsNullable<JsValue> isn't well-supported, just use JsValue
                             if let syn::Type::Path(path) = &inner {
                                 if path.qself.is_none()
                                     && path
@@ -757,7 +757,7 @@ impl<'a> WbgType<'a> {
                                     return Ok(Some(inner.clone()));
                                 }
                             }
-                            Ok(Some(js_option_ty(inner)))
+                            Ok(Some(js_nullable_ty(inner)))
                         }
                         None => Ok(None),
                     }
@@ -908,7 +908,7 @@ impl<'a> WbgType<'a> {
 
             WbgType::ArrayBufferView { .. } | WbgType::BufferSource { .. } => Ok(js_sys("Object")),
 
-            WbgType::JsOption(wbg_type) => {
+            WbgType::Nullable(wbg_type) => {
                 // Top-level position: use Rust Option<T>
                 // (inner positions are handled in to_syn_type before calling to_syn_type_inner)
                 let inner = wbg_type.to_syn_type(pos, legacy, no_generics)?;
@@ -1158,11 +1158,11 @@ impl<'a> WbgType<'a> {
     /// [flattened union member types]: https://heycam.github.io/webidl/#dfn-flattened-union-member-types
     pub(crate) fn flatten(&self, attrs: Option<&ExtendedAttributeList<'_>>) -> Vec<Self> {
         match self {
-            WbgType::JsOption(wbg_type) => wbg_type
+            WbgType::Nullable(wbg_type) => wbg_type
                 .flatten(attrs)
                 .into_iter()
                 .map(Box::new)
-                .map(WbgType::JsOption)
+                .map(WbgType::Nullable)
                 .collect(),
             WbgType::FrozenArray(wbg_type) => wbg_type
                 .flatten(attrs)
@@ -1553,7 +1553,7 @@ fn wbg_type_flatten_test() {
                 Sequence(Box::new(Long),),
                 WbgType::id("Event", Interface("Event"))
             ]),
-            JsOption(Box::new(Union(vec![
+            Nullable(Box::new(Union(vec![
                 WbgType::id("XMLHttpRequest", Interface("XMLHttpRequest")),
                 DomString,
             ])),),
@@ -1567,11 +1567,11 @@ fn wbg_type_flatten_test() {
             WbgType::id("Node", Interface("Node")),
             Sequence(Box::new(Long)),
             WbgType::id("Event", Interface("Event")),
-            JsOption(Box::new(WbgType::id(
+            Nullable(Box::new(WbgType::id(
                 "XMLHttpRequest",
                 Interface("XMLHttpRequest")
             ))),
-            JsOption(Box::new(DomString)),
+            Nullable(Box::new(DomString)),
             Sequence(Box::new(Sequence(Box::new(Double)))),
             Sequence(Box::new(WbgType::id("NodeList", Interface("NodeList")))),
         ],

--- a/guide/src/reference/types/js-sys.md
+++ b/guide/src/reference/types/js-sys.md
@@ -22,7 +22,8 @@ All generic types listed implement `JsGeneric` and default to `JsValue` when typ
 | [`Generator<T>` / `AsyncGenerator<T>`](#generatort-and-asyncgeneratort) | Typed generators |
 | [`Object<T>`](#objectt) | Object with typed values |
 | [`WeakMap<K, V>` / `WeakSet<T>` / `WeakRef<T>`](#weakmapk-v-weaksett-weakreft) | Weak collections |
-| [`JsOption<T>`](#jsoptiont) | Nullable JS value (`T`, `null`, or `undefined`) |
+| [`JsOption<T>`](#jsoptiont) | Optional JS value (`T` or `undefined`) |
+| [`JsNullable<T>`](#jsnullablet) | Nullable JS value (`T` or `null`) |
 | `Number` | JavaScript number primitive |
 | `JsString` | JavaScript string primitive |
 | `Boolean` | JavaScript boolean primitive |
@@ -302,15 +303,57 @@ let weak_ref: WeakRef<Object> = WeakRef::new(&my_object);
 
 ## JsOption\<T\>
 
-Represents a JS value that may be `T`, `null`, or `undefined`.
+Represents a JS value that may be `T` or `undefined`, matching TypeScript's
+`T | undefined`. Only `undefined` is treated as absent; JS `null` is a
+distinct present value.
 
 ```rust
-use wasm_bindgen::JsOption;
-use js_sys::Number;
+use js_sys::{JsOption, Number};
 
 #[wasm_bindgen]
 extern "C" {
     fn maybeGetValue() -> JsOption<Number>;
+}
+
+let value = maybeGetValue();
+
+// Check emptiness
+if value.is_empty() {
+    // undefined
+}
+
+// Convert to Option
+match value.into_option() {
+    Some(num) => { /* use num */ }
+    None => { /* handle undefined */ }
+}
+
+// Unwrap methods
+let num = value.unwrap();
+let num = value.expect("should exist");
+let num = value.unwrap_or_default();
+let num = value.unwrap_or_else(|| Number::from(0));
+
+// Create values
+let with_value = JsOption::wrap(Number::from(42));
+let empty: JsOption<Number> = JsOption::new();
+let from_opt = JsOption::from_option(Some(Number::from(42)));
+```
+
+## JsNullable\<T\>
+
+Represents a JS value that may be `T` or `null`, matching WebIDL nullable
+types (`T?`). Following WebIDL's ECMAScript conversion rules, both `null`
+and `undefined` are treated as absent; the canonical empty value produced
+from Rust is `null`. `web-sys` uses `JsNullable<T>` for nullable types
+nested inside generics, such as `Promise<GpuError?>`.
+
+```rust
+use js_sys::{JsNullable, Number};
+
+#[wasm_bindgen]
+extern "C" {
+    fn maybeGetValue() -> JsNullable<Number>;
 }
 
 let value = maybeGetValue();
@@ -326,21 +369,16 @@ match value.into_option() {
     None => { /* handle null */ }
 }
 
-// Unwrap methods
-let num = value.unwrap();
-let num = value.expect("should exist");
-let num = value.unwrap_or_default();
-let num = value.unwrap_or_else(|| Number::from(0));
-
-// Create values
-let with_value = JsOption::wrap(Number::from(42));
-let empty: JsOption<Number> = JsOption::new();
-let from_opt = JsOption::from_option(Some(Number::from(42)));
+// Create values (the same unwrap methods as JsOption are also available)
+let with_value = JsNullable::wrap(Number::from(42));
+let empty: JsNullable<Number> = JsNullable::new(); // null
+let from_opt = JsNullable::from_option(Some(Number::from(42)));
 ```
 
-**`JsOption<T>` vs `Option<T>`:**
+**`JsOption<T>` / `JsNullable<T>` vs `Option<T>`:**
 
 | Type | Behavior |
 | ---- | -------- |
 | `Option<T>` | Undefined or Null check at ABI boundary, immediately converts to `Some(T)` or `None` |
-| `JsOption<T>` | Defers undefined or null check, works in `JsGeneric` positions |
+| `JsOption<T>` | Defers undefined check, works in `JsGeneric` positions |
+| `JsNullable<T>` | Defers null or undefined check, works in `JsGeneric` positions |

--- a/guide/src/reference/working-with-generics.md
+++ b/guide/src/reference/working-with-generics.md
@@ -137,7 +137,7 @@ For the common case, it is recommended to use the `JsGeneric` trait bound when n
 - All js-sys types: `Object`, `Array`, `Function`, `Promise`, `Map`, `Set`, etc.
 - JS primitives: `JsValue`, `Number`, `BigInt`, `Boolean`, `JsString`, `Symbol`
 - JS special values: `Undefined`, `Null`
-- Wrapper types: `JsOption<T>` (for any `T: JsGeneric`)
+- Wrapper types: `JsOption<T>` and `JsNullable<T>` (for any `T: JsGeneric`)
 - All web-sys generated types
 - Custom types imported via `#[wasm_bindgen]` automatically generate this trait on the `JsValue` repr.
 

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -12,7 +12,7 @@ use crate::convert::{
     RefFromWasmAbi, ReturnWasmAbi, TryFromJsValue, UpcastFrom,
 };
 use crate::sys::Promising;
-use crate::sys::{JsOption, Undefined};
+use crate::sys::{JsNullable, JsOption, Undefined};
 use crate::{Clamped, JsError, JsValue, UnwrapThrowExt};
 
 // Primitive types can always be passed over the ABI.
@@ -139,6 +139,7 @@ macro_rules! type_wasm_native {
 
         impl UpcastFrom<$t> for JsValue {}
         impl UpcastFrom<$t> for JsOption<JsValue> {}
+        impl UpcastFrom<$t> for JsNullable<JsValue> {}
         impl UpcastFrom<$t> for $t {}
     )*)
 }
@@ -153,8 +154,10 @@ type_wasm_native!(
 
 impl UpcastFrom<u64> for u128 {}
 impl UpcastFrom<u64> for JsOption<u128> {}
+impl UpcastFrom<u64> for JsNullable<u128> {}
 impl UpcastFrom<i64> for i128 {}
 impl UpcastFrom<i64> for JsOption<i128> {}
+impl UpcastFrom<i64> for JsNullable<i128> {}
 
 /// Sentinel value used to encode `None` for optional pointer-sized and
 /// 32-bit numeric values transferred over the JS `number` ABI.
@@ -215,6 +218,7 @@ macro_rules! type_wasm_native_f64_option {
 
         impl UpcastFrom<$t> for JsValue {}
         impl UpcastFrom<$t> for JsOption<JsValue> {}
+        impl UpcastFrom<$t> for JsNullable<JsValue> {}
         impl UpcastFrom<$t> for $t {}
     )*)
 }
@@ -231,37 +235,52 @@ type_wasm_native_f64_option!(
 impl UpcastFrom<isize> for i32 {}
 #[cfg(target_pointer_width = "32")]
 impl UpcastFrom<isize> for JsOption<i32> {}
+#[cfg(target_pointer_width = "32")]
+impl UpcastFrom<isize> for JsNullable<i32> {}
 
 impl UpcastFrom<isize> for i64 {}
 impl UpcastFrom<isize> for JsOption<i64> {}
+impl UpcastFrom<isize> for JsNullable<i64> {}
 impl UpcastFrom<isize> for i128 {}
 impl UpcastFrom<isize> for JsOption<i128> {}
+impl UpcastFrom<isize> for JsNullable<i128> {}
 
 impl UpcastFrom<i32> for isize {}
 impl UpcastFrom<i32> for JsOption<isize> {}
+impl UpcastFrom<i32> for JsNullable<isize> {}
 impl UpcastFrom<i32> for i64 {}
 impl UpcastFrom<i32> for JsOption<i64> {}
+impl UpcastFrom<i32> for JsNullable<i64> {}
 impl UpcastFrom<i32> for i128 {}
 impl UpcastFrom<i32> for JsOption<i128> {}
+impl UpcastFrom<i32> for JsNullable<i128> {}
 
 impl UpcastFrom<u32> for usize {}
 impl UpcastFrom<u32> for JsOption<usize> {}
+impl UpcastFrom<u32> for JsNullable<usize> {}
 impl UpcastFrom<u32> for u64 {}
 impl UpcastFrom<u32> for JsOption<u64> {}
+impl UpcastFrom<u32> for JsNullable<u64> {}
 impl UpcastFrom<u32> for u128 {}
 impl UpcastFrom<u32> for JsOption<u128> {}
+impl UpcastFrom<u32> for JsNullable<u128> {}
 
 #[cfg(target_pointer_width = "32")]
 impl UpcastFrom<usize> for u32 {}
 #[cfg(target_pointer_width = "32")]
 impl UpcastFrom<usize> for JsOption<u32> {}
+#[cfg(target_pointer_width = "32")]
+impl UpcastFrom<usize> for JsNullable<u32> {}
 impl UpcastFrom<usize> for u64 {}
 impl UpcastFrom<usize> for JsOption<u64> {}
+impl UpcastFrom<usize> for JsNullable<u64> {}
 impl UpcastFrom<usize> for u128 {}
 impl UpcastFrom<usize> for JsOption<u128> {}
+impl UpcastFrom<usize> for JsNullable<u128> {}
 
 impl UpcastFrom<f32> for f64 {}
 impl UpcastFrom<f32> for JsOption<f64> {}
+impl UpcastFrom<f32> for JsNullable<f64> {}
 
 /// The sentinel value is 0xFF_FFFF for primitives with less than 32 bits.
 ///
@@ -306,6 +325,7 @@ macro_rules! type_abi_as_u32 {
 
         impl UpcastFrom<$t> for JsValue {}
         impl UpcastFrom<$t> for JsOption<JsValue> {}
+        impl UpcastFrom<$t> for JsNullable<JsValue> {}
         impl UpcastFrom<$t> for $t {}
     )*)
 }
@@ -314,35 +334,49 @@ type_abi_as_u32!(i8 u8 i16 u16);
 
 impl UpcastFrom<i8> for i16 {}
 impl UpcastFrom<i8> for JsOption<i16> {}
+impl UpcastFrom<i8> for JsNullable<i16> {}
 impl UpcastFrom<i8> for i32 {}
 impl UpcastFrom<i8> for JsOption<i32> {}
+impl UpcastFrom<i8> for JsNullable<i32> {}
 impl UpcastFrom<i8> for i64 {}
 impl UpcastFrom<i8> for JsOption<i64> {}
+impl UpcastFrom<i8> for JsNullable<i64> {}
 impl UpcastFrom<i8> for i128 {}
 impl UpcastFrom<i8> for JsOption<i128> {}
+impl UpcastFrom<i8> for JsNullable<i128> {}
 
 impl UpcastFrom<u8> for u16 {}
 impl UpcastFrom<u8> for JsOption<u16> {}
+impl UpcastFrom<u8> for JsNullable<u16> {}
 impl UpcastFrom<u8> for u32 {}
 impl UpcastFrom<u8> for JsOption<u32> {}
+impl UpcastFrom<u8> for JsNullable<u32> {}
 impl UpcastFrom<u8> for u64 {}
 impl UpcastFrom<u8> for JsOption<u64> {}
+impl UpcastFrom<u8> for JsNullable<u64> {}
 impl UpcastFrom<u8> for u128 {}
 impl UpcastFrom<u8> for JsOption<u128> {}
+impl UpcastFrom<u8> for JsNullable<u128> {}
 
 impl UpcastFrom<i16> for i32 {}
 impl UpcastFrom<i16> for JsOption<i32> {}
+impl UpcastFrom<i16> for JsNullable<i32> {}
 impl UpcastFrom<i16> for i64 {}
 impl UpcastFrom<i16> for JsOption<i64> {}
+impl UpcastFrom<i16> for JsNullable<i64> {}
 impl UpcastFrom<i16> for i128 {}
 impl UpcastFrom<i16> for JsOption<i128> {}
+impl UpcastFrom<i16> for JsNullable<i128> {}
 
 impl UpcastFrom<u16> for u32 {}
 impl UpcastFrom<u16> for JsOption<u32> {}
+impl UpcastFrom<u16> for JsNullable<u32> {}
 impl UpcastFrom<u16> for u64 {}
 impl UpcastFrom<u16> for JsOption<u64> {}
+impl UpcastFrom<u16> for JsNullable<u64> {}
 impl UpcastFrom<u16> for u128 {}
 impl UpcastFrom<u16> for JsOption<u128> {}
+impl UpcastFrom<u16> for JsNullable<u128> {}
 
 impl IntoWasmAbi for bool {
     type Abi = u32;
@@ -386,6 +420,7 @@ impl Promising for bool {
 
 impl UpcastFrom<bool> for JsValue {}
 impl UpcastFrom<bool> for JsOption<JsValue> {}
+impl UpcastFrom<bool> for JsNullable<JsValue> {}
 impl UpcastFrom<bool> for bool {}
 
 impl IntoWasmAbi for char {
@@ -431,6 +466,7 @@ impl Promising for char {
 
 impl UpcastFrom<char> for JsValue {}
 impl UpcastFrom<char> for JsOption<JsValue> {}
+impl UpcastFrom<char> for JsNullable<JsValue> {}
 impl UpcastFrom<char> for char {}
 
 impl<T> IntoWasmAbi for *const T {
@@ -457,6 +493,7 @@ unsafe impl<T: ErasableGeneric> ErasableGeneric for *const T {
 
 impl<T, Target> UpcastFrom<*const T> for *const Target where Target: UpcastFrom<T> {}
 impl<T, Target> UpcastFrom<*const T> for JsOption<*const Target> where Target: UpcastFrom<T> {}
+impl<T, Target> UpcastFrom<*const T> for JsNullable<*const Target> where Target: UpcastFrom<T> {}
 
 impl<T> IntoWasmAbi for Option<*const T> {
     type Abi = f64;
@@ -474,6 +511,7 @@ unsafe impl<T: ErasableGeneric> ErasableGeneric for Option<T> {
 
 impl<T, Target> UpcastFrom<Option<T>> for Option<Target> where Target: UpcastFrom<T> {}
 impl<T, Target> UpcastFrom<Option<T>> for JsOption<Option<Target>> where Target: UpcastFrom<T> {}
+impl<T, Target> UpcastFrom<Option<T>> for JsNullable<Option<Target>> where Target: UpcastFrom<T> {}
 
 impl<T> FromWasmAbi for Option<*const T> {
     type Abi = f64;
@@ -778,6 +816,12 @@ where
     TargetE: UpcastFrom<E>,
 {
 }
+impl<T, E, TargetT, TargetE> UpcastFrom<Result<T, E>> for JsNullable<Result<TargetT, TargetE>>
+where
+    TargetT: UpcastFrom<T>,
+    TargetE: UpcastFrom<E>,
+{
+}
 
 unsafe impl ErasableGeneric for JsError {
     type Repr = JsValue;
@@ -809,6 +853,7 @@ impl Promising for JsError {
 
 impl UpcastFrom<JsError> for JsValue {}
 impl UpcastFrom<JsError> for JsOption<JsValue> {}
+impl UpcastFrom<JsError> for JsNullable<JsValue> {}
 impl UpcastFrom<JsError> for JsError {}
 
 /// # ⚠️ Unstable

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 use core::panic::AssertUnwindSafe;
 
-use crate::sys::JsOption;
+use crate::sys::{JsNullable, JsOption};
 use crate::{describe::*, JsCast};
 use crate::{ErasableGeneric, JsValue};
 
@@ -517,6 +517,12 @@ macro_rules! impl_tuple_upcast {
         {
         }
         impl<$($T: JsGeneric,)+ $($Target: JsGeneric,)+> UpcastFrom<($($T,)+)> for JsOption<($($Target,)+)>
+        where
+            $($Target: JsGeneric + UpcastFrom<$T>,)+
+            $($T: JsGeneric,)+
+        {
+        }
+        impl<$($T: JsGeneric,)+ $($Target: JsGeneric,)+> UpcastFrom<($($T,)+)> for JsNullable<($($Target,)+)>
         where
             $($Target: JsGeneric + UpcastFrom<$T>,)+
             $($T: JsGeneric,)+

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -270,3 +270,173 @@ impl<T> UpcastFrom<Undefined> for JsOption<T> {}
 impl<T> UpcastFrom<()> for JsOption<T> {}
 impl<T> UpcastFrom<JsOption<T>> for JsValue {}
 impl<T, U> UpcastFrom<JsOption<U>> for JsOption<T> where T: UpcastFrom<U> {}
+
+// JsNullable
+#[wasm_bindgen(wasm_bindgen = crate)]
+extern "C" {
+    /// A nullable JS value of type `T`.
+    ///
+    /// Unlike `Option<T>`, which is a Rust-side construct, `JsNullable<T>`
+    /// represents a JS value that may be `T` or `null`, where the presence
+    /// status is not yet known in Rust. The value remains in JS until inspected
+    /// via methods like [`is_empty`](Self::is_empty),
+    /// [`as_option`](Self::as_option), or [`into_option`](Self::into_option).
+    ///
+    /// This models WebIDL nullable types (`T?`). Following WebIDL's
+    /// ECMAScript conversion rules, where `undefined` coerces to `null` at
+    /// nullable positions, both `null` and `undefined` are treated as absent.
+    /// The canonical empty value produced from Rust is `null`.
+    ///
+    /// For TypeScript-style `T | undefined` with strict undefined-only
+    /// emptiness, use [`JsOption<T>`] instead.
+    ///
+    /// `T` must implement [`JsGeneric`], meaning it is any type that can be
+    /// represented as a `JsValue` (e.g., `JsString`, `Number`, `Object`, etc.).
+    /// `JsNullable<T>` itself implements `JsGeneric`, so it can be used in all
+    /// generic positions that accept JS types.
+    #[wasm_bindgen(typescript_type = "any", no_upcast)]
+    #[derive(Clone, PartialEq)]
+    pub type JsNullable<T>;
+}
+
+impl<T: JsGeneric> JsNullable<T> {
+    /// Creates an empty `JsNullable<T>` representing `null`.
+    #[inline]
+    pub fn new() -> Self {
+        Null::NULL.unchecked_into()
+    }
+
+    /// Wraps a value in a `JsNullable<T>`.
+    #[inline]
+    pub fn wrap(val: T) -> Self {
+        val.unchecked_into()
+    }
+
+    /// Creates a `JsNullable<T>` from an `Option<T>`.
+    ///
+    /// Returns `JsNullable::wrap(val)` if `Some(val)`, otherwise `JsNullable::new()`.
+    #[inline]
+    pub fn from_option(opt: Option<T>) -> Self {
+        match opt {
+            Some(val) => Self::wrap(val),
+            None => Self::new(),
+        }
+    }
+
+    /// Tests whether this `JsNullable<T>` is empty (`null` or `undefined`).
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        JsValue::is_null(self) || JsValue::is_undefined(self)
+    }
+
+    /// Converts this `JsNullable<T>` to an `Option<T>` by cloning the inner value.
+    ///
+    /// Returns `None` if the value is `null` or `undefined`, otherwise returns
+    /// `Some(T)` with a clone of the contained value.
+    #[inline]
+    pub fn as_option(&self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            let cloned = self.deref().clone();
+            Some(cloned.unchecked_into())
+        }
+    }
+
+    /// Converts this `JsNullable<T>` into an `Option<T>`, consuming `self`.
+    ///
+    /// Returns `None` if the value is `null` or `undefined`, otherwise returns
+    /// `Some(T)` with the contained value.
+    #[inline]
+    pub fn into_option(self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.unchecked_into())
+        }
+    }
+
+    /// Returns the contained value, consuming `self`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `null` or `undefined`.
+    #[inline]
+    pub fn unwrap(self) -> T {
+        self.expect("called `JsNullable::unwrap()` on an empty value")
+    }
+
+    /// Returns the contained value, consuming `self`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `null` or `undefined`, with a panic message
+    /// including the passed message.
+    #[inline]
+    pub fn expect(self, msg: &str) -> T {
+        match self.into_option() {
+            Some(val) => val,
+            None => panic!("{}", msg),
+        }
+    }
+
+    /// Returns the contained value or a default.
+    ///
+    /// Returns the contained value if not `null` or `undefined`, otherwise
+    /// returns the default value of `T`.
+    #[inline]
+    pub fn unwrap_or_default(self) -> T
+    where
+        T: Default,
+    {
+        self.into_option().unwrap_or_default()
+    }
+
+    /// Returns the contained value or computes it from a closure.
+    ///
+    /// Returns the contained value if not `null` or `undefined`, otherwise
+    /// calls `f` and returns the result.
+    #[inline]
+    pub fn unwrap_or_else<F>(self, f: F) -> T
+    where
+        F: FnOnce() -> T,
+    {
+        self.into_option().unwrap_or_else(f)
+    }
+}
+
+impl<T: JsGeneric> Default for JsNullable<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: JsGeneric + fmt::Debug> fmt::Debug for JsNullable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}?(", core::any::type_name::<T>())?;
+        match self.as_option() {
+            Some(v) => write!(f, "{v:?}")?,
+            None => f.write_str("null")?,
+        }
+        f.write_str(")")
+    }
+}
+
+impl<T: JsGeneric + fmt::Display> fmt::Display for JsNullable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}?(", core::any::type_name::<T>())?;
+        match self.as_option() {
+            Some(v) => write!(f, "{v}")?,
+            None => f.write_str("null")?,
+        }
+        f.write_str(")")
+    }
+}
+
+impl UpcastFrom<JsValue> for JsNullable<JsValue> {}
+impl<T> UpcastFrom<Null> for JsNullable<T> {}
+impl<T> UpcastFrom<Undefined> for JsNullable<T> {}
+impl<T> UpcastFrom<()> for JsNullable<T> {}
+impl<T> UpcastFrom<JsNullable<T>> for JsValue {}
+impl<T, U> UpcastFrom<JsNullable<U>> for JsNullable<T> where T: UpcastFrom<U> {}
+impl<T, U> UpcastFrom<JsOption<U>> for JsNullable<T> where T: UpcastFrom<U> {}

--- a/tests/wasm/nullable.js
+++ b/tests/wasm/nullable.js
@@ -69,3 +69,9 @@ exports.test_nullable_exports = () => {
     wasm.rust_take_nullable_null(undefined);
     wasm.rust_take_nullable_value(789);
 };
+
+exports.call_with_null_undefined_and_value = (f) => {
+    f(null);
+    f(undefined);
+    f(321);
+};

--- a/tests/wasm/nullable.js
+++ b/tests/wasm/nullable.js
@@ -31,6 +31,29 @@ exports.take_nullable_string = (val) => {
     assert.strictEqual(typeof val, 'string');
 };
 
+exports.take_js_nullable_null = (val) => {
+    assert.strictEqual(val, null, `expected null, got ${val}`);
+};
+
+exports.take_js_nullable_value = (val) => {
+    assert.strictEqual(val, 321);
+};
+
+exports.test_js_nullable_exports = () => {
+    // Rust JsNullable empty produces canonical `null`.
+    const nullVal = wasm.rust_return_js_nullable_null();
+    assert.strictEqual(nullVal, null,
+        `expected null from rust_return_js_nullable_null, got ${nullVal}`);
+
+    const numVal = wasm.rust_return_js_nullable_value();
+    assert.strictEqual(numVal, 654);
+
+    // Both null and undefined decode as empty.
+    wasm.rust_take_js_nullable_empty(null);
+    wasm.rust_take_js_nullable_empty(undefined);
+    wasm.rust_take_js_nullable_value(987);
+};
+
 exports.test_nullable_exports = () => {
     // Test rust functions that return JsOption — strict: empty == undefined only.
     const nullVal = wasm.rust_return_nullable_null();

--- a/tests/wasm/nullable.rs
+++ b/tests/wasm/nullable.rs
@@ -45,6 +45,8 @@ extern "C" {
     fn take_js_nullable_value(val: JsNullable<Number>);
 
     fn test_js_nullable_exports();
+
+    fn call_with_null_undefined_and_value(f: &Closure<dyn FnMut(JsNullable<Number>)>);
 }
 
 #[wasm_bindgen_test]
@@ -509,4 +511,94 @@ fn test_option_vs_js_option_compat() {
 
     // Option<i32> Some(7) -> passes 7 to JS, no default.
     test_value(Some(7), 7);
+}
+
+// Closure variance with JsNullable arguments: JsNullable participates in the
+// same contravariant argument casts as JsOption.
+mod nullable_closure_variance {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    #[wasm_bindgen_test]
+    fn arg_contravariance_jsvalue_to_nullable() {
+        let closure: Closure<dyn Fn(JsValue)> = Closure::new(|_: JsValue| {});
+        let _narrower: &Closure<dyn Fn(JsNullable<Number>)> = closure.upcast();
+    }
+
+    #[wasm_bindgen_test]
+    fn arg_contravariance_nullable_jsvalue_to_nullable_number() {
+        let closure: Closure<dyn Fn(JsNullable<JsValue>)> =
+            Closure::new(|_: JsNullable<JsValue>| {});
+        let _narrower: &Closure<dyn Fn(JsNullable<Number>)> = closure.upcast();
+    }
+
+    #[wasm_bindgen_test]
+    fn arg_contravariance_nullable_to_option() {
+        // JsNullable emptiness (null | undefined) is a superset of JsOption
+        // emptiness (undefined), so a JsNullable-accepting closure can be used
+        // where a JsOption-accepting one is expected -- but not vice versa.
+        let closure: Closure<dyn Fn(JsNullable<Number>)> = Closure::new(|_: JsNullable<Number>| {});
+        let _narrower: &Closure<dyn Fn(JsOption<Number>)> = closure.upcast();
+    }
+
+    #[wasm_bindgen_test]
+    fn arg_contravariance_nullable_jsvalue_to_i32() {
+        let closure: Closure<dyn Fn(JsNullable<JsValue>)> =
+            Closure::new(|_: JsNullable<JsValue>| {});
+        let _narrower: &Closure<dyn Fn(i32)> = closure.upcast();
+    }
+
+    #[wasm_bindgen_test]
+    fn return_covariance_number_to_nullable() {
+        let closure: Closure<dyn Fn() -> Number> = Closure::new(|| Number::from(42));
+        let _wider: &Closure<dyn Fn() -> JsNullable<Number>> = closure.upcast();
+    }
+
+    #[wasm_bindgen_test]
+    fn function_to_nullable_jsvalue() {
+        fn assert_upcast<T, U: wasm_bindgen::convert::UpcastFrom<T>>() {}
+        assert_upcast::<js_sys::Function<fn() -> JsValue>, JsNullable<JsValue>>();
+        assert_upcast::<js_sys::Function<fn() -> JsValue>, JsNullable<Object>>();
+        assert_upcast::<js_sys::Function<fn(JsNullable<Number>) -> JsValue>, JsNullable<JsValue>>();
+    }
+
+    #[wasm_bindgen_test]
+    fn invoke_nullable_arg_closure() {
+        let calls = Rc::new(Cell::new((0u32, 0u32)));
+        let calls2 = calls.clone();
+        let closure: Closure<dyn FnMut(JsNullable<Number>)> =
+            Closure::new(move |val: JsNullable<Number>| {
+                let (empty, present) = calls2.get();
+                match val.into_option() {
+                    None => calls2.set((empty + 1, present)),
+                    Some(num) => {
+                        assert_eq!(num.value_of(), 321.0);
+                        calls2.set((empty, present + 1));
+                    }
+                }
+            });
+        call_with_null_undefined_and_value(&closure);
+        // null and undefined are both empty; 321 is present.
+        assert_eq!(calls.get(), (2, 1));
+    }
+
+    #[wasm_bindgen_test]
+    fn invoke_upcast_jsvalue_closure_as_nullable() {
+        let calls = Rc::new(Cell::new((0u32, 0u32, 0u32)));
+        let calls2 = calls.clone();
+        let closure: Closure<dyn FnMut(JsValue)> = Closure::new(move |val: JsValue| {
+            let (nulls, undefs, values) = calls2.get();
+            if val.is_null() {
+                calls2.set((nulls + 1, undefs, values));
+            } else if val.is_undefined() {
+                calls2.set((nulls, undefs + 1, values));
+            } else {
+                calls2.set((nulls, undefs, values + 1));
+            }
+        });
+        call_with_null_undefined_and_value(closure.upcast());
+        // The raw JsValue view distinguishes null from undefined.
+        assert_eq!(calls.get(), (1, 1, 1));
+    }
 }

--- a/tests/wasm/nullable.rs
+++ b/tests/wasm/nullable.rs
@@ -1,4 +1,4 @@
-use js_sys::{JsOption, Undefined};
+use js_sys::{JsNullable, JsOption, Null, Undefined};
 use js_sys::{JsString, Number, Object};
 use wasm_bindgen::convert::Upcast;
 use wasm_bindgen::prelude::*;
@@ -31,6 +31,20 @@ extern "C" {
     fn take_nullable_string(val: JsOption<JsString>);
 
     fn test_nullable_exports();
+
+    #[wasm_bindgen(js_name = return_null)]
+    fn js_nullable_return_null() -> JsNullable<Number>;
+    #[wasm_bindgen(js_name = return_undefined)]
+    fn js_nullable_return_undefined() -> JsNullable<Number>;
+    #[wasm_bindgen(js_name = return_number)]
+    fn js_nullable_return_number() -> JsNullable<Number>;
+    #[wasm_bindgen(js_name = return_string)]
+    fn js_nullable_return_string() -> JsNullable<JsString>;
+
+    fn take_js_nullable_null(val: JsNullable<Number>);
+    fn take_js_nullable_value(val: JsNullable<Number>);
+
+    fn test_js_nullable_exports();
 }
 
 #[wasm_bindgen_test]
@@ -332,6 +346,150 @@ fn test_upcast_with_helper_function() {
     // Pass Undefined via upcast
     let result = accepts_nullable_number(Undefined::UNDEFINED.upcast_into());
     assert_eq!(result, None);
+}
+
+// ============================================================================
+// JsNullable tests
+// ============================================================================
+
+#[wasm_bindgen_test]
+fn test_js_nullable_new() {
+    let empty: JsNullable<Number> = JsNullable::new();
+    assert!(empty.is_empty());
+    // Canonical empty is `null`
+    assert!(JsValue::from(empty).is_null());
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_wrap() {
+    let num = JsNullable::wrap(Number::from(42));
+    assert!(!num.is_empty());
+    assert_eq!(num.unwrap().value_of(), 42.0);
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_from_option() {
+    let nullable = JsNullable::from_option(Some(Number::from(123)));
+    assert!(!nullable.is_empty());
+    assert_eq!(nullable.unwrap().value_of(), 123.0);
+
+    let nullable = JsNullable::from_option(None::<Number>);
+    assert!(nullable.is_empty());
+    assert!(JsValue::from(nullable).is_null());
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_null_is_empty() {
+    // The WebIDL `T?` contract: JS `null` is absent.
+    let val = js_nullable_return_null();
+    assert!(val.is_empty());
+    assert!(val.into_option().is_none());
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_undefined_is_empty() {
+    // WebIDL ES conversion coerces `undefined` to `null` at nullable
+    // positions, so `undefined` is also absent.
+    let val = js_nullable_return_undefined();
+    assert!(val.is_empty());
+    assert!(val.as_option().is_none());
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_value() {
+    let val = js_nullable_return_number();
+    assert!(!val.is_empty());
+    assert_eq!(val.as_option().unwrap().value_of(), 42.0);
+    assert_eq!(val.into_option().unwrap().value_of(), 42.0);
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_string() {
+    let val = js_nullable_return_string();
+    assert_eq!(val.unwrap(), "hello");
+}
+
+#[wasm_bindgen_test]
+#[should_panic(expected = "called `JsNullable::unwrap()` on an empty value")]
+fn test_js_nullable_unwrap_panic() {
+    js_nullable_return_null().unwrap();
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_unwrap_or() {
+    let num = js_nullable_return_null().unwrap_or_default();
+    assert_eq!(num.value_of(), 0.0);
+
+    let num = js_nullable_return_undefined().unwrap_or_else(|| Number::from(99));
+    assert_eq!(num.value_of(), 99.0);
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_debug() {
+    let val = JsNullable::wrap(Number::from(42));
+    let debug_str = format!("{:?}", val);
+    assert!(debug_str.contains("Number"));
+    assert!(debug_str.contains("42"));
+
+    let val: JsNullable<Number> = JsNullable::new();
+    let debug_str = format!("{:?}", val);
+    assert!(debug_str.contains("null"));
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_default() {
+    let val: JsNullable<Number> = Default::default();
+    assert!(val.is_empty());
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_upcasts() {
+    // A value upcasts to JsNullable of its own type
+    let nullable: JsNullable<Number> = Number::from(42).upcast_into();
+    assert_eq!(nullable.unwrap().value_of(), 42.0);
+
+    // Null and Undefined both upcast to empty
+    let nullable: JsNullable<Number> = Null::NULL.upcast_into();
+    assert!(nullable.is_empty());
+    let nullable: JsNullable<Number> = Undefined::UNDEFINED.upcast_into();
+    assert!(nullable.is_empty());
+
+    // JsOption<T> upcasts to JsNullable<T>
+    let opt: JsOption<Number> = JsOption::wrap(Number::from(7));
+    let nullable: JsNullable<Number> = opt.upcast_into();
+    assert_eq!(nullable.unwrap().value_of(), 7.0);
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_export() {
+    take_js_nullable_null(JsNullable::new());
+    take_js_nullable_value(JsNullable::wrap(Number::from(321)));
+}
+
+#[wasm_bindgen_test]
+fn test_js_nullable_js_calls_rust() {
+    test_js_nullable_exports();
+}
+
+// Exported functions for JS to call
+#[wasm_bindgen]
+pub fn rust_return_js_nullable_null() -> JsNullable<Number> {
+    JsNullable::new()
+}
+
+#[wasm_bindgen]
+pub fn rust_return_js_nullable_value() -> JsNullable<Number> {
+    JsNullable::wrap(Number::from(654))
+}
+
+#[wasm_bindgen]
+pub fn rust_take_js_nullable_empty(val: JsNullable<Number>) {
+    assert!(val.is_empty());
+}
+
+#[wasm_bindgen]
+pub fn rust_take_js_nullable_value(val: JsNullable<Number>) {
+    assert_eq!(val.unwrap().value_of(), 987.0);
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/nullable.rs
+++ b/tests/wasm/nullable.rs
@@ -518,6 +518,7 @@ fn test_option_vs_js_option_compat() {
 mod nullable_closure_variance {
     use super::*;
     use std::cell::Cell;
+    use std::panic::AssertUnwindSafe;
     use std::rc::Rc;
 
     #[wasm_bindgen_test]
@@ -566,7 +567,7 @@ mod nullable_closure_variance {
     #[wasm_bindgen_test]
     fn invoke_nullable_arg_closure() {
         let calls = Rc::new(Cell::new((0u32, 0u32)));
-        let calls2 = calls.clone();
+        let calls2 = AssertUnwindSafe(calls.clone());
         let closure: Closure<dyn FnMut(JsNullable<Number>)> =
             Closure::new(move |val: JsNullable<Number>| {
                 let (empty, present) = calls2.get();
@@ -586,7 +587,7 @@ mod nullable_closure_variance {
     #[wasm_bindgen_test]
     fn invoke_upcast_jsvalue_closure_as_nullable() {
         let calls = Rc::new(Cell::new((0u32, 0u32, 0u32)));
-        let calls2 = calls.clone();
+        let calls2 = AssertUnwindSafe(calls.clone());
         let closure: Closure<dyn FnMut(JsValue)> = Closure::new(move |val: JsValue| {
             let (nulls, undefs, values) = calls2.get();
             if val.is_null() {

--- a/tests/wasm/nullable.rs
+++ b/tests/wasm/nullable.rs
@@ -551,6 +551,27 @@ mod nullable_closure_variance {
     }
 
     #[wasm_bindgen_test]
+    fn arg_contravariance_wrapped_jsvalue_to_extern_type() {
+        // Catch-all nullable/optional handlers can accept any extern type:
+        // extern types upcast into JsOption<JsValue>/JsNullable<JsValue>.
+        let closure: Closure<dyn Fn(JsNullable<JsValue>)> =
+            Closure::new(|_: JsNullable<JsValue>| {});
+        let _narrower: &Closure<dyn Fn(Number)> = closure.upcast();
+
+        let closure: Closure<dyn Fn(JsOption<JsValue>)> = Closure::new(|_: JsOption<JsValue>| {});
+        let _narrower: &Closure<dyn Fn(Number)> = closure.upcast();
+    }
+
+    #[wasm_bindgen_test]
+    fn extern_type_to_wrapped_jsvalue() {
+        fn assert_upcast<T, U: wasm_bindgen::convert::UpcastFrom<T>>() {}
+        assert_upcast::<Number, JsOption<JsValue>>();
+        assert_upcast::<Number, JsNullable<JsValue>>();
+        assert_upcast::<JsString, JsOption<JsValue>>();
+        assert_upcast::<JsString, JsNullable<JsValue>>();
+    }
+
+    #[wasm_bindgen_test]
     fn return_covariance_number_to_nullable() {
         let closure: Closure<dyn Fn() -> Number> = Closure::new(|| Number::from(42));
         let _wider: &Closure<dyn Fn() -> JsNullable<Number>> = closure.upcast();


### PR DESCRIPTION
This implements a null-aware nullable type for WebIDL bindings, resolves #5234.

WebIDL `T?` is strictly `T | null`, but nullable types nested inside generics (`Promise<T?>`, `sequence<T?>`, callback params) lowered to `JsOption<T>`, whose intentional undefined-only emptiness (#5170) treats spec-defined `null` resolutions as present values — e.g. `GPUDevice.popErrorScope()` resolving `null` panicked downstream in wgpu. Top-level `T?` already decoded null-tolerantly via `Option<T>` glue, so the same WebIDL construct decoded differently depending on nesting depth.

What was implemented:

* New `JsNullable<T>` in `wasm_bindgen::sys` (re-exported from js-sys) modeling `T | null`: per WebIDL ES conversion rules both `null` and `undefined` are treated as absent; the canonical empty value produced from Rust is `null`
* Full `JsOption`-parity API and upcast lattice, including auto-generated `UpcastFrom<T> for JsNullable<T>` for all extern types, and `JsOption<U> → JsNullable<T>`
* webidl now emits `JsNullable<T>` for nullable types in inner positions; top-level `T?` continues to lower to `Option<T>` (the `WbgType::JsOption` variant is renamed to `WbgType::Nullable`)
* web-sys regenerated: 10 files, 29 signature lines, all wrapper-type swaps only

`JsOption<T>` itself is unchanged and keeps its strict `T | undefined` semantics for optional positions.

```rs
pub fn pop_error_scope(this: &GpuDevice) -> Promise<JsOption<GpuError>>;
```

```rs
pub fn pop_error_scope(this: &GpuDevice) -> Promise<JsNullable<GpuError>>;
```

Every changed web-sys signature is behind `--cfg=web_sys_unstable_apis` — the stable web-sys surface is unchanged (stable mode lowers generic containers untyped, so it cannot contain either wrapper type by construction). The full list of changed (unstable) APIs:

* `Promise<T?>` returns: `DataTransferItem::get_as_file_system_handle`, `Gpu::request_adapter`, `Gpu::request_adapter_with_options`, `GpuDevice::pop_error_scope`
* `sequence<T?>` dictionary fields (getter/setter/`new`/builder): `GpuFragmentState.targets`, `GpuPipelineLayoutDescriptor.bindGroupLayouts`, `GpuRenderBundleEncoderDescriptor.colorFormats`, `GpuRenderPassDescriptor.colorAttachments`, `GpuRenderPassLayout.colorFormats`, `GpuVertexState.buffers`
* Nullable callback params: `LockManager::request_with_callback`, `LockManager::request_with_options_and_callback` (`Function<fn(JsNullable<Lock>) -> Promise>`)

Test coverage: a `Promise<DOMString?>`-resolves-to-null regression test in webidl-tests (passing in both legacy and next-unstable modes, failing on the previous behavior), plus JsNullable unit and JS↔Rust round-trip coverage in `tests/wasm/nullable.rs`. The guide types reference is updated, also fixing the stale pre-#5170 `JsOption` description.
