### PR TITLE
Add --split-debug-info to put DWARF debug info in a separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ### Added
 
+* Added `--split-debug-info` to the CLI. This option extracts the DWARF debug
+  info to a separate `*_bg.debug.wasm` file. Use `--debug-info-url` to set
+  the recorded URL for the debug info. [#5279](https://github.com/wasm-bindgen/wasm-bindgen/pull/5279)
+
 ### Changed
 
 * Setting `js_namespace` on both an `extern "C"` block and an item inside it

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -33,6 +33,8 @@ pub struct Bindgen {
     demangle: bool,
     keep_lld_exports: bool,
     keep_debug: bool,
+    split_debug_info: bool,
+    debug_info_url: Option<String>,
     remove_name_section: bool,
     remove_producers_section: bool,
     omit_default_module_path: bool,
@@ -48,6 +50,8 @@ pub struct Bindgen {
 pub struct Output {
     module: walrus::Module,
     stem: String,
+    split_debug_info: bool,
+    debug_info_url: Option<String>,
     generated: Generated,
 }
 
@@ -108,6 +112,8 @@ impl Bindgen {
             demangle: true,
             keep_lld_exports: false,
             keep_debug: false,
+            split_debug_info: false,
+            debug_info_url: None,
             remove_name_section: false,
             remove_producers_section: false,
             emit_start: true,
@@ -270,6 +276,16 @@ impl Bindgen {
         self
     }
 
+    pub fn split_debug_info(&mut self, split: bool) -> &mut Bindgen {
+        self.split_debug_info = split;
+        self
+    }
+
+    pub fn debug_info_url(&mut self, url: &str) -> &mut Bindgen {
+        self.debug_info_url = Some(url.to_string());
+        self
+    }
+
     pub fn remove_name_section(&mut self, remove: bool) -> &mut Bindgen {
         self.remove_name_section = remove;
         self
@@ -326,6 +342,9 @@ impl Bindgen {
     }
 
     pub fn generate_output(&mut self) -> Result<Output, Error> {
+        if self.debug_info_url.is_some() && !self.split_debug_info {
+            bail!("cannot specify `debug_info_url` without `split_debug_info`");
+        }
         let mut module = match self.input {
             Input::None => bail!("must have an input by now"),
             Input::Module(ref mut m, _) => {
@@ -547,6 +566,8 @@ impl Bindgen {
         Ok(Output {
             module,
             stem: stem.to_string(),
+            split_debug_info: self.split_debug_info,
+            debug_info_url: self.debug_info_url.clone(),
             generated,
         })
     }
@@ -560,7 +581,7 @@ impl Bindgen {
             // include shared memory, so it fails that part of
             // validation!
             .strict_validate(false)
-            .generate_dwarf(self.keep_debug)
+            .generate_dwarf(self.keep_debug || self.split_debug_info)
             .generate_name_section(!self.remove_name_section)
             .generate_producers_section(!self.remove_producers_section)
             .parse(bytes)
@@ -754,6 +775,17 @@ impl Output {
         fs::create_dir_all(out_dir)?;
 
         let wasm_bytes = self.module.emit_wasm();
+        let wasm_bytes = if self.split_debug_info {
+            let debug_name = format!("{wasm_name}.debug.wasm");
+            let url = self.debug_info_url.as_deref().unwrap_or(&debug_name);
+            let main_bytes = split_debug_info(&wasm_bytes, url)?;
+            let debug_path = out_dir.join(&debug_name);
+            fs::write(&debug_path, &wasm_bytes)
+                .with_context(|| format!("failed to write `{}`", debug_path.display()))?;
+            main_bytes
+        } else {
+            wasm_bytes
+        };
         fs::write(&wasm_path, wasm_bytes)
             .with_context(|| format!("failed to write `{}`", wasm_path.display()))?;
 
@@ -855,6 +887,48 @@ impl Output {
 
         Ok(())
     }
+}
+
+/// Remove the `.debug_*` custom sections from an emitted Wasm module and
+/// append an `external_debug_info` custom section that holds `url`.
+///
+/// Ref: https://github.com/WebAssembly/tool-conventions/blob/main/Debugging.md
+fn split_debug_info(wasm: &[u8], url: &str) -> Result<Vec<u8>, Error> {
+    let mut kept = Vec::new();
+    let mut keep_from = 0;
+    let mut section_start = 0;
+    for payload in wasmparser::Parser::new(0).parse_all(wasm) {
+        let payload = payload?;
+        if let wasmparser::Payload::CustomSection(section) = &payload {
+            if section.name().starts_with(".debug_") {
+                kept.push(keep_from..section_start);
+                keep_from = section.range().end;
+            }
+        }
+        if let wasmparser::Payload::Version { range, .. } = &payload {
+            section_start = range.end;
+        } else if let Some((_, range)) = payload.as_section() {
+            section_start = range.end;
+        }
+    }
+    kept.push(keep_from..wasm.len());
+
+    let mut contents = Vec::new();
+    let name = "external_debug_info";
+    leb128::write::unsigned(&mut contents, name.len() as u64)?;
+    contents.extend_from_slice(name.as_bytes());
+    leb128::write::unsigned(&mut contents, url.len() as u64)?;
+    contents.extend_from_slice(url.as_bytes());
+
+    let kept_len: usize = kept.iter().map(|range| range.len()).sum();
+    let mut out = Vec::with_capacity(kept_len + contents.len() + 6);
+    for range in kept {
+        out.extend_from_slice(&wasm[range]);
+    }
+    out.push(0);
+    leb128::write::unsigned(&mut out, contents.len() as u64)?;
+    out.extend_from_slice(&contents);
+    Ok(out)
 }
 
 /// Instrument `#[wasm_bindgen(jspi)]` exports and `#[wasm_bindgen(suspending)]`

--- a/crates/cli/src/wasm_bindgen.rs
+++ b/crates/cli/src/wasm_bindgen.rs
@@ -72,6 +72,19 @@ struct Args {
     keep_debug: bool,
     #[arg(
         long,
+        help = "Write DWARF debug info to a separate `*_bg.debug.wasm` file (implies `--keep-debug`)"
+    )]
+    split_debug_info: bool,
+    #[arg(
+        long,
+        value_name = "URL",
+        requires = "split_debug_info",
+        help = "URL of the split debug info file, recorded in the main Wasm file\n\
+                (defaults to the file name of the debug info file)"
+    )]
+    debug_info_url: Option<String>,
+    #[arg(
+        long,
         value_name = "MODE",
         help = "Whether or not to use TextEncoder#encodeInto",
         value_parser = ["test", "always", "never"]
@@ -161,6 +174,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .demangle(!args.no_demangle)
         .keep_lld_exports(args.keep_lld_exports)
         .keep_debug(args.keep_debug)
+        .split_debug_info(args.split_debug_info)
         .remove_name_section(args.remove_name_section)
         .remove_producers_section(args.remove_producers_section)
         .typescript(!args.no_typescript)
@@ -171,6 +185,9 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .reset_state_function(args.generate_reset_state)
         .force_enable_abort_handler(args.force_enable_abort_handler);
 
+    if let Some(ref url) = args.debug_info_url {
+        b.debug_info_url(url);
+    }
     if let Some(ref name) = args.no_modules_global {
         b.no_modules_global(name)?;
     }

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -3270,6 +3270,113 @@ fn slice_to_array_works_in_a_no_std_crate() {
     project.build();
 }
 
+#[test]
+fn split_debug_info() {
+    /// Collect the name and data of each custom section in a Wasm module.
+    fn custom_sections(wasm: &[u8]) -> Vec<(String, Vec<u8>)> {
+        wasmparser::Parser::new(0)
+            .parse_all(wasm)
+            .filter_map(|payload| match payload.unwrap() {
+                Payload::CustomSection(s) => Some((s.name().to_string(), s.data().to_vec())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Get the contents of the code section of a Wasm module.
+    fn code_section(wasm: &[u8]) -> Vec<u8> {
+        wasmparser::Parser::new(0)
+            .parse_all(wasm)
+            .find_map(|payload| match payload.unwrap() {
+                Payload::CodeSectionStart { range, .. } => Some(wasm[range].to_vec()),
+                _ => None,
+            })
+            .expect("no code section")
+    }
+
+    /// Encode a string as a Wasm name string: a LEB128 length, then the
+    /// UTF-8 bytes.
+    fn name_string(s: &str) -> Vec<u8> {
+        assert!(s.len() < 128);
+        let mut bytes = vec![s.len() as u8];
+        bytes.extend_from_slice(s.as_bytes());
+        bytes
+    }
+
+    /// Get the data of the `external_debug_info` custom section, if the
+    /// module has one.
+    fn external_debug_info(wasm: &[u8]) -> Option<Vec<u8>> {
+        let sections = custom_sections(wasm)
+            .into_iter()
+            .filter(|(name, _)| name == "external_debug_info")
+            .collect::<Vec<_>>();
+        assert!(sections.len() <= 1);
+        sections.into_iter().next().map(|(_, data)| data)
+    }
+
+    let mut project = Project::new("split_debug_info");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub fn add(a: u32, b: u32) -> u32 {
+                a + b
+            }
+        "#,
+    );
+
+    // `--split-debug-info` writes the debug info to a second file and
+    // records that file's name in the main module by default.
+    let out_dir = project
+        .wasm_bindgen("--target web --split-debug-info")
+        .unwrap();
+    let main = fs::read(out_dir.join("split_debug_info_bg.wasm")).unwrap();
+    let debug = fs::read(out_dir.join("split_debug_info_bg.debug.wasm")).unwrap();
+    wasmparser::validate(&main).unwrap();
+
+    let main_sections = custom_sections(&main);
+    assert!(
+        main_sections
+            .iter()
+            .all(|(name, _)| !name.starts_with(".debug_")),
+        "main module must not contain DWARF sections"
+    );
+    assert_eq!(
+        external_debug_info(&main),
+        Some(name_string("split_debug_info_bg.debug.wasm"))
+    );
+
+    // The debug file keeps the DWARF sections and the code section, and
+    // does not point at itself.
+    assert_eq!(external_debug_info(&debug), None);
+    assert_eq!(code_section(&main), code_section(&debug));
+
+    // `--debug-info-url` changes the recorded URL, not the file name.
+    let url = "http://localhost:5173/app_bg.debug.wasm";
+    let out_dir = project
+        .wasm_bindgen(&format!(
+            "--target web --split-debug-info --debug-info-url {url}"
+        ))
+        .unwrap();
+    let main = fs::read(out_dir.join("split_debug_info_bg.wasm")).unwrap();
+    assert!(out_dir.join("split_debug_info_bg.debug.wasm").is_file());
+    assert_eq!(external_debug_info(&main), Some(name_string(url)));
+
+    // `--debug-info-url` requires `--split-debug-info`.
+    assert!(project
+        .wasm_bindgen("--target web --debug-info-url http://localhost/app.wasm")
+        .is_err());
+
+    // Without `--split-debug-info`, the DWARF stays embedded and no debug
+    // file or `external_debug_info` section appears.
+    let out_dir = project.wasm_bindgen("--target web --keep-debug").unwrap();
+    let main = fs::read(out_dir.join("split_debug_info_bg.wasm")).unwrap();
+    assert!(!out_dir.join("split_debug_info_bg.debug.wasm").exists());
+    assert_eq!(external_debug_info(&main), None);
+}
+
 /// Look up an executable on `PATH`. Used so the test can opportunistically
 /// validate the generated .d.ts with `tsc` without hard-requiring it.
 fn which(name: &str) -> Option<PathBuf> {

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -80,6 +80,21 @@ sections. See [debug information] for more.
 
 [debug information]: debug-info.html
 
+### `--split-debug-info`
+
+Write the DWARF debug info to a separate `<name>_bg.debug.wasm` file next to
+the main `<name>_bg.wasm` file. The main file gets an `external_debug_info`
+custom section that holds the URL of the debug info file. This flag
+implies `--keep-debug`. See [debug information] for more.
+
+### `--debug-info-url <URL>`
+
+Set the URL that `--split-debug-info` records in the main file. The default
+is the file name of the debug info file, which resolves relative to the URL
+of the main file. Give an absolute URL if you debug with VS Code: its
+debugger cannot resolve a relative URL. This option requires
+`--split-debug-info`.
+
 ### `--browser`
 
 When generating bundler-compatible code (see the section on [deployment]) this

--- a/guide/src/reference/debug-info.md
+++ b/guide/src/reference/debug-info.md
@@ -11,4 +11,7 @@ allows for live debugging in the dev-tools or in external editors have a debugge
 The `wasm-bindgen-test-runner` currently generates DWARF debug information for tests by default.
 
 Use [`--split-debug-info`](cli.html#--split-debug-info) to write the DWARF to a
-separate `<name>_bg.debug.wasm` file. For debuggers like VS Code DWARF extension, provide `--debug-info-url` with the absolute URL where the debug Wasm module will be served in order to satisfy the debuggers absolute URL requirement.
+separate `<name>_bg.debug.wasm` file. For debuggers like the VS Code DWARF
+extension, provide `--debug-info-url` with the absolute URL where the debug
+Wasm module will be served in order to satisfy the debugger's absolute URL
+requirement.

--- a/guide/src/reference/debug-info.md
+++ b/guide/src/reference/debug-info.md
@@ -9,3 +9,6 @@ to get DWARF support in Chrome. This doesn't just demangle symbols in your stack
 allows for live debugging in the dev-tools or in external editors have a debugger bridge to Chrome.
 
 The `wasm-bindgen-test-runner` currently generates DWARF debug information for tests by default.
+
+Use [`--split-debug-info`](cli.html#--split-debug-info) to write the DWARF to a
+separate `<name>_bg.debug.wasm` file. For debuggers like VS Code DWARF extension, provide `--debug-info-url` with the absolute URL where the debug Wasm module will be served in order to satisfy the debuggers absolute URL requirement.


### PR DESCRIPTION
### Description

I have (mis)pleasure of needing to debug Wasm modules that when debug info is included, exceeds v8's max module size: https://github.com/v8/v8/blob/5280f012d5ce0714c8db750cbada4251c76412c7/src/wasm/wasm-limits.h#L48

emscripten works around the issue by allowing one to specify a separate file to emit debug information (`-gseparate-dwarf[=FILENAME]`): https://emscripten.org/docs/tools_reference/emcc.html

Both the chrome dwarf debug tools and vscode dwarf extension can integrate this separate file (though vscode requires an absolute URL whereas chrome is fine with relative).

Previous issue on this topic (https://github.com/wasm-bindgen/wasm-bindgen/issues/3741 was closed in favor https://github.com/wasm-bindgen/wasm-bindgen/issues/3698 though it's a little unclear why (at least to me)).

With all that said, this PR does two things:

- adds `--split-debug-info` flag which writes the debug info into a `_bg.debug.wasm` file and emits the [spec sanctioned `external_debug_info`](https://github.com/WebAssembly/tool-conventions/blob/58188346ab5b5cbc4af125e74406b35121ff0458/Debugging.md) that [chrome](https://issues.chromium.org/issues/40681181) and vscode supports
- adds `--debug-info-url`, the equivalent of emscripten `-sSEPARATE_DWARF_URL=URL`. The vscode extension requires absolute URLs so this is needed for those use cases.

With this PR, I verified I can split out the debug info and that chrome and vscode recognizes it.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
