### PR TITLE
Update syn requirement from 2.0 to 3.0

### DIFF
--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -19,7 +19,7 @@ strict-macro = []
 bumpalo = "3.0.0"
 proc-macro2 = "1.0"
 quote = '1.0'
-syn = { version = '2.0', features = ['visit', 'visit-mut', 'full', 'extra-traits'] }
+syn = { version = '3.0', features = ['visit', 'visit-mut', 'full', 'extra-traits'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.127" }
 
 [lints]

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -898,6 +898,7 @@ impl TryToTokens for ast::Export {
             converted_arguments.push(quote! { #ident });
         }
         let syn_unit = syn::Type::Tuple(syn::TypeTuple {
+            attrs: Vec::new(),
             elems: Default::default(),
             paren_token: Default::default(),
         });
@@ -2561,6 +2562,7 @@ impl TryToTokens for ast::ImportFunction {
         if let Some((_, class)) = class {
             let mut class = class.clone();
             if let syn::Type::Path(syn::TypePath {
+                attrs: _,
                 qself: None,
                 ref mut path,
             }) = class
@@ -2684,7 +2686,11 @@ fn is_spreadable_sequence(ty: &syn::Type) -> bool {
     match ty {
         // `[T]` and `[T; N]`.
         syn::Type::Slice(_) | syn::Type::Array(_) => true,
-        syn::Type::Path(syn::TypePath { qself: None, path }) => {
+        syn::Type::Path(syn::TypePath {
+            attrs: _,
+            qself: None,
+            path,
+        }) => {
             let Some(seg) = path.segments.last() else {
                 return false;
             };
@@ -3323,7 +3329,12 @@ impl ast::ImportFunction {
             // segment so we impl on the bare class (class generics are rejected
             // above, so this only removes defaulted/elided arguments).
             let mut class = class;
-            if let syn::Type::Path(syn::TypePath { qself: None, path }) = &mut class {
+            if let syn::Type::Path(syn::TypePath {
+                attrs: _,
+                qself: None,
+                path,
+            }) = &mut class
+            {
                 if let Some(segment) = path.segments.last_mut() {
                     segment.arguments = syn::PathArguments::None;
                 }
@@ -3401,6 +3412,7 @@ impl ast::ImportFunction {
                     let ident = &type_param.ident;
                     let bounds = type_param.bounds.clone();
                     let predicate = syn::WherePredicate::Type(syn::PredicateType {
+                        attrs: Vec::new(),
                         lifetimes: None,
                         bounded_ty: syn::parse_quote!(#ident),
                         colon_token: syn::Token![:](proc_macro2::Span::call_site()),
@@ -3636,6 +3648,7 @@ impl ast::ImportFunction {
 
         let ret_ty = self.js_ret.as_ref()?;
         let syn::Type::Path(syn::TypePath {
+            attrs: _,
             qself: None,
             ref path,
         }) = get_ty(ret_ty)
@@ -4296,7 +4309,12 @@ pub(crate) fn detect_slice_or_option_slice(ty: &syn::Type) -> Option<SliceArg> {
         }
     }
     // `Option<&[T]>` — match shape `Option<...>` and recurse once.
-    if let syn::Type::Path(syn::TypePath { qself: None, path }) = ty {
+    if let syn::Type::Path(syn::TypePath {
+        attrs: _,
+        qself: None,
+        path,
+    }) = ty
+    {
         if let Some(seg) = path.segments.last() {
             if seg.ident == "Option" {
                 if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
@@ -4326,7 +4344,12 @@ pub(crate) fn detect_slice_or_option_slice(ty: &syn::Type) -> Option<SliceArg> {
 /// `Result` alias or a re-ordered alias will not be recognised, which only means
 /// a diagnostic is skipped.
 fn result_err_ty(ty: &syn::Type) -> Option<&syn::Type> {
-    let syn::Type::Path(syn::TypePath { qself: None, path }) = get_ty(ty) else {
+    let syn::Type::Path(syn::TypePath {
+        attrs: _,
+        qself: None,
+        path,
+    }) = get_ty(ty)
+    else {
         return None;
     };
     let syn::PathArguments::AngleBracketed(args) = &path.segments.last()?.arguments else {

--- a/crates/macro-support/src/generics.rs
+++ b/crates/macro-support/src/generics.rs
@@ -426,10 +426,10 @@ impl<'a> VisitMut for ImplTraitDesugar<'a> {
             ident: ident.clone(),
             colon_token: Some(Default::default()),
             bounds: impl_trait.bounds.clone(),
-            eq_token: None,
             default: None,
         }));
         *ty = syn::Type::Path(syn::TypePath {
+            attrs: Vec::new(),
             qself: None,
             path: ident.into(),
         });
@@ -594,7 +594,7 @@ fn type_is_constraining(ty: &syn::Type, generic_names: &[&Ident]) -> bool {
             .elems
             .iter()
             .all(|e| type_is_constraining(e, generic_names)),
-        // Pointer / BareFn / TraitObject / ImplTrait / Infer / Never / Macro:
+        // Pointer / FnPtr / TraitObject / ImplTrait / Infer / Never / Macro:
         // any fn-generic mention here is non-constraining (fn-ptr, dyn, impl
         // Trait are explicitly non-constraining per RFC 0447; the rest are
         // handled conservatively).

--- a/crates/macro-support/src/generics.rs
+++ b/crates/macro-support/src/generics.rs
@@ -159,7 +159,7 @@ impl<'a, 'b> Visit<'a> for GenericNameVisitor<'a, 'b> {
                 syn::PathArguments::Parenthesized(args) => {
                     // Handle function syntax like FnMut(T) -> Result<R, JsValue>
                     for input in &args.inputs {
-                        syn::visit::visit_type(self, input);
+                        syn::visit::visit_type(self, &input.ty);
                     }
                     if let syn::ReturnType::Type(_, return_type) = &args.output {
                         syn::visit::visit_type(self, return_type);
@@ -175,7 +175,7 @@ impl<'a, 'b> Visit<'a> for GenericNameVisitor<'a, 'b> {
 pub(crate) fn generic_params(generics: &syn::Generics) -> Vec<(&Ident, Option<&syn::Type>)> {
     generics
         .type_params()
-        .map(|tp| (&tp.ident, tp.default.as_ref()))
+        .map(|tp| (&tp.ident, tp.default.as_ref().map(|(_, ty)| ty)))
         .collect()
 }
 
@@ -228,6 +228,7 @@ pub(crate) fn generic_bounds<'a>(generics: &'a syn::Generics) -> Vec<Cow<'a, syn
             if !type_param.bounds.is_empty() {
                 let ident = &type_param.ident;
                 let predicate = syn::WherePredicate::Type(syn::PredicateType {
+                    attrs: Vec::new(),
                     lifetimes: None,
                     bounded_ty: syn::parse_quote!(#ident),
                     colon_token: syn::Token![:](proc_macro2::Span::call_site()),
@@ -570,7 +571,7 @@ fn type_is_constraining(ty: &syn::Type, generic_names: &[&Ident]) -> bool {
                         // `Fn(T) -> U` sugar: function-pointer-like,
                         // non-constraining.
                         for input in &p.inputs {
-                            if type_mentions_any(input, generic_names) {
+                            if type_mentions_any(&input.ty, generic_names) {
                                 return false;
                             }
                         }
@@ -1126,7 +1127,11 @@ mod tests {
     fn args_are_constraining(ty_src: &str, params: &[&str]) -> bool {
         let ty: syn::Type = syn::parse_str(ty_src).expect("valid type");
         let path = match ty {
-            syn::Type::Path(syn::TypePath { qself: None, path }) => path,
+            syn::Type::Path(syn::TypePath {
+                attrs: _,
+                qself: None,
+                path,
+            }) => path,
             _ => panic!("test helper expects a bare path type"),
         };
         let seg = path.segments.last().expect("at least one segment");

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -993,6 +993,7 @@ impl<'a>
 
             let class_name = match class_ty {
                 syn::Type::Path(syn::TypePath {
+                    attrs: _,
                     qself: None,
                     ref path,
                 }) => path,
@@ -1015,6 +1016,7 @@ impl<'a>
                 .unwrap_or_else(|| cls.unraw().to_string());
 
             let ty = syn::Type::Path(syn::TypePath {
+                attrs: Vec::new(),
                 qself: None,
                 path: syn::Path {
                     leading_colon: None,
@@ -1039,6 +1041,7 @@ impl<'a>
             };
             let class_name = match get_ty(class) {
                 syn::Type::Path(syn::TypePath {
+                    attrs: _,
                     qself: None,
                     ref path,
                 }) => path,
@@ -1306,7 +1309,7 @@ impl ConvertToAst<(&ast::Program, BindgenAttrs)> for syn::ForeignItemType {
             if param.default.is_none() {
                 let generics = generics.get_or_insert_with(|| self.generics.clone());
                 let type_param_mut = generics.type_params_mut().nth(n).unwrap();
-                type_param_mut.default = Some(syn::parse_quote! { JsValue });
+                type_param_mut.default = Some((Default::default(), syn::parse_quote! { JsValue }));
             }
         }
 
@@ -1493,18 +1496,27 @@ impl ConvertToAst<(BindgenAttrs, Vec<FnArgAttrs>)> for syn::ItemFn {
 fn get_self_method(r: syn::Receiver) -> ast::MethodSelf {
     // The tricky part here is that `r` can have many forms. E.g. `self`,
     // `&self`, `&mut self`, `self: Self`, `self: &Self`, `self: &mut Self`,
-    // `self: Box<Self>`, `self: Rc<Self>`, etc.
-    // Luckily, syn always populates the `ty` field with the type of `self`, so
-    // e.g. `&self` gets the type `&Self`. So we only have check whether the
-    // type is a reference or not.
-    match &*r.ty {
-        syn::Type::Reference(ty) => {
-            if ty.mutability.is_some() {
+    // `self: Box<Self>`, `self: Rc<Self>`, etc. The shorthand forms are
+    // covered by `ReceiverKind::Value`/`ReceiverKind::Reference`; for the
+    // `self: Ty` forms we check whether the explicit type is a reference.
+    match &r.kind {
+        syn::ReceiverKind::Reference(_, _, mutability) => {
+            if mutability.is_some() {
                 ast::MethodSelf::RefMutable
             } else {
                 ast::MethodSelf::RefShared
             }
         }
+        syn::ReceiverKind::Typed(_, ty) => match &**ty {
+            syn::Type::Reference(ty) => {
+                if ty.mutability.is_some() {
+                    ast::MethodSelf::RefMutable
+                } else {
+                    ast::MethodSelf::RefShared
+                }
+            }
+            _ => ast::MethodSelf::ByValue,
+        },
         _ => ast::MethodSelf::ByValue,
     }
 }
@@ -1686,7 +1698,7 @@ fn function_from_decl(
             name,
             rust_attrs: attrs,
             rust_vis: vis,
-            r#unsafe: sig.unsafety.is_some(),
+            r#unsafe: matches!(sig.safety, syn::Safety::Unsafe(_)),
             r#async: sig.asyncness.is_some(),
             jspi: opts.jspi().is_some(),
             generate_typescript: opts.skip_typescript().is_none(),
@@ -2037,9 +2049,9 @@ impl<'a> MacroParse<(Option<BindgenAttrs>, &'a mut TokenStream)> for syn::Item {
 
 impl MacroParse<BindgenAttrs> for &mut syn::ItemImpl {
     fn macro_parse(self, program: &mut ast::Program, opts: BindgenAttrs) -> Result<(), Diagnostic> {
-        if self.defaultness.is_some() {
+        if self.modifiers.defaultness.is_some() {
             bail_span!(
-                self.defaultness,
+                self.modifiers.defaultness,
                 "#[wasm_bindgen] default impls are not supported"
             );
         }
@@ -2049,7 +2061,7 @@ impl MacroParse<BindgenAttrs> for &mut syn::ItemImpl {
                 "#[wasm_bindgen] unsafe impls are not supported"
             );
         }
-        if let Some((_, path, _)) = &self.trait_ {
+        if let Some((path, _)) = &self.trait_ {
             bail_span!(path, "#[wasm_bindgen] trait impls are not supported");
         }
         if !self.generics.params.is_empty() {
@@ -2060,6 +2072,7 @@ impl MacroParse<BindgenAttrs> for &mut syn::ItemImpl {
         }
         let name = match get_ty(&self.self_ty) {
             syn::Type::Path(syn::TypePath {
+                attrs: _,
                 qself: None,
                 ref path,
             }) => path,
@@ -2203,7 +2216,7 @@ impl MacroParse<&ClassMarker> for &mut syn::ImplItemFn {
             syn::Visibility::Public(_) => {}
             _ => return Ok(()),
         }
-        if self.defaultness.is_some() {
+        if self.modifiers.defaultness.is_some() {
             panic!("default methods are not supported");
         }
         if self.sig.constness.is_some() {
@@ -2972,6 +2985,7 @@ fn extract_first_ty_param(ty: Option<&syn::Type>) -> Result<Option<syn::Type>, D
     };
     let path = match *get_ty(t) {
         syn::Type::Path(syn::TypePath {
+            attrs: _,
             qself: None,
             ref path,
         }) => path,
@@ -3116,7 +3130,7 @@ fn validate_generic_type_param_bound(bound: &syn::TypeParamBound) -> Result<(), 
     match bound {
         syn::TypeParamBound::Trait(trait_bound) => {
             // Higher-ranked trait bounds (for<'a>) are now supported
-            if let syn::TraitBoundModifier::Maybe(question) = trait_bound.modifier {
+            if let Some(question) = &trait_bound.maybe {
                 bail_generic_unsupported(question)?;
             }
         }

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", default-features = false, features = [
+syn = { version = "3.0", default-features = false, features = [
   "parsing",
   "proc-macro",
   "derive",

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -16,7 +16,7 @@ once_cell = "1.12"
 proc-macro2 = "1.0"
 quote = '1.0'
 sourcefile = "0.2"
-syn = { version = '2.0', features = ['extra-traits', 'full'] }
+syn = { version = '3.0', features = ['extra-traits', 'full'] }
 weedle = "0.13.1"
 
 [lints]

--- a/crates/webidl/src/traverse.rs
+++ b/crates/webidl/src/traverse.rs
@@ -13,7 +13,7 @@ impl TraverseType for Type {
     {
         match self {
             Type::Array(x) => x.traverse_type(f),
-            Type::BareFn(x) => x.traverse_type(f),
+            Type::FnPtr(x) => x.traverse_type(f),
             Type::Group(x) => x.traverse_type(f),
             Type::Paren(x) => x.traverse_type(f),
             Type::Path(x) => x.traverse_type(f),
@@ -35,7 +35,7 @@ impl TraverseType for syn::TypeArray {
     }
 }
 
-impl TraverseType for syn::TypeBareFn {
+impl TraverseType for syn::TypeFnPtr {
     fn traverse_type<F>(&self, f: &mut F)
     where
         F: FnMut(&Ident),
@@ -156,8 +156,8 @@ impl TraverseType for syn::ParenthesizedGenericArguments {
     where
         F: FnMut(&Ident),
     {
-        for ty in self.inputs.iter() {
-            ty.traverse_type(f);
+        for arg in self.inputs.iter() {
+            arg.ty.traverse_type(f);
         }
 
         self.output.traverse_type(f);

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -48,7 +48,8 @@ where
 
 /// Take a type and create an immutable shared reference to that type.
 pub(crate) fn shared_ref(ty: syn::Type, mutable: bool) -> syn::Type {
-    syn::TypeReference {
+    syn::Type::Reference(syn::TypeReference {
+        attrs: Vec::new(),
         and_token: Default::default(),
         lifetime: None,
         mutability: if mutable {
@@ -57,8 +58,7 @@ pub(crate) fn shared_ref(ty: syn::Type, mutable: bool) -> syn::Type {
             None
         },
         elem: Box::new(ty),
-    }
-    .into()
+    })
 }
 
 /// Fix case of identifiers like `HTMLBRElement` or `texImage2D`
@@ -169,11 +169,11 @@ pub fn webidl_const_v_to_backend_const_v(v: &ConstValueLit) -> ConstValue {
 
 /// From `T` create `[T]`.
 pub(crate) fn slice_ty(t: syn::Type) -> syn::Type {
-    syn::TypeSlice {
+    syn::Type::Slice(syn::TypeSlice {
+        attrs: Vec::new(),
         bracket_token: Default::default(),
         elem: Box::new(t),
-    }
-    .into()
+    })
 }
 
 /// From `T` create `alloc::Vec<T>`.
@@ -195,8 +195,11 @@ pub(crate) fn vec_ty(t: syn::Type) -> syn::Type {
         ident: raw_ident("Vec"),
         arguments,
     });
-    let ty = syn::TypePath { qself: None, path };
-    ty.into()
+    syn::Type::Path(syn::TypePath {
+        attrs: Vec::new(),
+        qself: None,
+        path,
+    })
 }
 
 /// From `T` create `Option<T>`
@@ -211,8 +214,11 @@ pub(crate) fn option_ty(t: syn::Type) -> syn::Type {
     let ident = raw_ident("Option");
     let seg = syn::PathSegment { ident, arguments };
     let path: syn::Path = seg.into();
-    let ty = syn::TypePath { qself: None, path };
-    ty.into()
+    syn::Type::Path(syn::TypePath {
+        attrs: Vec::new(),
+        qself: None,
+        path,
+    })
 }
 
 /// From `T` create `::js_sys::JsNullable<T>`
@@ -233,8 +239,11 @@ pub(crate) fn js_nullable_ty(t: syn::Type) -> syn::Type {
         leading_colon: Some(Default::default()),
         segments: FromIterator::from_iter(vec![syn::PathSegment::from(raw_ident("js_sys")), seg]),
     };
-    let ty = syn::TypePath { qself: None, path };
-    ty.into()
+    syn::Type::Path(syn::TypePath {
+        attrs: Vec::new(),
+        qself: None,
+        path,
+    })
 }
 
 /// Check if a type is `::wasm_bindgen::JsValue`
@@ -274,7 +283,11 @@ pub(crate) fn generic_ty(base: syn::Type, type_arg: syn::Type) -> syn::Type {
             });
     }
 
-    syn::Type::Path(syn::TypePath { qself: None, path })
+    syn::Type::Path(syn::TypePath {
+        attrs: Vec::new(),
+        qself: None,
+        path,
+    })
 }
 
 /// Direction of data flow across the JS/Wasm boundary.

--- a/crates/webidl/src/wbg_type.rs
+++ b/crates/webidl/src/wbg_type.rs
@@ -1589,7 +1589,8 @@ fn clamped(t: syn::Type) -> syn::Type {
 
     let ident = raw_ident("Clamped");
     let seg = syn::PathSegment { ident, arguments };
-    syn::TypePath {
+    syn::Type::Path(syn::TypePath {
+        attrs: Vec::new(),
         qself: None,
         path: syn::Path {
             leading_colon: Some(Default::default()),
@@ -1597,6 +1598,5 @@ fn clamped(t: syn::Type) -> syn::Type {
                 .into_iter()
                 .collect(),
         },
-    }
-    .into()
+    })
 }


### PR DESCRIPTION
### Description

Ports `macro-support` and `webidl` to the syn 3 API (`test-macro` needed no code change). Motivation and context in #5296 : the plain requirement bumps (#5232, #5240) could not compile because syn 3 reshaped parts of the syntax tree.

API changes covered:

- Add the new `attrs` field to type-node patterns (ignored) and constructors (empty), and replace the removed `From<TypeX> for Type` impls with explicit `syn::Type::X(...)` wrapping.
- Read `defaultness` from the new `modifiers` bags on `ItemImpl` and `ImplItemFn`; adjust `ItemImpl::trait_` to its new 2-tuple shape (the `!` polarity moved into `modifiers`; trait impls are rejected here anyway).
- Replace `Signature::unsafety` with `Signature::safety` matching (the new `safe fn` classifies as not unsafe, like the previous absence of `unsafe`).
- Rewrite `get_self_method` on top of `ReceiverKind`, since `Receiver` lost its always-populated `ty` field: `&self`/`&mut self` come from `ReceiverKind::Reference`, and the `self: Ty` forms are classified by inspecting the explicit type, as before.
- Detect `?Sized` via `TraitBound::maybe` (`TraitBoundModifier` is gone).
- Follow the `Type::BareFn` -> `Type::FnPtr` rename, and the `Punctuated<Type>` -> `Punctuated<NamedArg>` change in fn-pointer and parenthesized generic arguments.
- `TypeParam::default` now carries its `=` token as `Option<(Eq, Type)>`.

Validation:

- Unit tests pass; clippy is clean on native and Wasm targets.
- Regenerating web-sys with the ported webidl produces byte-identical output.
- The trybuild UI snapshots are unchanged relative to the syn 2 baseline on the same toolchain.
- Full CI matrix ran green on my fork (51 jobs): https://github.com/Crovitche-1623/wasm-bindgen/actions/runs/32736522633 (the Coverage job failure there is the Codecov upload only, which cannot work from a fork).

Closes #5296

### Checklist

- [x] Verified changelog requirement