### PR TITLE
Remove dead WBINDGEN_I_PROMISE_JS_SYNTAX_WORKS_IN_NODE env var from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,8 +249,6 @@ jobs:
   #       GECKODRIVER_ARGS: --log trace
   #   - run: cargo test --target wasm32-unknown-unknown -p js-sys
   #   - run: cargo test --target wasm32-unknown-unknown -p webidl-tests
-  #     env:
-  #       WBINDGEN_I_PROMISE_JS_SYNTAX_WORKS_IN_NODE: 1
   #   - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --features "Node Window Document"
 
   # This checks that the output of the CLI is actually valid JavaScript and TypeScript
@@ -334,8 +332,6 @@ jobs:
             run: cargo test -p wasm-bindgen-webidl
           - name: "webidl-tests"
             run: cargo test -p webidl-tests --target wasm32-unknown-unknown
-            env:
-              WBINDGEN_I_PROMISE_JS_SYNTAX_WORKS_IN_NODE: 1
           - name: "webidl-tests (unstable)"
             run: cargo test -p webidl-tests --target wasm32-unknown-unknown
             env:
@@ -350,7 +346,6 @@ jobs:
     name: "Run ${{ matrix.runs.name }} tests (with geckodriver)"
     env:
       RUSTFLAGS: ${{ matrix.runs.env.RUSTFLAGS }}
-      WBINDGEN_I_PROMISE_JS_SYNTAX_WORKS_IN_NODE: ${{ matrix.runs.env.WBINDGEN_I_PROMISE_JS_SYNTAX_WORKS_IN_NODE }}
       WBG_NEXT_UNSTABLE: ${{ matrix.runs.env.WBG_NEXT_UNSTABLE }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This removes the `WBINDGEN_I_PROMISE_JS_SYNTAX_WORKS_IN_NODE` environment variable from CI.

It was historically an escape hatch for the test runner to allow running tests with linked local JS under Node, but no crate in the tree reads it anymore (the last reader went away in 68c5233f8), so the three remaining references in `main.yml` are no-ops.
