### PR TITLE
Fix `js-sys` wasm64 build with `atomics` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Fixed
 
+* Fix `js-sys` wasm64 build with `atomics` feature.
+  [#5274](https://github.com/wasm-bindgen/wasm-bindgen/issues/5274)
+
 ### Removed
 
 ## [0.2.127](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.126...0.2.127)

--- a/crates/js-sys/src/futures/task/multithread.rs
+++ b/crates/js-sys/src/futures/task/multithread.rs
@@ -12,6 +12,11 @@ use core::sync::atomic::Ordering::SeqCst;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use wasm_bindgen::prelude::*;
 
+#[cfg(target_arch = "wasm32")]
+use core::arch::wasm32 as wasm;
+#[cfg(target_arch = "wasm64")]
+use core::arch::wasm64 as wasm;
+
 const SLEEPING: i32 = 0;
 const AWAKE: i32 = 1;
 
@@ -38,7 +43,7 @@ impl AtomicWaker {
         // the corresponding `waitAsync` that was waiting for the transition
         // from SLEEPING to AWAKE.
         unsafe {
-            core::arch::wasm32::memory_atomic_notify(
+            wasm::memory_atomic_notify(
                 self.state.as_ptr(),
                 1, // Number of threads to notify
             );

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -28,6 +28,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(target_feature = "atomics", feature(thread_local))]
 #![cfg_attr(target_feature = "atomics", feature(stdarch_wasm_atomic_wait))]
+#![cfg_attr(
+    all(target_feature = "atomics", target_arch = "wasm64"),
+    feature(simd_wasm64)
+)]
 
 extern crate alloc;
 


### PR DESCRIPTION
resolve https://github.com/wasm-bindgen/wasm-bindgen/issues/5271

That said, `wasm64` support for multithreading is currently incomplete. It’s not only that `js-sys` fails to compile; `wasm-bindgen` also doesn’t yet support the post-processing needed for `wasm64` atomics.