### PR TITLE
Reference emcc's top-level export bindings in emscripten glue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@
   the block-level namespace.
   [#4324](https://github.com/wasm-bindgen/wasm-bindgen/issues/4324)
 
+* Emscripten glue no longer reads `wasmExports['name']` inline inside inner
+  functions. It now references the asmjs-mangled identifiers emcc's own
+  top-level `assignWasmExports` receiving code binds for every wasm export
+  (e.g. `___wbindgen_malloc`, `___wbindgen_externrefs`), which are the
+  canonical DCE-graph pairs: wasm-metadce keeps exactly the exports the
+  included glue uses (previously internal exports and the externref table
+  could be stripped or left unrenamed by the import/export minifier at `-O2`,
+  breaking at runtime). Hoisted classes are now emitted as `=`-prefixed
+  string value snippets so jsifier declares them as
+  `export var Class = class Class {...}` instead of an `export class`
+  declaration, which crashes emcc's acorn-optimizer under
+  `-sMODULARIZE=instance`.
+
 ### Fixed
 
 * The CLI now reports an actionable error when the `__wasm_bindgen_unstable`

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -525,6 +525,16 @@ impl<'a> Context<'a> {
         } else {
             String::new()
         };
+        // Class expressions are passed to jsifier as an `=`-prefixed string
+        // snippet, which it emits as `var <id> = class <id> {...};` (an
+        // `export var` under MODULARIZE=instance). A live class value would be
+        // emitted as a `class` *declaration*, and `export class` crashes
+        // emcc's acorn-optimizer ExportNamedDeclaration handling.
+        let value = if value.trim_start().starts_with("class ") {
+            Cow::Owned(format!("{:?}", format!("={value}")))
+        } else {
+            Cow::Borrowed(value)
+        };
         self.emscripten_library(&format!(
             "addToLibrary({{\n    ${identifier}: {value},\n    \
              ${identifier}__deps: [{}]{postset_field}{export_attrs}\n}});",
@@ -1816,17 +1826,27 @@ if (require('worker_threads').isMainThread) {{
         // function bodies, so we have to enumerate explicitly. We union
         // `adapter_deps` with `emscripten_global_deps` so symbols that are
         // *only* declared globally (e.g. `$heap`) are also pulled in.
+        // References below use the identifiers emcc's `assignWasmExports`
+        // receiving code binds at the top level for every wasm export (see
+        // `wasm_export_ref`). `_initialize` is only referenced when the module
+        // actually exports it, since its receiving binding otherwise doesn't
+        // exist. It runs static constructors on --no-entry builds.
+        let initialize_logic = if self.module.exports.iter().any(|e| e.name == "_initialize") {
+            format!("{}();", emscripten_mangle("_initialize"))
+        } else {
+            String::new()
+        };
+        let start_logic = if needs_manual_start {
+            format!("{}();", emscripten_mangle("__wbindgen_start"))
+        } else {
+            String::new()
+        };
+
         let init_deps: BTreeSet<&str> = std::iter::once("addOnInit")
             .chain(self.adapter_deps.iter().map(String::as_str))
             .chain(self.emscripten_global_deps.iter().map(String::as_str))
             .collect();
         let init_dep_refs: Vec<String> = init_deps.iter().map(|d| format!("'${d}'")).collect();
-
-        let start_logic = if needs_manual_start {
-            "wasmExports['__wbindgen_start']();"
-        } else {
-            ""
-        };
 
         // `__force` keeps `$initBindgen` (and, via its `__deps`, every global
         // helper) in the build even though no compiled code references it.
@@ -1841,11 +1861,7 @@ if (require('worker_threads').isMainThread) {{
                 $initBindgen__postset: 'addOnInit(initBindgen);',
                 $initBindgen__force: true,
                 $initBindgen: () => {{
-                    // Call emscripten's _initialize to run static constructors
-                    // (needed for --no-entry builds)
-                    if (wasmExports['_initialize']) {{
-                        wasmExports['_initialize']();
-                    }}
+                    {initialize_logic}
                     {start_logic}
                     {classes_and_exports}
                 }}
@@ -7038,13 +7054,17 @@ addToLibrary({
     }
 
     /// JS expression that reaches a wasm export by name, honoring the output
-    /// mode. The emscripten target reaches exports through emscripten's own
-    /// `wasmExports` object using bracket (string-literal) access, which is the
-    /// form emcc's DCE graph and import/export minifier track and rename in
-    /// lockstep; other modes use the local `wasm` binding.
+    /// mode. The emscripten target never reads `wasmExports['name']` inline in
+    /// inner functions — emcc's metadce/minify export tracking doesn't reliably
+    /// cover name-keyed accesses there across versions. Instead it references
+    /// the identifier emcc's own top-level receiving code (`assignWasmExports`)
+    /// binds for every wasm export: the asmjs-mangled name. Those bindings are
+    /// the canonical DCE-graph pairs (kept iff used, dropped together with the
+    /// wasm export otherwise) and are renamed by the import/export minifier in
+    /// lockstep with the wasm. Other modes use the local `wasm` binding.
     fn wasm_export_ref(&self, name: &str) -> String {
         if matches!(self.config.mode, OutputMode::Emscripten) {
-            format!("wasmExports['{name}']")
+            emscripten_mangle(name)
         } else {
             format!("wasm.{name}")
         }
@@ -7679,6 +7699,19 @@ fn define_namespace_export(
         define_namespace_export(&mut ns.ns, export_name, &ns_path[1..], export)?;
     }
     Ok(())
+}
+
+/// Mirror of emscripten's `shared.asmjs_mangle`: the JS identifier emcc's
+/// top-level receiving code (`assignWasmExports`) binds a wasm export to.
+/// Internal symbols keep their name; everything else is prefixed with `_`.
+fn emscripten_mangle(name: &str) -> String {
+    match name {
+        "memory" | "__indirect_function_table" | "__asyncify_data" | "__asyncify_state" => {
+            name.to_string()
+        }
+        _ if name.starts_with("dynCall_") => name.to_string(),
+        _ => format!("_{name}"),
+    }
 }
 
 /// Returns a string to tack on to the end of an expression to access a

--- a/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
+++ b/crates/cli/src/wasm_bindgen_test_runner/emscripten_test.js
@@ -2,11 +2,13 @@
     var elem = document.querySelector('#output');
     window.mergedLibrary = {};
 
-    window.wasmExports = {
-        __wbindgen_start: () => {},
-        __wbg_wasmbindgentestcontext_free: () => {},
-        __wbg_interval_free: () => {}
-    };
+    // Glue references wasm exports through the asmjs-mangled identifiers
+    // that emcc's `assignWasmExports` receiving code binds at the top level.
+    window.wasmExports = {};
+    window.___wbindgen_start = () => {};
+    window.__initialize = () => {};
+    window.___wbg_wasmbindgentestcontext_free = () => {};
+    window.___wbg_interval_free = () => {};
     window.cachedTextEncoder = { encodeInto: () => {} };
     window.cachedTextDecoder = { decode: () => {} };
     window.Module = {};
@@ -75,8 +77,11 @@
             if (typeof Module.hello !== 'function') {
                 return { status: false, e: 'test result: hello() is not found in Module' };
             }
-            if (typeof Module.Interval !== 'function') {
-                return { status: false, e: 'test result: Interval is not found in Module' };
+            // Classes are `=`-prefixed string snippets (jsifier emits them as
+            // `var Interval = class Interval {...};`) so they never become
+            // `export class` declarations.
+            if (typeof Module.Interval !== 'string' || !Module.Interval.startsWith('=class ')) {
+                return { status: false, e: 'test result: Interval is not a class value snippet' };
             }
             // The hoisted exports must carry both attributes so emscripten
             // emits them as named ESM exports under -sMODULARIZE=instance.

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -3029,7 +3029,7 @@ fn emscripten_jspi_codegen() {
         "compute should hoist as an async library function:\n{lib}"
     );
     assert!(
-        lib.contains("WebAssembly.promising(wasmExports['do_work'])"),
+        lib.contains("WebAssembly.promising(_do_work)"),
         "do_work should call through WebAssembly.promising:\n{lib}"
     );
     assert!(

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2874,10 +2874,13 @@ fn emscripten_exports_hoisted_to_library_symbols() {
         lib.contains("$add__postset: \"Module['add'] = add;\""),
         "add should attach to Module via __postset:\n{lib}"
     );
-    // Class + its finalization registry hoisted to library symbols.
+    // Class + its finalization registry hoisted to library symbols. Classes
+    // are `=`-prefixed string snippets so jsifier emits `var Counter = class
+    // Counter {...}` rather than an `export class` declaration (which crashes
+    // emcc's acorn-optimizer).
     assert!(
-        lib.contains("$Counter: class Counter"),
-        "Counter should be a hoisted library class:\n{lib}"
+        lib.contains(r#"$Counter: "=class Counter"#),
+        "Counter should be a hoisted string-snippet library class:\n{lib}"
     );
     assert!(
         lib.contains("$CounterFinalization:"),
@@ -2933,7 +2936,7 @@ fn emscripten_exports_hoisted_to_library_symbols() {
     );
     // A private class is hoisted but must NOT be exposed as a public export.
     assert!(
-        lib.contains("$Secret: class Secret"),
+        lib.contains(r#"$Secret: "=class Secret"#),
         "private class should still be hoisted as a library symbol:\n{lib}"
     );
     assert!(


### PR DESCRIPTION
This updates the emscripten target output so glue never reads `wasmExports['name']` inline inside inner functions. This avoids a bug where emcc's metadce and import/export minifier only reliably track exports through its own top-level receiving bindings, so name-keyed accesses in inner functions could be stripped at -O2 (e.g. `__wbindgen_start`, the `__wbindgen_externrefs` table) or left referencing pre-minification names, failing at runtime.

* Glue now references the asmjs-mangled identifiers emcc's `assignWasmExports` receiving code binds at the top level for every wasm export (`_add`, `___wbindgen_malloc`, `___wbindgen_externrefs`, ...). These are the canonical DCE-graph pairs: wasm-metadce keeps exactly the exports the included glue uses, and the minifier renames them in lockstep with the wasm.
* `$initBindgen` calls `__initialize` only when the module actually exports `_initialize`, since the receiving binding otherwise doesn't exist.
* Hoisted classes are emitted as `=`-prefixed string value snippets so jsifier declares them as `export var` rather than `export class`, which crashes emcc's acorn-optimizer `ExportNamedDeclaration` handling under `-sMODULARIZE=instance`.

```js
ptr => wasmExports['__wbg_counter_free'](ptr, 1)
```

```js
ptr => ___wbg_counter_free(ptr, 1)
```

Verified end-to-end against emscripten's unified `-sWASM_BINDGEN` flow at `-O2` (`MODULARIZE=instance`, `EXPORT_ES6`, `AUTO_INIT`): internal exports and the externref table survive metadce and are minify-renamed correctly, unused exports are still DCE'd, ESM `module = "..."` imports and exported classes link and run; debug builds unchanged. Emscripten CLI shape tests updated for the class snippet form, and the emscripten test harness now stubs the mangled receiving identifiers.