### PR TITLE
fix: Incorrect generic bounds suggestion by rustc

### DIFF
--- a/crates/macro-support/src/generics.rs
+++ b/crates/macro-support/src/generics.rs
@@ -78,6 +78,24 @@ impl<'a, 'b> GenericNameVisitor<'a, 'b> {
             found_set,
         }
     }
+
+    fn generic_param(&self, ident: &Ident) -> Option<&Ident> {
+        self.generic_params
+            .iter()
+            .copied()
+            .find(|param| *param == ident)
+    }
+
+    fn record_generic_param(&mut self, ident: &Ident) -> bool {
+        let Some(param) = self.generic_param(ident).cloned() else {
+            return false;
+        };
+        // Keep the declaration's span when this identifier is later emitted as
+        // a generated generic parameter, so rustc suggestions target the
+        // declaration rather than an occurrence in a type argument.
+        self.found_set.insert(param);
+        true
+    }
 }
 
 impl<'a, 'b> Visit<'a> for GenericNameVisitor<'a, 'b> {
@@ -95,14 +113,11 @@ impl<'a, 'b> Visit<'a> for GenericNameVisitor<'a, 'b> {
 
             if let Some(first_segment) = type_path.path.segments.first() {
                 if type_path.path.segments.len() == 1 && first_segment.arguments.is_empty() {
-                    if self.generic_params.contains(&&first_segment.ident) {
-                        self.found_set.insert(first_segment.ident.clone());
+                    if self.record_generic_param(&first_segment.ident) {
                         return;
                     }
                 } else {
-                    if self.generic_params.contains(&&first_segment.ident) {
-                        self.found_set.insert(first_segment.ident.clone());
-                    }
+                    self.record_generic_param(&first_segment.ident);
 
                     syn::visit::visit_path_arguments(self, &first_segment.arguments);
 
@@ -120,9 +135,7 @@ impl<'a, 'b> Visit<'a> for GenericNameVisitor<'a, 'b> {
 
     fn visit_path(&mut self, path: &'a syn::Path) {
         if let Some(first_segment) = path.segments.first() {
-            if self.generic_params.contains(&&first_segment.ident) {
-                self.found_set.insert(first_segment.ident.clone());
-            }
+            self.record_generic_param(&first_segment.ident);
         }
 
         for segment in &path.segments {

--- a/crates/macro/ui-tests/generic-method-bound-suggestion.rs
+++ b/crates/macro/ui-tests/generic-method-bound-suggestion.rs
@@ -1,0 +1,14 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    pub type Foo<T: Clone>;
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(method)]
+    pub fn value<T>(this: &Foo<T>);
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/generic-method-bound-suggestion.stderr
+++ b/crates/macro/ui-tests/generic-method-bound-suggestion.stderr
@@ -1,16 +1,16 @@
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> ui-tests/generic-method-bound-suggestion.rs:8:1
-   |
- 8 | #[wasm_bindgen]
-   | ^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
-   |
+ --> ui-tests/generic-method-bound-suggestion.rs:8:1
+  |
+8 | #[wasm_bindgen]
+  | ^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
+  |
 note: required by a bound in `Foo`
-  --> ui-tests/generic-method-bound-suggestion.rs:5:21
-   |
- 5 |     pub type Foo<T: Clone>;
-   |                     ^^^^^ required by this bound in `Foo`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> ui-tests/generic-method-bound-suggestion.rs:5:21
+  |
+5 |     pub type Foo<T: Clone>;
+  |                     ^^^^^ required by this bound in `Foo`
+  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Clone`
-   |
-11 |     pub fn value<T: std::clone::Clone>(this: &Foo<T>);
-   |                   +++++++++++++++++++
+  |
+11|     pub fn value<T: std::clone::Clone>(this: &Foo<T>);
+  |                   +++++++++++++++++++

--- a/crates/macro/ui-tests/generic-method-bound-suggestion.stderr
+++ b/crates/macro/ui-tests/generic-method-bound-suggestion.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the trait bound `T: Clone` is not satisfied
+  --> ui-tests/generic-method-bound-suggestion.rs:8:1
+   |
+ 8 | #[wasm_bindgen]
+   | ^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
+   |
+note: required by a bound in `Foo`
+  --> ui-tests/generic-method-bound-suggestion.rs:5:21
+   |
+ 5 |     pub type Foo<T: Clone>;
+   |                     ^^^^^ required by this bound in `Foo`
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T` with trait `Clone`
+   |
+11 |     pub fn value<T: std::clone::Clone>(this: &Foo<T>);
+   |                   +++++++++++++++++++


### PR DESCRIPTION
### Description
This code fails to compile because the `Clone` trait bound is not met:

```rust
#[wasm_bindgen]
extern "C" {
    pub type Foo<T: Clone>;
}

#[wasm_bindgen]
extern "C" {
    #[wasm_bindgen(method)]
    pub fn value<T>(this: &Foo<T>);
}
```

however, the compiler suggested quick fix is wrong:

```
 --> src/lib.rs:8:1
   |
 8 | #[wasm_bindgen]
   | ^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
   |
note: required by a bound in `Foo`
  --> src/lib.rs:5:21
   |
 5 |     pub type Foo<T: Clone>;
   |                     ^^^^^ required by this bound in `Foo`
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider restricting type parameter `T` with trait `Clone`
   |
11 |     pub fn value<T>(this: &Foo<T: std::clone::Clone>);
   |                                +++++++++++++++++++
```

This suggestion is wrong, the bound belongs on `value<T: Clone>`

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
