### PR TITLE
ci: pin icu_* crates to stop MSRV drift

### DIFF
--- a/crates/msrv/cli/Cargo.toml
+++ b/crates/msrv/cli/Cargo.toml
@@ -8,4 +8,14 @@ version = "0.0.0"
 # time 0.3.46 requires Rust 1.88
 time = "=0.3.45"
 
+# icu_*'s 2.3.0 release requires Rust 1.88 (pulled in transitively via
+# ureq -> url -> idna -> idna_adapter)
+icu_collections = "=2.2.0"
+icu_locale_core = "=2.2.0"
+icu_normalizer = "=2.2.0"
+icu_normalizer_data = "=2.2.0"
+icu_properties = "=2.2.0"
+icu_properties_data = "=2.2.0"
+icu_provider = "=2.2.0"
+
 wasm-bindgen-cli = { path = "../../cli" }


### PR DESCRIPTION
`icu_collections`/`icu_locale_core`/`icu_normalizer`/`icu_normalizer_data`/`icu_properties`/`icu_properties_data`/`icu_provider` released 2.3.0, which bumps their own MSRV to Rust 1.88.

```
error: rustc 1.86.0 is not supported by the following packages:
  icu_collections@2.3.0 requires rustc 1.88
  ...
```