### PR TITLE
Use string literal for PanicError name so it survives minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ### Fixed
 
+* The `name` property of the JS error thrown for `panic=unwind` is now set from
+  a string literal instead of `PanicError.name`, so it survives minification.
+  [#5260](https://github.com/wasm-bindgen/wasm-bindgen/issues/5260)
+
 * Restored `__stack_pointer` when an exception unwinds out of a wasm export,
   preventing repeated `panic = "unwind"` calls from leaking shadow-stack frames
   until the shadow stack is exhausted and calls trap. Node reports

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -4331,7 +4331,7 @@ if (require('worker_threads').isMainThread) {{
                 } else {
                     "class PanicError extends Error {}
                 Object.defineProperty(PanicError.prototype, 'name', {
-                    value: PanicError.name,
+                    value: 'PanicError',
                 });
                 "
                     .into()

--- a/crates/cli/tests/reference/panic-unwind-legacy.bg.js
+++ b/crates/cli/tests/reference/panic-unwind-legacy.bg.js
@@ -98,7 +98,7 @@ function getUint8ArrayMemory0() {
 
 class PanicError extends Error {}
 Object.defineProperty(PanicError.prototype, 'name', {
-    value: PanicError.name,
+    value: 'PanicError',
 });
 
 let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });

--- a/crates/cli/tests/reference/panic-unwind.bg.js
+++ b/crates/cli/tests/reference/panic-unwind.bg.js
@@ -95,7 +95,7 @@ function getUint8ArrayMemory0() {
 
 class PanicError extends Error {}
 Object.defineProperty(PanicError.prototype, 'name', {
-    value: PanicError.name,
+    value: 'PanicError',
 });
 
 let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });


### PR DESCRIPTION
This sets the `name` property of the `PanicError` prototype from a string literal instead of `PanicError.name`, resolves #5260.

When output runs through a minifying bundler (e.g. Vite), the `PanicError` class identifier gets renamed, so `PanicError.name` evaluates to the minified name (e.g. `O`) and thrown panics report an uninformative error name. The Emscripten output path already used a string literal here.

```js
Object.defineProperty(PanicError.prototype, 'name', {
    value: PanicError.name,
});
```

becomes:

```js
Object.defineProperty(PanicError.prototype, 'name', {
    value: 'PanicError',
});
```

Reference fixtures `panic-unwind.bg.js` and `panic-unwind-legacy.bg.js` are re-blessed accordingly and cover the change.