### PR TITLE
cli-support: --experimental-memory-discard trampoline generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   info to a separate `*_bg.debug.wasm` file. Use `--debug-info-url` to set
   the recorded URL for the debug info. [#5279](https://github.com/wasm-bindgen/wasm-bindgen/pull/5279)
 
+* Added an experimental `--experimental-memory-discard` flag which replaces an
+  `env.__wbindgen_memory_discard` function import with a local trampoline
+  containing the `memory.discard` instruction from the memory-control
+  proposal, allowing custom allocators to release physical pages back to the
+  host. Experimental and subject to change.
+
 ### Changed
 
 * Setting `js_namespace` on both an `extern "C"` block and an item inside it

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 rustc-demangle = "0.1.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-walrus = { version = "0.26.1", features = ['parallel'] }
+walrus = { version = "0.26.5", features = ['parallel'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.127" }
 wasmparser = "0.245"
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -45,6 +45,7 @@ pub struct Bindgen {
     split_linked_modules: bool,
     generate_reset_state: bool,
     force_enable_abort_handler: bool,
+    memory_discard: bool,
 }
 
 pub struct Output {
@@ -124,6 +125,7 @@ impl Bindgen {
             split_linked_modules: false,
             generate_reset_state: false,
             force_enable_abort_handler: false,
+            memory_discard: false,
         }
     }
 
@@ -326,6 +328,14 @@ impl Bindgen {
         self
     }
 
+    /// Experimental and subject to change: replace an
+    /// `env.__wbindgen_memory_discard` import with a `memory.discard`
+    /// trampoline from the memory-control proposal.
+    pub fn memory_discard(&mut self, memory_discard: bool) -> &mut Self {
+        self.memory_discard = memory_discard;
+        self
+    }
+
     pub fn generate<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
         self.generate_output()?.emit(path.as_ref())
     }
@@ -401,6 +411,9 @@ impl Bindgen {
 
         let thread_count = transforms::threads::run(&mut module)
             .with_context(|| "failed to prepare module for threading")?;
+
+        transforms::memory_discard::run(&mut module, self.memory_discard)
+            .with_context(|| "failed to generate `memory.discard` trampoline")?;
 
         // If requested, turn all mangled symbols into prettier unmangled
         // symbols with the help of `rustc-demangle`.

--- a/crates/cli-support/src/transforms/memory_discard.rs
+++ b/crates/cli-support/src/transforms/memory_discard.rs
@@ -1,0 +1,231 @@
+//! Replaces the `env.__wbindgen_memory_discard` import with a local trampoline whose
+//! body is the `memory.discard` instruction from the memory-control proposal.
+//!
+//! Experimental and subject to change, gated behind the
+//! `--experimental-memory-discard` CLI flag since the emitted instruction
+//! requires an engine supporting the memory-control proposal.
+//!
+//! LLVM has no way to emit `memory.discard` directly, so allocators that
+//! release physical pages back to the host on wasm32-unknown-unknown (such as
+//! jemalloc's purging path) declare this import instead:
+//!
+//! ```c
+//! __attribute__((import_module("env"), import_name("__wbindgen_memory_discard")))
+//! extern void __wbindgen_memory_discard(void *addr, size_t len);
+//! ```
+//!
+//! The import is deleted and its function id becomes a local function, so
+//! nothing survives to instantiation and page discard remains a pure wasm
+//! operation. `memory.discard` traps on non-page-aligned ranges and has
+//! zeroing semantics, matching `madvise(MADV_DONTNEED)` on an overcommitting
+//! Linux.
+
+use crate::wasm_conventions;
+use anyhow::{bail, Result};
+use walrus::ir::MemoryDiscard;
+use walrus::{ImportKind, Module, ValType};
+
+pub const IMPORT_MODULE: &str = "env";
+pub const IMPORT_NAME: &str = "__wbindgen_memory_discard";
+
+pub fn run(module: &mut Module, enabled: bool) -> Result<()> {
+    let fid = module.imports.iter().find_map(|impt| match impt.kind {
+        ImportKind::Function(id) if impt.module == IMPORT_MODULE && impt.name == IMPORT_NAME => {
+            Some(id)
+        }
+        _ => None,
+    });
+    let Some(fid) = fid else {
+        return Ok(());
+    };
+    if !enabled {
+        bail!(
+            "module imports `{IMPORT_MODULE}.{IMPORT_NAME}`, which requires the experimental \
+             `--experimental-memory-discard` flag; the emitted `memory.discard` instruction \
+             needs an engine supporting the wasm memory-control proposal"
+        );
+    }
+
+    let memory = wasm_conventions::get_memory(module)?;
+    // Address and length follow the memory's index type.
+    let ptr = if module.memories.get(memory).memory64 {
+        ValType::I64
+    } else {
+        ValType::I32
+    };
+    let ty = module.types.get(module.funcs.get(fid).ty());
+    if ty.params() != [ptr; 2] || !ty.results().is_empty() {
+        bail!(
+            "`{IMPORT_MODULE}.{IMPORT_NAME}` import must have type [{ptr} {ptr}] -> [], found \
+             [{}] -> [{}]",
+            ty.params()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" "),
+            ty.results()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+    }
+
+    module.replace_imported_func(fid, |(body, args)| {
+        body.local_get(args[0])
+            .local_get(args[1])
+            .instr(MemoryDiscard { memory });
+    })?;
+    module.funcs.get_mut(fid).name = Some(IMPORT_NAME.to_string());
+    log::debug!("Replaced `{IMPORT_MODULE}.{IMPORT_NAME}` with a `memory.discard` trampoline");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transforms::parse_wat;
+    use walrus::ir::{dfs_in_order, Instr, Visitor};
+    use walrus::FunctionKind;
+
+    fn validate(module: &mut walrus::Module) {
+        let features =
+            wasmparser::WasmFeatures::default() | wasmparser::WasmFeatures::MEMORY_CONTROL;
+        wasmparser::Validator::new_with_features(features)
+            .validate_all(&module.emit_wasm())
+            .expect("transformed module should validate");
+    }
+
+    fn count_discards(module: &walrus::Module) -> usize {
+        struct Scan(usize);
+        impl<'instr> Visitor<'instr> for Scan {
+            fn visit_instr(&mut self, instr: &Instr, _: &walrus::InstrLocId) {
+                if matches!(instr, Instr::MemoryDiscard(_)) {
+                    self.0 += 1;
+                }
+            }
+        }
+        let mut scan = Scan(0);
+        for func in module.funcs.iter() {
+            if let FunctionKind::Local(local) = &func.kind {
+                dfs_in_order(&mut scan, local, local.entry_block());
+            }
+        }
+        scan.0
+    }
+
+    #[test]
+    fn replaces_import_with_discard_trampoline() {
+        let mut module = parse_wat(
+            r#"
+            (module
+                (import "env" "__wbindgen_memory_discard" (func $discard (param i32 i32)))
+                (memory 1)
+                (export "memory" (memory 0))
+                (func $purge (param i32 i32)
+                    local.get 0
+                    local.get 1
+                    call $discard
+                )
+                (export "purge" (func $purge))
+            )
+        "#,
+        );
+
+        run(&mut module, true).unwrap();
+
+        assert_eq!(module.imports.iter().count(), 0);
+        assert_eq!(count_discards(&module), 1);
+        validate(&mut module);
+    }
+
+    #[test]
+    fn memory64_uses_i64_params() {
+        let mut module = parse_wat(
+            r#"
+            (module
+                (import "env" "__wbindgen_memory_discard" (func $discard (param i64 i64)))
+                (memory i64 1)
+                (export "memory" (memory 0))
+                (func $purge (param i64 i64)
+                    local.get 0
+                    local.get 1
+                    call $discard
+                )
+                (export "purge" (func $purge))
+            )
+        "#,
+        );
+
+        run(&mut module, true).unwrap();
+
+        assert_eq!(module.imports.iter().count(), 0);
+        assert_eq!(count_discards(&module), 1);
+        validate(&mut module);
+    }
+
+    #[test]
+    fn no_import_is_a_no_op() {
+        for enabled in [true, false] {
+            let mut module = parse_wat(
+                r#"
+                (module
+                    (memory 1)
+                    (export "memory" (memory 0))
+                )
+            "#,
+            );
+
+            run(&mut module, enabled).unwrap();
+
+            assert_eq!(count_discards(&module), 0);
+        }
+    }
+
+    #[test]
+    fn import_without_flag_errors() {
+        let mut module = parse_wat(
+            r#"
+            (module
+                (import "env" "__wbindgen_memory_discard" (func (param i32 i32)))
+                (memory 1)
+            )
+        "#,
+        );
+
+        let err = run(&mut module, false).unwrap_err().to_string();
+        assert!(err.contains("--experimental-memory-discard"), "{err}");
+    }
+
+    #[test]
+    fn wrong_signature_errors() {
+        let mut module = parse_wat(
+            r#"
+            (module
+                (import "env" "__wbindgen_memory_discard" (func (param i32 i32) (result i32)))
+                (memory 1)
+                (export "memory" (memory 0))
+            )
+        "#,
+        );
+
+        let err = run(&mut module, true).unwrap_err().to_string();
+        assert!(err.contains("must have type [i32 i32] -> []"), "{err}");
+    }
+
+    #[test]
+    fn memory64_rejects_i32_signature() {
+        let mut module = parse_wat(
+            r#"
+            (module
+                (import "env" "__wbindgen_memory_discard" (func (param i32 i32)))
+                (memory i64 1)
+                (export "memory" (memory 0))
+            )
+        "#,
+        );
+
+        let err = run(&mut module, true).unwrap_err().to_string();
+        assert!(err.contains("must have type [i64 i64] -> []"), "{err}");
+    }
+}

--- a/crates/cli-support/src/transforms/memory_discard.rs
+++ b/crates/cli-support/src/transforms/memory_discard.rs
@@ -228,4 +228,43 @@ mod tests {
         let err = run(&mut module, true).unwrap_err().to_string();
         assert!(err.contains("must have type [i64 i64] -> []"), "{err}");
     }
+
+    #[test]
+    fn errors_without_a_memory() {
+        // The import is present (and the flag is enabled), but the module
+        // declares no memory at all, so `wasm_conventions::get_memory` should
+        // fail and that failure should propagate out of `run`.
+        let mut module = parse_wat(
+            r#"
+            (module
+                (import "env" "__wbindgen_memory_discard" (func (param i32 i32)))
+            )
+        "#,
+        );
+
+        let err = run(&mut module, true).unwrap_err().to_string();
+        assert!(err.contains("does not have a memory"), "{err}");
+    }
+
+    #[test]
+    fn errors_with_multiple_memories() {
+        // Build the module via the walrus API directly rather than `.wat`,
+        // since the text format's multi-memory syntax requires enabling a
+        // wasm proposal `wat::parse_str` doesn't have turned on by default.
+        let mut config = walrus::ModuleConfig::new();
+        config.generate_producers_section(false);
+        let mut module = walrus::Module::with_config(config);
+
+        module.memories.add_local(false, false, 1, None, None);
+        module.memories.add_local(false, false, 1, None, None);
+
+        let ty = module.types.add(&[ValType::I32, ValType::I32], &[]);
+        module.add_import_func(IMPORT_MODULE, IMPORT_NAME, ty);
+
+        let err = run(&mut module, true).unwrap_err().to_string();
+        assert!(
+            err.contains("expected a single memory, found multiple"),
+            "{err}"
+        );
+    }
 }

--- a/crates/cli-support/src/transforms/mod.rs
+++ b/crates/cli-support/src/transforms/mod.rs
@@ -2,6 +2,7 @@ pub mod catch_handler;
 pub mod export_sp_restore;
 pub mod externref;
 pub mod jspi;
+pub mod memory_discard;
 pub mod multi_value;
 pub mod threads;
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0"
 shlex = "1"
 tempfile = "3.0"
 ureq = { version = "3", default-features = false, features = ["brotli", "gzip"] }
-walrus = "0.26.1"
+walrus = "0.26.5"
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.127" }
 wasm-bindgen-test-shared = { path = "../test-shared", version = "=0.2.127" }
 wasmparser = "0.245"

--- a/crates/cli/src/wasm_bindgen.rs
+++ b/crates/cli/src/wasm_bindgen.rs
@@ -111,6 +111,12 @@ struct Args {
         help = "Enable abort handler even if building with panic=abort. Does nothing when panic=unwind."
     )]
     force_enable_abort_handler: bool,
+    #[arg(
+        long = "experimental-memory-discard",
+        help = "Replace an `env.__wbindgen_memory_discard` import with a `memory.discard`\n\
+                trampoline from the wasm memory-control proposal (experimental)"
+    )]
+    experimental_memory_discard: bool,
     // The options below are deprecated. They're still parsed for backwards compatibility,
     // but we don't want to show them in `--help` to avoid distracting users.
     #[arg(long, hide = true)]
@@ -183,7 +189,8 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .split_linked_modules(args.split_linked_modules)
         .reference_types(args.reference_types)
         .reset_state_function(args.generate_reset_state)
-        .force_enable_abort_handler(args.force_enable_abort_handler);
+        .force_enable_abort_handler(args.force_enable_abort_handler)
+        .memory_discard(args.experimental_memory_discard);
 
     if let Some(ref url) = args.debug_info_url {
         b.debug_info_url(url);

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -3377,6 +3377,94 @@ fn split_debug_info() {
     assert_eq!(external_debug_info(&main), None);
 }
 
+#[test]
+fn experimental_memory_discard() {
+    /// Whether a module contains a `memory.discard` instruction in any local
+    /// function body.
+    fn has_memory_discard(module: &walrus::Module) -> bool {
+        use walrus::ir::{dfs_in_order, Instr, Visitor};
+        use walrus::FunctionKind;
+
+        struct Scan(bool);
+        impl<'instr> Visitor<'instr> for Scan {
+            fn visit_instr(&mut self, instr: &Instr, _: &walrus::InstrLocId) {
+                if matches!(instr, Instr::MemoryDiscard(_)) {
+                    self.0 = true;
+                }
+            }
+        }
+
+        let mut scan = Scan(false);
+        for func in module.funcs.iter() {
+            if let FunctionKind::Local(local) = &func.kind {
+                dfs_in_order(&mut scan, local, local.entry_block());
+            }
+        }
+        scan.0
+    }
+
+    let mut project = Project::new("experimental_memory_discard");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            #[link(wasm_import_module = "env")]
+            extern "C" {
+                #[link_name = "__wbindgen_memory_discard"]
+                fn __wbindgen_memory_discard(addr: usize, len: usize);
+            }
+
+            #[wasm_bindgen]
+            pub fn purge(addr: usize, len: usize) {
+                unsafe { __wbindgen_memory_discard(addr, len) }
+            }
+        "#,
+    );
+
+    // Without the flag, the import is left dangling and `wasm-bindgen` must
+    // hard-error rather than emit a module with an unresolvable import.
+    let err = project
+        .wasm_bindgen("--target web")
+        .expect_err("should fail without --experimental-memory-discard");
+    assert!(
+        format!("{err:#}").contains("--experimental-memory-discard"),
+        "{err:#}"
+    );
+
+    // With the flag, the import is replaced by a local `memory.discard`
+    // trampoline and no longer appears in the import section.
+    let out_dir = project
+        .wasm_bindgen("--target web --experimental-memory-discard")
+        .unwrap_or_else(|e| panic!("{e:#}"));
+    let wasm = out_dir.join("experimental_memory_discard_bg.wasm");
+    let module = ModuleConfig::new().parse_file(&wasm).unwrap();
+
+    assert!(
+        module
+            .imports
+            .iter()
+            .all(|i| !(i.module == "env" && i.name == "__wbindgen_memory_discard")),
+        "`__wbindgen_memory_discard` import should have been removed"
+    );
+    assert!(
+        has_memory_discard(&module),
+        "output module should contain a `memory.discard` instruction"
+    );
+
+    // The emitted `memory.discard` instruction only validates against an
+    // engine/parser that understands the memory-control proposal.
+    let bytes = fs::read(&wasm).unwrap();
+    assert!(
+        wasmparser::validate(&bytes).is_err(),
+        "plain validation should reject `memory.discard` without the feature"
+    );
+    let features = wasmparser::WasmFeatures::default() | wasmparser::WasmFeatures::MEMORY_CONTROL;
+    wasmparser::Validator::new_with_features(features)
+        .validate_all(&bytes)
+        .expect("module should validate once memory-control is enabled");
+}
+
 /// Look up an executable on `PATH`. Used so the test can opportunistically
 /// validate the generated .d.ts with `tsc` without hard-requiring it.
 fn which(name: &str) -> Option<PathBuf> {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -52,6 +52,7 @@
   - [Supported Browsers](./reference/browser-support.md)
   - [Support for Weak References](./reference/weak-references.md)
   - [Support for Reference Types](./reference/reference-types.md)
+  - [Releasing Memory with `memory.discard`](./reference/memory-discard.md)
   - [Catching Panics](./reference/catch-unwind.md)
   - [Handling Aborts](./reference/handling-aborts.md)
   - [Supported Types](./reference/types.md)

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -139,3 +139,17 @@ already contains the exception-handling instructions it relies on. A
 nothing for `panic=unwind` builds.
 
 See [Handling Aborts](./handling-aborts.md) for the `set_on_abort` API.
+
+### `--experimental-memory-discard`
+
+Replaces an `env.__wbindgen_memory_discard` function import with a local
+trampoline containing the `memory.discard` instruction from the wasm
+memory-control proposal, allowing custom allocators to release physical pages
+back to the host.
+
+This feature is experimental and subject to change: the emitted instruction
+requires an engine supporting the memory-control proposal, and the import
+contract WILL change as the proposal evolves.
+
+See [Releasing Memory with `memory.discard`](./memory-discard.md) for the
+import contract.

--- a/guide/src/reference/memory-discard.md
+++ b/guide/src/reference/memory-discard.md
@@ -1,0 +1,47 @@
+# Releasing Memory with `memory.discard`
+
+> **Note**: this feature is experimental and subject to change. It is only
+> enabled when the `--experimental-memory-discard` CLI flag is passed, and
+> the import contract WILL change as the underlying proposal evolves.
+
+WebAssembly's linear memory can only grow. Even when an allocator frees pages,
+the host engine keeps the physical memory committed, so a temporary allocation
+spike stays resident for the lifetime of the instance.
+
+The [memory-control proposal] adds a `memory.discard` instruction which
+releases the physical pages backing a region of linear memory back to the
+host, zeroing the region in the process (like `madvise(MADV_DONTNEED)` on
+Linux).
+
+LLVM cannot emit this instruction directly yet. Instead, when the
+`--experimental-memory-discard` flag is passed, `wasm-bindgen` recognizes the
+following function import as a request for it:
+
+```wat
+(import "env" "__wbindgen_memory_discard" (func (param i32 i32)))
+```
+
+or from C:
+
+```c
+__attribute__((import_module("env"), import_name("__wbindgen_memory_discard")))
+extern void __wbindgen_memory_discard(void *addr, size_t len);
+```
+
+During the `wasm-bindgen` CLI post-processing step this import is replaced
+with a local function whose body is the `memory.discard` instruction, so no
+import survives to instantiation and page discard remains a pure Wasm
+operation with no JS involved.
+
+The arguments are a start address and a length in bytes; both follow the
+memory's index type (`i64` under memory64). Per the proposal, the range must
+be page-aligned (64KiB) or the instruction traps.
+
+Note that a module containing `memory.discard` requires an engine with
+memory-control support to validate. The import is typically pulled in
+deliberately by a custom allocator whose purging path forwards to
+`__wbindgen_memory_discard`; if it is present without the
+`--experimental-memory-discard` flag, `wasm-bindgen` reports an error rather
+than leaving a dangling import.
+
+[memory-control proposal]: https://github.com/WebAssembly/memory-control


### PR DESCRIPTION
This adds experimental support for the `memory.discard` instruction from the [memory-control proposal](https://github.com/WebAssembly/memory-control), allowing custom allocators to release physical pages back to the host on wasm32-unknown-unknown.

Wasm linear memory can only grow, so a temporary allocation spike stays resident for the lifetime of the instance. `memory.discard` releases the backing pages with zeroing semantics (equivalent to `madvise(MADV_DONTNEED)`), but LLVM has no way to emit it. Instead, an allocator declares:

```c
__attribute__((import_module("env"), import_name("__wbindgen_memory_discard")))
extern void __wbindgen_memory_discard(void *addr, size_t len);
```

and, behind the new `--experimental-memory-discard` flag, wasm-bindgen replaces the import with a local trampoline containing the instruction, so nothing survives to instantiation and page discard remains a pure wasm operation with no JS involved.

* Gated behind `--experimental-memory-discard` and documented as experimental and subject to change, since the emitted instruction requires an engine supporting the memory-control proposal
* The import without the flag is a hard error pointing at the flag, rather than a dangling `env` import at instantiation time
* Signature-checked as `[i32 i32] -> []`, following the memory's index type (`[i64 i64]` under memory64)
* Bumps walrus to 0.26.5 for `MemoryDiscard` support

Unit tests cover trampoline generation, memory64, flag gating, and signature mismatch errors, and a guide reference page documents the contract. Verified end-to-end against a jemalloc build whose `madvise` purge path forwards to this import ([guybedford/jemallocator memory-discard](https://github.com/guybedford/jemallocator/tree/memory-discard)) - the final bindgen output validates with wasm-tools and contains the discard trampoline with no surviving import.