### PR TITLE
Fix nightly coverage CI failure

### DIFF
--- a/crates/cli/src/wasm_bindgen_test_runner/node.rs
+++ b/crates/cli/src/wasm_bindgen_test_runner/node.rs
@@ -29,8 +29,9 @@ const wrap = method => {{
     }};
 }};
 
-// save original `console.log`
+// save original `console.log` and `console.error`
 global.__wbgtest_og_console_log = console.log;
+global.__wbgtest_og_console_error = console.error;
 // override `console.log` and `console.error` etc... before we import tests to
 // ensure they're bound correctly in wasm. This'll allow us to intercept
 // all these calls and capture the output of tests
@@ -148,7 +149,7 @@ pub fn execute(
                 exit(0);
             })
             .catch(e => {
-                console.error(e);
+                global.__wbgtest_og_console_error(e);
                 exit(1);
             });
     ",

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -33,7 +33,9 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 # benchmark required end
 
 [target.'cfg(all(target_arch = "wasm32", wasm_bindgen_unstable_test_coverage))'.dependencies]
-minicov = "0.3.8"
+# Pinned: 0.3.9 bundles the LLVM 23.1 profiling runtime (profraw v11), which
+# crashes/mismatches with the LLVM 22 instrumentation of the pinned nightly.
+minicov = "=0.3.8"
 
 [dev-dependencies]
 web-sys = { path = "../web-sys", features = [


### PR DESCRIPTION
This fixes the nightly coverage CI failure on main.

minicov 0.3.9 (released Aug 14) bundles the LLVM 23.1 profiling runtime with raw profile format v11. Since `Cargo.lock` is not committed, CI picked it up immediately, and its runtime crashes with `RuntimeError: memory access out of bounds` in `initializeValueProfRuntimeRecord` when writing profile data instrumented by the pinned nightly's LLVM 22 - the failure appeared after tests passed and the error was swallowed by test output capture, so CI only showed `Node failed with exit_code 1`.

* Pin `minicov = "=0.3.8"`, matching the pinned `nightly-2026-02-18` (LLVM 22) coverage toolchain
* Surface uncaught node runner errors via the saved original `console.error` so failures after output capture are no longer silent

Note: latest nightly (LLVM 23.1.0) + minicov 0.3.9 was also tested and produces zero coverage with mismatched function data, so unpinning the toolchain instead is not currently viable - that combination needs upstream investigation before both pins can be lifted.

Coverage CI is green on this PR.