### PR TITLE
Add `riscv64gc-unknown-linux-gnu` release artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -474,6 +474,9 @@ jobs:
     - run: sudo apt update -y && sudo apt install gcc-aarch64-linux-gnu -y
     - run: |
         cargo build --manifest-path crates/cli/Cargo.toml --target aarch64-unknown-linux-gnu --features vendored-openssl --release
+        aarch64-linux-gnu-strip -g target/aarch64-unknown-linux-gnu/release/wasm-bindgen
+        aarch64-linux-gnu-strip -g target/aarch64-unknown-linux-gnu/release/wasm-bindgen-test-runner
+        aarch64-linux-gnu-strip -g target/aarch64-unknown-linux-gnu/release/wasm2es6js
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
     - uses: actions/upload-artifact@v7
@@ -508,6 +511,9 @@ jobs:
     - run: sudo apt update -y && sudo apt install gcc-riscv64-linux-gnu -y
     - run: |
         cargo build --manifest-path crates/cli/Cargo.toml --target riscv64gc-unknown-linux-gnu --features vendored-openssl --release
+        riscv64-linux-gnu-strip -g target/riscv64gc-unknown-linux-gnu/release/wasm-bindgen
+        riscv64-linux-gnu-strip -g target/riscv64gc-unknown-linux-gnu/release/wasm-bindgen-test-runner
+        riscv64-linux-gnu-strip -g target/riscv64gc-unknown-linux-gnu/release/wasm2es6js
       env:
         CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER: riscv64-linux-gnu-gcc
     - uses: actions/upload-artifact@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -497,6 +497,24 @@ jobs:
         name: dist_linux_aarch64_musl
         path: "target/aarch64-unknown-linux-musl/release/wasm*"
 
+  dist_linux_riscv64_gnu:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: riscv64gc-unknown-linux-gnu
+    - run: sudo apt update -y && sudo apt install gcc-riscv64-linux-gnu -y
+    - run: |
+        cargo build --manifest-path crates/cli/Cargo.toml --target riscv64gc-unknown-linux-gnu --features vendored-openssl --release
+      env:
+        CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER: riscv64-linux-gnu-gcc
+    - uses: actions/upload-artifact@v7
+      with:
+        name: dist_linux_riscv64_gnu
+        path: "target/riscv64gc-unknown-linux-gnu/release/wasm*"
+
   dist_macos_x86_64:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     runs-on: macos-latest
@@ -651,6 +669,7 @@ jobs:
       - dist_linux_x86_64_musl
       - dist_linux_aarch64_gnu
       - dist_linux_aarch64_musl
+      - dist_linux_riscv64_gnu
       - dist_macos_x86_64
       - dist_macos_aarch64
       - dist_windows
@@ -688,6 +707,7 @@ jobs:
         mk x86_64-unknown-linux-musl dist_linux_x86_64_musl
         mk aarch64-unknown-linux-gnu dist_linux_aarch64_gnu
         mk aarch64-unknown-linux-musl dist_linux_aarch64_musl
+        mk riscv64gc-unknown-linux-gnu dist_linux_riscv64_gnu
         mk x86_64-apple-darwin dist_macos_x86_64
         mk aarch64-apple-darwin dist_macos_aarch64
         mk x86_64-pc-windows-msvc dist_windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API)
   to `web-sys` [#5247](https://github.com/wasm-bindgen/wasm-bindgen/pull/5247)
 
+* Added `riscv64gc-unknown-linux-gnu` release artifacts.
+  [#5265](https://github.com/wasm-bindgen/wasm-bindgen/pull/5265)
+
 ### Changed
 
 * Emscripten output now marks public exports (free functions, classes, enums,


### PR DESCRIPTION
### Description
<!-- Please describe the changes introduced by this PR. -->

Cross-compile the CLI for RISC-V 64-bit Linux GNU, matching the existing aarch64-linux-gnu release job layout.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
