### PR TITLE
Add WebGPU `setImmediates` to immutable slice whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   e.g. `js_namespace = ["a", "b"]`. The previous behavior silently dropped
   the block-level namespace.
   [#4324](https://github.com/wasm-bindgen/wasm-bindgen/issues/4324)
-* Changed WebGPU `setImmediates` APIs to take immutable u8 slice
+* Changed WebGPU `setImmediates` APIs to take immutable u8 slice.
   [#5289](https://github.com/wasm-bindgen/wasm-bindgen/pull/5289)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   e.g. `js_namespace = ["a", "b"]`. The previous behavior silently dropped
   the block-level namespace.
   [#4324](https://github.com/wasm-bindgen/wasm-bindgen/issues/4324)
+* Changed WebGPU `setImmediates` APIs to take immutable u8 slice
+  [#5289](https://github.com/wasm-bindgen/wasm-bindgen/pull/5289)
 
 ### Fixed
 

--- a/crates/web-sys/src/features/gen_GpuComputePassEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuComputePassEncoder.rs
@@ -326,7 +326,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
@@ -387,7 +387,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
@@ -450,7 +450,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
@@ -514,7 +514,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32_and_u32(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
         data_size: u32,
     ) -> Result<(), JsValue>;
@@ -580,7 +580,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64_and_u32(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
         data_size: u32,
     ) -> Result<(), JsValue>;
@@ -646,7 +646,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32_and_f64(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
         data_size: f64,
     ) -> Result<(), JsValue>;
@@ -712,7 +712,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64_and_f64(
         this: &GpuComputePassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
         data_size: f64,
     ) -> Result<(), JsValue>;

--- a/crates/web-sys/src/features/gen_GpuRenderBundleEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderBundleEncoder.rs
@@ -236,7 +236,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
@@ -297,7 +297,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
@@ -360,7 +360,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
@@ -424,7 +424,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32_and_u32(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
         data_size: u32,
     ) -> Result<(), JsValue>;
@@ -490,7 +490,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64_and_u32(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
         data_size: u32,
     ) -> Result<(), JsValue>;
@@ -556,7 +556,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32_and_f64(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
         data_size: f64,
     ) -> Result<(), JsValue>;
@@ -622,7 +622,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64_and_f64(
         this: &GpuRenderBundleEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
         data_size: f64,
     ) -> Result<(), JsValue>;

--- a/crates/web-sys/src/features/gen_GpuRenderPassEncoder.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassEncoder.rs
@@ -346,7 +346,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
@@ -407,7 +407,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
@@ -470,7 +470,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
     ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
@@ -534,7 +534,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32_and_u32(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
         data_size: u32,
     ) -> Result<(), JsValue>;
@@ -600,7 +600,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64_and_u32(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
         data_size: u32,
     ) -> Result<(), JsValue>;
@@ -666,7 +666,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_u32_and_f64(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: u32,
         data_size: f64,
     ) -> Result<(), JsValue>;
@@ -732,7 +732,7 @@ extern "C" {
     pub fn set_immediates_with_u8_slice_and_f64_and_f64(
         this: &GpuRenderPassEncoder,
         range_offset: u32,
-        data: &mut [u8],
+        data: &[u8],
         data_offset: f64,
         data_size: f64,
     ) -> Result<(), JsValue>;

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -110,6 +110,7 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "send",
         // WebGPU
         "setBindGroup",
+        "setImmediates",
         "writeBuffer",
         "writeTexture",
         // AudioBuffer


### PR DESCRIPTION
### Description
`setImmediates` should take immutable u8 slice.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
