### PR TITLE
Support class-level generics and generic closure arguments in generic_per_mono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   info to a separate `*_bg.debug.wasm` file. Use `--debug-info-url` to set
   the recorded URL for the debug info. [#5279](https://github.com/wasm-bindgen/wasm-bindgen/pull/5279)
 
+* `#[wasm_bindgen(generic_per_mono)]` now supports class-level generics —
+  type and lifetime parameters of the imported *type* itself
+  (`this: &Cell<T>`), hoisted onto a parameterised `impl` block — and closure
+  arguments whose signature mentions a type parameter (`&dyn Fn(T) -> R`,
+  `&mut dyn FnMut(T)`).
+  [#5285](https://github.com/wasm-bindgen/wasm-bindgen/pull/5285)
+
 ### Changed
 
 * Setting `js_namespace` on both an `extern "C"` block and an item inside it

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -2799,27 +2799,21 @@ impl ast::ImportFunction {
                 class = Some(get_ty(self.js_ret.as_ref().unwrap()).clone());
             }
         }
-        // Class-level generics require the erasure machinery (`fn_class_generics`).
-        // This covers a type parameter (`this: &Holder<T>`) or a lifetime
-        // (`this: &Holder<'a>`) of the function appearing in the receiver/return
-        // *class* type's own argument list — either way the generated `impl`
-        // block would have to be parameterised, which this path does not do.
-        //
-        // Note `class` is the referent, with the receiver's outer `&` already
-        // stripped at parse time, so a lifetime written on the reference itself
-        // (`this: &'a Holder`) is deliberately not caught here: that one is
-        // supported, and is handled by binding the receiver as `&'a self` below.
-        if let Some(c) = &class {
-            if generics::uses_generic_params(c, &type_params)
-                || generics::uses_lifetime_params(c, &lifetime_params)
-            {
-                bail_span!(
-                    self.rust_name,
-                    "generic_per_mono does not support class-level generic parameters yet; \
-                     use the type-erasure generic path instead"
-                );
-            }
-        }
+        // Class-level generics (`this: &Foo<T>`) are supported by hoisting the
+        // class-typed parameters onto a parameterised `impl` block, reusing the
+        // same `get_fn_generics` partition the erased path uses. The imported
+        // type's handle impls (`IntoWasmAbi for Foo<T>` etc.) carry no erasure
+        // bound, so any `T` marshals as the class handle; only the per-mono
+        // `t: T` arguments constrain `T` (via the synthesized
+        // `IntoWasmAbi + WasmDescribe` bounds).
+        let fn_class_generics = self.get_fn_generics()?;
+        let class_is_generic = class
+            .as_ref()
+            .map(|c| {
+                generics::uses_generic_params(c, &type_params)
+                    || generics::uses_lifetime_params(c, &lifetime_params)
+            })
+            .unwrap_or(false);
 
         // A `variadic` import splats its final argument (`...arg`) on the JS
         // side, which requires that argument to be iterable at runtime.
@@ -2883,13 +2877,23 @@ impl ast::ImportFunction {
         // monomorphised shim. Inline bounds (`fn f<T: Trait>`) ride along with the
         // parameter list; `where` predicates have no such carrier and are
         // collected here.
-        let mut where_bounds: Vec<TokenStream> = self
-            .generics
-            .where_clause
-            .iter()
-            .flat_map(|where_clause| where_clause.predicates.iter())
-            .map(ToTokens::to_token_stream)
-            .collect();
+        // With a parameterised class impl, the hoisted params are declared on
+        // the `impl` header as bare idents, so every user bound (inline and
+        // `where`) is carried on the method's `where` clause instead. A method
+        // may constrain its impl's parameters, so this is always legal.
+        let mut where_bounds: Vec<TokenStream> = if class_is_generic {
+            generics::generic_bounds(&self.generics)
+                .iter()
+                .map(|p| p.to_token_stream())
+                .collect()
+        } else {
+            self.generics
+                .where_clause
+                .iter()
+                .flat_map(|where_clause| where_clause.predicates.iter())
+                .map(ToTokens::to_token_stream)
+                .collect()
+        };
         let mut wrapper_args = Vec::new();
         let mut shim_abi_args = Vec::new();
         let mut all_prim_names = Vec::new();
@@ -2935,7 +2939,26 @@ impl ast::ImportFunction {
                     }
                     _ => false,
                 };
-                if let (true, syn::Type::Reference(r)) = (top_level_shared_ref, ty) {
+                // A closure argument (`&dyn Fn(..)` / `&mut dyn FnMut(..)`)
+                // whose signature mentions a type parameter. The stack-closure
+                // impls make the reference an ordinary `IntoWasmAbi` type whose
+                // only obligation is `Self: WasmDescribe`, and the describe impl
+                // (`WasmDescribe for dyn Fn.. + '_`) is lifetime-parametric, so a
+                // single higher-ranked bound on the trait object is the whole
+                // contract; its own where-clauses (`args: FromWasmAbi`,
+                // `R: ReturnWasmAbi`) then surface per monomorphisation.
+                let ref_to_dyn = match ty {
+                    syn::Type::Reference(r) => {
+                        let elem = get_ty(&r.elem);
+                        matches!(elem, syn::Type::TraitObject(_)).then_some(elem)
+                    }
+                    _ => None,
+                };
+                if let Some(dyn_ty) = ref_to_dyn {
+                    where_bounds.push(quote! {
+                        for<'__wbg_fn> (#dyn_ty + '__wbg_fn): #wasm_bindgen::describe::WasmDescribe
+                    });
+                } else if let (true, syn::Type::Reference(r)) = (top_level_shared_ref, ty) {
                     let elem = &r.elem;
                     where_bounds.push(quote! {
                         for<'__wbg> &'__wbg #elem: #wasm_bindgen::convert::IntoWasmAbi
@@ -3137,7 +3160,18 @@ impl ast::ImportFunction {
             let doc_comment = &self.doc_comment;
             quote! { #[doc = #doc_comment] }
         };
-        let generic_params = &self.generics.params;
+        // Params hoisted to a parameterised class impl are excluded from the
+        // method's own generics (redeclaring them would be E0403); the rest
+        // stay on the method, as bare idents with their bounds carried in the
+        // `where` clause built above.
+        let generic_params: TokenStream = if class_is_generic {
+            let lts = &fn_class_generics.fn_lifetime_params;
+            let tys = &fn_class_generics.fn_generic_params;
+            quote! { #(#lts,)* #(#tys),* }
+        } else {
+            self.generics.params.to_token_stream()
+        };
+        let generic_params = &generic_params;
         // The shim redeclares the wrapper's type *and* lifetime parameters,
         // since it's a nested item and inherits none of the wrapper's generics.
         // Type params need their inline bounds too: its signature names ABI
@@ -3267,21 +3301,50 @@ impl ast::ImportFunction {
 
         if let Some(class) = class {
             // Strip any generic arguments from the class type's last path
-            // segment so we impl on the bare class (class generics are rejected
-            // above, so this only removes defaulted/elided arguments).
+            // segment so we impl on the bare class name; for a generic class the
+            // hoisted params are re-applied explicitly below.
             let mut class = class;
             if let syn::Type::Path(syn::TypePath { qself: None, path }) = &mut class {
                 if let Some(segment) = path.segments.last_mut() {
                     segment.arguments = syn::PathArguments::None;
                 }
             }
-            quote! {
-                #[automatically_derived]
-                impl #class {
-                    #invocation
+            if class_is_generic {
+                // Parameterised impl mirroring the erased path's
+                // `class_impl_def` construction in `try_to_tokens`. The hoisted
+                // class bounds are load-bearing: struct-declared bounds
+                // (`ArrayTuple<T: JsTuple>`) must be restated on the impl, and
+                // associated-type-equality predicates (`F: JsFunction<Ret = Ret>`)
+                // are what constrain otherwise-unconstrained impl params (E0207).
+                let class_lifetime_params = &fn_class_generics.class_lifetime_params;
+                let class_bound_lifetime_params = &fn_class_generics.class_bound_lifetime_params;
+                let class_generic_params = &fn_class_generics.class_generic_params;
+                let class_generic_exprs = &fn_class_generics.class_generic_exprs;
+                let impl_where_clause = if fn_class_generics.class_bounds.is_empty() {
+                    quote! {}
+                } else {
+                    let class_bounds = fn_class_generics.class_bounds.iter();
+                    quote! { where #(#class_bounds),* }
+                };
+                quote! {
+                    #[automatically_derived]
+                    impl<#(#class_lifetime_params,)* #(#class_bound_lifetime_params,)* #(#class_generic_params),*>
+                        #class<#(#class_lifetime_params,)* #(#class_generic_exprs),*>
+                    #impl_where_clause
+                    {
+                        #invocation
+                    }
                 }
+                .to_tokens(tokens);
+            } else {
+                quote! {
+                    #[automatically_derived]
+                    impl #class {
+                        #invocation
+                    }
+                }
+                .to_tokens(tokens);
             }
-            .to_tokens(tokens);
         } else {
             invocation.to_tokens(tokens);
         }

--- a/crates/macro/ui-tests/generic-per-mono-unsupported.rs
+++ b/crates/macro/ui-tests/generic-per-mono-unsupported.rs
@@ -93,31 +93,6 @@ extern "C" {
     fn tuple_pattern_arg<T>((a, b): (u32, u32), x: T);
 }
 
-// Class-level generics on the imported type need the erasure machinery
-// (`fn_class_generics`), so a `generic_per_mono` method on a generic imported
-// type is rejected. Kept in its own block so the `type Holder<T>` declaration
-// can't interfere with the diagnostics above.
-#[wasm_bindgen]
-extern "C" {
-    type Holder<T>;
-
-    #[wasm_bindgen(method, generic_per_mono)]
-    fn get<T>(this: &Holder<T>) -> T;
-}
-
-// Lifetime parameters on the *function* are supported (see
-// `generic_import_ref.rs` / `generic_import_lifetime.rs` for passing cases),
-// but the same class-level rejection above also applies when the function's
-// lifetime parameter is what parameterises the receiver/return class type,
-// since that also needs the erasure machinery's hoisting.
-#[wasm_bindgen]
-extern "C" {
-    type LifetimeHolder<'a>;
-
-    #[wasm_bindgen(method, generic_per_mono)]
-    fn get_lifetime<'a, T>(this: &'a LifetimeHolder<'a>) -> T;
-}
-
 // The rejections below happen while *parsing* the block rather than while
 // generating its tokens, and a parse failure aborts the whole block, swallowing
 // every codegen-time diagnostic in it. Keep them in their own block so they

--- a/crates/macro/ui-tests/generic-per-mono-unsupported.stderr
+++ b/crates/macro/ui-tests/generic-per-mono-unsupported.stderr
@@ -112,62 +112,50 @@ error: unsupported pattern in generic_per_mono imported function
 93 |     fn tuple_pattern_arg<T>((a, b): (u32, u32), x: T);
    |                             ^^^^^^
 
-error: generic_per_mono does not support class-level generic parameters yet; use the type-erasure generic path instead
-   --> ui-tests/generic-per-mono-unsupported.rs:105:8
-    |
-105 |     fn get<T>(this: &Holder<T>) -> T;
-    |        ^^^
-
-error: generic_per_mono does not support class-level generic parameters yet; use the type-erasure generic path instead
-   --> ui-tests/generic-per-mono-unsupported.rs:118:8
-    |
-118 |     fn get_lifetime<'a, T>(this: &'a LifetimeHolder<'a>) -> T;
-    |        ^^^^^^^^^^^^
-
 error: `assert_no_shim` cannot be used with `generic_per_mono`, which always generates one shim per monomorphisation
-   --> ui-tests/generic-per-mono-unsupported.rs:129:38
+   --> ui-tests/generic-per-mono-unsupported.rs:104:38
     |
-129 |     #[wasm_bindgen(generic_per_mono, assert_no_shim)]
+104 |     #[wasm_bindgen(generic_per_mono, assert_no_shim)]
     |                                      ^^^^^^^^^^^^^^
 
 error: `reexport` cannot be used with `generic_per_mono`, because one binding is manufactured per monomorphisation and there is no single shim to reexport; remove the reexport or use the type-erasure generic path
-   --> ui-tests/generic-per-mono-unsupported.rs:135:8
+   --> ui-tests/generic-per-mono-unsupported.rs:110:8
     |
-135 |     fn reexported<T>(x: T);
+110 |     fn reexported<T>(x: T);
     |        ^^^^^^^^^^
 
 error: unsupported in wasm-bindgen generics
-   --> ui-tests/generic-per-mono-unsupported.rs:141:22
+   --> ui-tests/generic-per-mono-unsupported.rs:116:22
     |
-141 |     fn const_generic<const N: usize, T>(x: T);
+116 |     fn const_generic<const N: usize, T>(x: T);
     |                      ^^^^^^^^^^^^^^
 
 error: unsupported in wasm-bindgen generics
-   --> ui-tests/generic-per-mono-unsupported.rs:148:30
+   --> ui-tests/generic-per-mono-unsupported.rs:123:30
     |
-148 |     fn unsized_type_param<T: ?Sized>(x: &T);
+123 |     fn unsized_type_param<T: ?Sized>(x: &T);
     |                              ^
 
 error: `slice_to_array` requires a concrete slice element type (e.g. `&[u16]`); a type parameter cannot work here because `VectorRefIntoWasmAbi` is implemented per concrete ABI shape — drop `slice_to_array`, or take the argument by value
-   --> ui-tests/generic-per-mono-unsupported.rs:156:43
+   --> ui-tests/generic-per-mono-unsupported.rs:131:43
     |
-156 |     fn slice_to_array_generic_elem<T>(xs: &[T], other: T);
+131 |     fn slice_to_array_generic_elem<T>(xs: &[T], other: T);
     |                                           ^^^^
 
 error: `slice_to_array` requires a concrete slice element type (e.g. `&[u16]`); a type parameter cannot work here because `VectorRefIntoWasmAbi` is implemented per concrete ABI shape — drop `slice_to_array`, or take the argument by value
-   --> ui-tests/generic-per-mono-unsupported.rs:160:42
+   --> ui-tests/generic-per-mono-unsupported.rs:135:42
     |
-160 |     fn slice_to_array_nested_elem<T>(xs: &[Vec<T>], other: T);
+135 |     fn slice_to_array_nested_elem<T>(xs: &[Vec<T>], other: T);
     |                                          ^^^^^^^^^
 
 error: `slice_to_array` requires a concrete slice element type (e.g. `&[u16]`); a type parameter cannot work here because `VectorRefIntoWasmAbi` is implemented per concrete ABI shape — drop `slice_to_array`, or take the argument by value
-   --> ui-tests/generic-per-mono-unsupported.rs:164:42
+   --> ui-tests/generic-per-mono-unsupported.rs:139:42
     |
-164 |     fn slice_to_array_option_elem<T>(xs: Option<&[T]>, other: T);
+139 |     fn slice_to_array_option_elem<T>(xs: Option<&[T]>, other: T);
     |                                          ^^^^^^^^^^^^
 
 error: `slice_to_array` requires a concrete slice element type (e.g. `&[u16]`); a type parameter cannot work here because `VectorRefIntoWasmAbi` is implemented per concrete ABI shape — drop `slice_to_array`, or take the argument by value
-   --> ui-tests/generic-per-mono-unsupported.rs:171:50
+   --> ui-tests/generic-per-mono-unsupported.rs:146:50
     |
-171 |     fn erased_slice_to_array_generic_elem<T>(xs: &[T]);
+146 |     fn erased_slice_to_array_generic_elem<T>(xs: &[T]);
     |                                                  ^^^^

--- a/guide/src/reference/attributes/on-js-imports/generic_per_mono.md
+++ b/guide/src/reference/attributes/on-js-imports/generic_per_mono.md
@@ -111,11 +111,42 @@ extern "C" {
 
 Lifetimes carry no runtime information — they are erased before values cross
 the wasm ABI — so this imposes no restriction beyond what plain Rust already
-requires of the signature. The one shape that is *not* supported is a lifetime
-belonging to the **class** itself, i.e. an imported type declared with its own
-lifetime parameter (`type Holder<'a>`, used as `this: &Holder<'a>`), since that
-needs the same hoisting machinery class-level type parameters do; see
-[Unsupported shapes](#unsupported-shapes).
+requires of the signature. A lifetime belonging to the **class** itself
+(`type Holder<'a>`, used as `this: &Holder<'a>`) is hoisted onto the generated
+`impl` block, exactly like a class-level type parameter; see
+[Class-level generics](#class-level-generics).
+
+## Class-level generics
+
+A generic parameter belonging to the imported *type* itself is supported: when
+the receiver or return class names one of the function's parameters in the
+class's own argument list (`this: &Cell<T>`, or a constructor returning
+`Cell<T>`), that parameter is hoisted off the method onto a parameterised
+`impl` block (`impl<T> Cell<T>`), reusing the same partition the erasure path
+performs:
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    type Cell<T>;
+
+    #[wasm_bindgen(constructor, generic_per_mono)]
+    fn new<T>(value: T) -> Cell<T>;
+
+    #[wasm_bindgen(method, generic_per_mono)]
+    fn get<T>(this: &Cell<T>) -> T;
+}
+
+let cell = Cell::new(42u32); // Cell<u32>
+let v: u32 = cell.get();     // crosses as a number
+```
+
+Unlike on the erasure path, the class parameter does not have to be a JS type:
+the handle impls carry no erasure bound, so `Cell<u32>` is a perfectly good
+type, and each method call marshals its arguments and return value at that
+monomorphisation's concrete types. Bounds declared on the function — inline or
+in a `where` clause — are carried on the generated method rather than the
+`impl` header, which constrains exactly the same set of instantiations.
 
 ## Other attributes
 
@@ -172,18 +203,15 @@ These are rejected at compile time with a diagnostic pointing at the offending
 declaration. Each generally keeps working on the type-erasure path, so the fix is
 usually to drop `generic_per_mono`:
 
-* **Generic parameters on the imported *type*** (class-level generics),
-  whether a type parameter (`this: &Holder<T>`) or a lifetime
-  (`this: &Holder<'a>`). Lifetime parameters on the *function* itself —
-  including on a method's receiver, `this: &'a Holder` — are supported; see
-  [Lifetime parameters](#lifetime-parameters).
 * **A mutable reference to a type parameter** (`&mut T`, or `&mut Vec<T>`, or
   any other `&mut` whose referent mentions a type parameter), and a reference to
   a type parameter **nested inside another type** (e.g. `Option<&T>`). A bare
   `&T` *is* supported, and mutable references to *concrete* types (e.g.
   `&mut [u16]`, `&mut dyn FnMut(u32)`) bind exactly as they do on the
-  non-generic import path — the restriction is only about references to type
-  parameters.
+  non-generic import path. Closure trait objects are the other exception: a
+  closure argument whose *signature* mentions a type parameter
+  (`&dyn Fn(T) -> R`, `&mut dyn FnMut(T)`) is supported, with each
+  monomorphisation crossing at its concrete types.
 * **Returning a reference.**
 * **A bare type parameter, or a reference to one (`&T`), as the `variadic`
   argument**, since it may monomorphise to a scalar, which is not spreadable.

--- a/guide/src/reference/working-with-generics.md
+++ b/guide/src/reference/working-with-generics.md
@@ -126,7 +126,7 @@ There are two ways a generic import can be bound, and they suit different jobs:
 | JS bindings generated       | One, shared by all instantiations             | One per monomorphisation                                            |
 | How `T` crosses the ABI     | Boxed to `JsValue` (via `ErasableGeneric`)    | At its concrete type (`u32` as a number, `String` as a string)      |
 | What `T` can be             | JS types (`JsGeneric`): `Array`, `Promise`, … | Any type wasm-bindgen can marshal, including Rust primitives        |
-| Generic imported *types*    | Yes — `type ListNode<T>`                      | No, function-level type parameters only                             |
+| Generic imported *types*    | Yes — `type ListNode<T>`                      | Yes — hoisted onto a parameterised `impl` block                     |
 | Code size                   | Constant                                      | Grows with the number of instantiations                             |
 
 Use erasure when you are modelling a JS generic — `Array<T>`, `Promise<T>`, a
@@ -136,8 +136,8 @@ the concrete marshalling is the point, e.g. a `log<T>` that should pass a `u32`
 as a number rather than boxing it.
 
 `generic_per_mono` also rejects a number of shapes that erasure accepts
-(generic parameters on the imported *type*, `&mut T`, generic `slice_to_array`
-element types, and others); those are listed on
+(`&mut T`, generic `slice_to_array` element types, and others); those are
+listed on
 [its own page](./attributes/on-js-imports/generic_per_mono.md#unsupported-shapes).
 
 ## The ErasableGeneric Trait

--- a/tests/wasm/generic_import_args.js
+++ b/tests/wasm/generic_import_args.js
@@ -45,6 +45,16 @@ exports.describeAny = function (x) {
   return typeof x + ":" + x;
 };
 
+exports.mapWith = function (f, x) {
+  return f(x);
+};
+
+exports.feedCallback = function (f) {
+  f(1);
+  f(2);
+  f(3);
+};
+
 exports.sumSlice = function (xs) {
   let total = 0;
   for (const v of xs) {

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -6,6 +6,9 @@
 //!   the caller. A copy would produce identical-looking glue.
 //! - `&mut dyn FnMut`: must be invoked the expected number of times, with the
 //!   reentrancy guard released afterwards.
+//! - closure arguments whose signature mentions a type parameter
+//!   (`&dyn Fn(T) -> R`, `&mut dyn FnMut(T)`): each monomorphisation crosses
+//!   at its own concrete types in both directions.
 //! - non-async `catch` with a *generic* `Ok`: the success value is marshalled at
 //!   each monomorphisation's concrete type while the error stays `JsValue`; the
 //!   throwing path is a different unwrap from the async one covered elsewhere.
@@ -55,6 +58,16 @@ extern "C" {
     // view.
     #[wasm_bindgen(generic_per_mono, js_name = sumSlice)]
     fn sum_slice<T>(xs: &[T]) -> f64;
+
+    // Closure arguments whose *signature* mentions a type parameter: the
+    // trait object gets a single higher-ranked `WasmDescribe` bound, and its
+    // describe impl's own where-clauses (`args: FromWasmAbi`,
+    // `R: ReturnWasmAbi`) then surface per monomorphisation.
+    #[wasm_bindgen(generic_per_mono, js_name = mapWith)]
+    fn map_with<T, R>(f: &dyn Fn(T) -> R, x: T) -> R;
+
+    #[wasm_bindgen(generic_per_mono, js_name = feedCallback)]
+    fn feed_callback<T>(f: &mut dyn FnMut(T));
 }
 
 #[wasm_bindgen_test]
@@ -89,6 +102,22 @@ fn generic_per_mono_mut_closure_is_invoked() {
         with_callback(&mut bump, 2.0f64);
     }
     assert_eq!(count, 2);
+}
+
+#[wasm_bindgen_test]
+fn generic_per_mono_generic_closure_signature() {
+    // `&dyn Fn` with the type parameter in both argument and return position.
+    assert_eq!(map_with(&|v: u32| v * 2, 21u32), 42);
+    assert_eq!(map_with(&|v: f64| format!("v={v}"), 1.5f64), "v=1.5");
+
+    // `&mut dyn FnMut` capturing state, at two element types.
+    let mut sum = 0u32;
+    feed_callback(&mut |v: u32| sum += v);
+    assert_eq!(sum, 6);
+
+    let mut joined = String::new();
+    feed_callback(&mut |v: f64| joined.push_str(&format!("{v},")));
+    assert_eq!(joined, "1,2,3,");
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/generic_import_lifetime.js
+++ b/tests/wasm/generic_import_lifetime.js
@@ -33,3 +33,17 @@ class Scaler {
 }
 
 exports.Scaler = Scaler;
+
+// Class with a Rust-side lifetime parameter (`type Tagged<'a>`): invisible
+// here, it is purely a Rust borrow-tracking concern.
+class Tagged {
+  constructor(tag) {
+    this._tag = tag;
+  }
+
+  tagWith(x) {
+    return this._tag + ":" + x;
+  }
+}
+
+exports.Tagged = Tagged;

--- a/tests/wasm/generic_import_lifetime.rs
+++ b/tests/wasm/generic_import_lifetime.rs
@@ -55,6 +55,18 @@ extern "C" {
     // borrows together for the duration of the call.
     #[wasm_bindgen(method, generic_per_mono, js_name = scaleRef)]
     fn scale_ref<'a, T>(this: &'a Scaler, x: &'a T) -> f64;
+
+    // A lifetime belonging to the *class* itself (`type Tagged<'a>`): the
+    // class names it in its own argument list, so it is hoisted onto the impl
+    // header (`impl<'a> Tagged<'a>`) exactly like a class-level type
+    // parameter.
+    type Tagged<'a>;
+
+    #[wasm_bindgen(constructor, generic_per_mono)]
+    fn new<'a, T>(tag: &'a T) -> Tagged<'a>;
+
+    #[wasm_bindgen(method, generic_per_mono, js_name = tagWith)]
+    fn tag_with<'a, T>(this: &'a Tagged<'a>, x: T) -> String;
 }
 
 #[wasm_bindgen_test]
@@ -102,4 +114,13 @@ fn generic_per_mono_receiver_lifetime_shared_with_argument() {
     assert_eq!(scaler.scale_ref(&x), 70.0);
     let y = JsValue::from(1.25f64);
     assert_eq!(scaler.scale_ref(&y), 12.5);
+}
+
+#[wasm_bindgen_test]
+fn generic_per_mono_class_level_lifetime() {
+    let v = JsValue::from(3u32);
+    // `Tagged<'_>` borrows `v` for as long as the handle lives.
+    let t = Tagged::new(&v);
+    assert_eq!(t.tag_with(4u32), "3:4");
+    assert_eq!(t.tag_with(String::from("s")), "3:s");
 }

--- a/tests/wasm/generic_import_methods.js
+++ b/tests/wasm/generic_import_methods.js
@@ -48,6 +48,29 @@ class Widget {
 
 exports.Widget = Widget;
 
+// One JS class serving every `TypedCell<T>` instantiation: the class parameter
+// is phantom on the JS side, while method arguments and returns cross at each
+// monomorphisation's concrete type.
+class TypedCell {
+  constructor(value) {
+    this._value = value;
+  }
+
+  get() {
+    return this._value;
+  }
+
+  set(value) {
+    this._value = value;
+  }
+
+  describeWith(label) {
+    return label + ":" + typeof this._value + ":" + this._value;
+  }
+}
+
+exports.TypedCell = TypedCell;
+
 // Inspection helpers. These are deliberately plain (non-generic) imports so
 // that a bug in the generic per-monomorphisation path cannot also corrupt the
 // assertions themselves.

--- a/tests/wasm/generic_import_methods.rs
+++ b/tests/wasm/generic_import_methods.rs
@@ -1,7 +1,8 @@
 //! Runtime coverage for `#[wasm_bindgen(generic_per_mono)]` on every
 //! *method-shaped* import: constructors, instance methods, static methods,
-//! getters and setters (plain, `structural` and `final`), and the `indexing_*`
-//! operations.
+//! getters and setters (plain, `structural` and `final`), the `indexing_*`
+//! operations, and methods on a class with its own generic parameters
+//! (`this: &TypedCell<T>`).
 //!
 //! `crates/cli/tests/reference/generic-import.rs` pins the JS these emit, but a
 //! snapshot cannot catch a binding that is internally consistent and still
@@ -70,6 +71,27 @@ extern "C" {
     // the *index* position.
     #[wasm_bindgen(method, structural, indexing_deleter, generic_per_mono)]
     fn delete_indexed<T>(this: &Widget, prop: T);
+
+    // Class-level generics: the type parameter appears in the *class's* own
+    // argument list (`this: &TypedCell<T>`), so `T` is hoisted off the method
+    // onto a parameterised `impl<T> TypedCell<T>` block. The handle impls
+    // carry no erasure bound, so `T` may be an ordinary Rust type; per-mono
+    // then marshals each `value: T` at its concrete type.
+    type TypedCell<T>;
+
+    #[wasm_bindgen(constructor, generic_per_mono)]
+    fn new<T>(value: T) -> TypedCell<T>;
+
+    #[wasm_bindgen(method, generic_per_mono, js_name = get)]
+    fn get<T>(this: &TypedCell<T>) -> T;
+
+    #[wasm_bindgen(method, generic_per_mono, js_name = set)]
+    fn set<T>(this: &TypedCell<T>, value: T);
+
+    // A method-level parameter (`U`) alongside the hoisted class parameter:
+    // `U` stays on the method while `T` moves to the impl header.
+    #[wasm_bindgen(method, generic_per_mono, js_name = describeWith)]
+    fn describe_with<T, U>(this: &TypedCell<T>, label: U) -> String;
 
     #[wasm_bindgen(js_name = widgetValue)]
     fn widget_value(w: &Widget) -> JsValue;
@@ -195,6 +217,29 @@ fn generic_per_mono_indexing_getter_and_setter() {
     assert!(widget_has_prop(&w, "a"));
     assert!(widget_has_prop(&w, "b"));
     assert!(!widget_has_prop(&w, "c"));
+}
+
+#[wasm_bindgen_test]
+fn generic_per_mono_class_level_type_param() {
+    // `TypedCell<u32>` and `TypedCell<String>` are distinct Rust types sharing
+    // one JS class; each method call still marshals at its concrete type.
+    let a = TypedCell::new(7u32);
+    assert_eq!(a.get(), 7);
+    a.set(9u32);
+    assert_eq!(a.get(), 9);
+
+    let b = TypedCell::new(String::from("hi"));
+    assert_eq!(b.get(), "hi");
+    b.set(String::from("bye"));
+    assert_eq!(b.get(), "bye");
+}
+
+#[wasm_bindgen_test]
+fn generic_per_mono_class_and_method_level_params() {
+    let c = TypedCell::new(1.5f64);
+    // `U` monomorphises independently of the hoisted `T`.
+    assert_eq!(c.describe_with(1u32), "1:number:1.5");
+    assert_eq!(c.describe_with(String::from("y")), "y:number:1.5");
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
This extends `#[wasm_bindgen(generic_per_mono)]` to two shapes it previously rejected to the type-erasure path.

Class-level generics — a type or lifetime parameter of the imported *type* itself (`this: &Cell<T>`, `type Tagged<'a>`) — are now supported by hoisting the class-typed parameters onto a parameterised `impl` block, reusing the same `get_fn_generics` partition the erased path uses. The imported type's handle impls carry no erasure bound, so the class parameter need not be a JS type: `Cell<u32>` is a valid instantiation, with each method call marshalling at its concrete types per monomorphisation.

```rs
#[wasm_bindgen]
extern "C" {
    type Cell<T>;

    #[wasm_bindgen(constructor, generic_per_mono)]
    fn new<T>(value: T) -> Cell<T>;

    #[wasm_bindgen(method, generic_per_mono)]
    fn get<T>(this: &Cell<T>) -> T;
}
```

Closure arguments (`&dyn Fn(..)` / `&mut dyn FnMut(..)`) whose signatures mention a type parameter are also now accepted, by synthesising a single higher-ranked `WasmDescribe` bound on the trait object; the stack-closure impls make the reference an ordinary `IntoWasmAbi` type, so no other codegen is needed.

Implementation notes:

* Hoisted params are declared on the `impl` header as bare idents, with all user bounds (inline and `where`) carried on the method's `where` clause, which constrains the same instantiations.
* Struct-declared class bounds are restated on the impl, and associated-type-equality predicates constrain otherwise-unconstrained impl params (E0207), mirroring the erased path's `class_impl_def` construction.
* The former ui-test rejections for class-level generics are removed.

Test coverage: runtime tests for a generic class across constructor, getter, setter and a mixed class/method parameter split (`this: &TypedCell<T>`), a class-level lifetime receiver (`this: &'a Tagged<'a>`), and generic closure signatures in both `Fn` and `FnMut` forms with values crossing concretely in both directions. Guide and changelog updated.