### PR TITLE
Fix cross-crate private type descriptor resolution

### DIFF
--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -252,6 +252,10 @@ impl Descriptor {
             | Descriptor::Vector(d)
             | Descriptor::Option(d)
             | Descriptor::Result(d) => d.visit_named_types_mut(f),
+            // An externref has no defining crate, so a JS type whose name
+            // matches an ambiguous all-`private` struct/enum name still hits
+            // the ambiguity check even though it never refers to the Rust
+            // type.
             Descriptor::NamedExternref(name) => f(name, None),
             Descriptor::Enum {
                 name,

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -61,6 +61,7 @@ pub enum Descriptor {
     Enum {
         name: String,
         hole: u32,
+        unique_crate_identifier: String,
     },
     StringEnum {
         name: String,
@@ -71,7 +72,10 @@ pub enum Descriptor {
         name: String,
         variant_types: Vec<Descriptor>,
     },
-    RustStruct(String),
+    RustStruct {
+        name: String,
+        unique_crate_identifier: String,
+    },
     Char,
     Option(Box<Descriptor>),
     Result(Box<Descriptor>),
@@ -180,7 +184,12 @@ impl Descriptor {
             ENUM => {
                 let name = get_string(data);
                 let hole = get(data);
-                Descriptor::Enum { name, hole }
+                let unique_crate_identifier = get_string(data);
+                Descriptor::Enum {
+                    name,
+                    hole,
+                    unique_crate_identifier,
+                }
             }
             STRING_ENUM => {
                 let name = get_string(data);
@@ -207,7 +216,11 @@ impl Descriptor {
             }
             RUST_STRUCT => {
                 let name = get_string(data);
-                Descriptor::RustStruct(name)
+                let unique_crate_identifier = get_string(data);
+                Descriptor::RustStruct {
+                    name,
+                    unique_crate_identifier,
+                }
             }
             NAMED_EXTERNREF => {
                 let name = get_string(data);
@@ -224,10 +237,11 @@ impl Descriptor {
 
     /// Visit every struct/enum/externref type name embedded in this
     /// descriptor tree, so callers can rewrite names to their final JS
-    /// identities (see `Context::resolve_descriptor` in `wit`).
+    /// identities (see `Context::resolve_descriptor` in `wit`). Rust types
+    /// include their defining crate identifier; named externrefs do not.
     pub fn visit_named_types_mut<E>(
         &mut self,
-        f: &mut impl FnMut(&mut String) -> Result<(), E>,
+        f: &mut impl FnMut(&mut String, Option<&str>) -> Result<(), E>,
     ) -> Result<(), E> {
         match self {
             Descriptor::Function(function) => function.visit_named_types_mut(f),
@@ -238,9 +252,16 @@ impl Descriptor {
             | Descriptor::Vector(d)
             | Descriptor::Option(d)
             | Descriptor::Result(d) => d.visit_named_types_mut(f),
-            Descriptor::NamedExternref(name)
-            | Descriptor::Enum { name, .. }
-            | Descriptor::RustStruct(name) => f(name),
+            Descriptor::NamedExternref(name) => f(name, None),
+            Descriptor::Enum {
+                name,
+                unique_crate_identifier,
+                ..
+            }
+            | Descriptor::RustStruct {
+                name,
+                unique_crate_identifier,
+            } => f(name, Some(unique_crate_identifier)),
             Descriptor::DynamicUnion { variant_types, .. } => {
                 for d in variant_types {
                     d.visit_named_types_mut(f)?;
@@ -337,7 +358,7 @@ impl Function {
     /// See [`Descriptor::visit_named_types_mut`].
     pub fn visit_named_types_mut<E>(
         &mut self,
-        f: &mut impl FnMut(&mut String) -> Result<(), E>,
+        f: &mut impl FnMut(&mut String, Option<&str>) -> Result<(), E>,
     ) -> Result<(), E> {
         for d in &mut self.arguments {
             d.visit_named_types_mut(f)?;

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -70,7 +70,7 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32]
                 )
             }
-            Descriptor::RustStruct(class) => {
+            Descriptor::RustStruct { name: class, .. } => {
                 let ptr_ty = if self.cx.memory64() {
                     AdapterType::F64
                 } else {
@@ -216,7 +216,7 @@ impl InstructionBuilder<'_, '_> {
 
     fn incoming_ref(&mut self, mutable: bool, arg: &Descriptor) -> Result<(), Error> {
         match arg {
-            Descriptor::RustStruct(class) => {
+            Descriptor::RustStruct { name: class, .. } => {
                 let ptr_ty = if self.cx.memory64() {
                     AdapterType::F64
                 } else {
@@ -372,7 +372,7 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                 );
             }
-            Descriptor::Enum { name, hole } => {
+            Descriptor::Enum { name, hole, .. } => {
                 self.instruction(
                     &[AdapterType::Enum(name.clone()).option()],
                     Instruction::I32FromOptionEnum { hole: *hole },
@@ -394,7 +394,7 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                 );
             }
-            Descriptor::RustStruct(name) => {
+            Descriptor::RustStruct { name, .. } => {
                 let ptr_ty = if self.cx.memory64() {
                     AdapterType::F64
                 } else {

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -510,9 +510,11 @@ impl<'a> Context<'a> {
                          function signature; this is a wasm-bindgen bug, please report it"
                     ),
                 };
-                // No defining crate context here (monomorphisations are
-                // discovered globally), so this only rejects references to
-                // ambiguous all-`private` names.
+                // Struct/enum references carry their defining crate in the
+                // descriptor, so they resolve here even though
+                // monomorphisations are discovered globally; only
+                // `NamedExternref` references can still hit the ambiguity
+                // check.
                 self.resolve_descriptor_function(&mut signature)?;
                 let sig_comment = match &key {
                     GenericImportKey::Cast => {
@@ -2104,6 +2106,10 @@ impl<'a> Context<'a> {
                     bare,
                 );
                 let parent_qualified = parent.clone();
+                // The macro only records the parent's JS name, not its
+                // defining crate, so this resolves against the current
+                // program's crate: a cross-crate `extends` of a renamed
+                // `private` parent is not covered by the descriptor fix.
                 self.resolve_item_ref(&mut parent, None)
                     .with_context(|| format!("resolving the parent class of `{qualified_name}`"))?;
                 let upcast = self.mangled(&wasm_bindgen_shared::upcast_function(

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -888,14 +888,19 @@ impl<'a> Context<'a> {
             .unwrap_or_else(|| qualified.to_string())
     }
 
-    /// Final JS identity of a struct/enum referenced by name, possibly from
-    /// outside its defining crate. Same-crate references resolve through the
-    /// identity map; anything else must have an unambiguous canonical owner.
-    fn resolve_item_ref(&self, qualified: &mut String) -> Result<(), Error> {
-        if let Some(identity) = self.item_identities.get(&(
-            self.unique_crate_identifier.to_string(),
-            qualified.to_string(),
-        )) {
+    /// Final JS identity of a struct/enum referenced by name. Rust type
+    /// descriptors carry their defining crate; other named descriptors use
+    /// the current program's crate.
+    fn resolve_item_ref(
+        &self,
+        qualified: &mut String,
+        defining_crate: Option<&str>,
+    ) -> Result<(), Error> {
+        let defining_crate = defining_crate.unwrap_or(self.unique_crate_identifier);
+        if let Some(identity) = self
+            .item_identities
+            .get(&(defining_crate.to_string(), qualified.to_string()))
+        {
             *qualified = identity.clone();
         } else if self.ambiguous_items.contains(qualified.as_str()) {
             bail!(
@@ -909,12 +914,16 @@ impl<'a> Context<'a> {
     /// Rewrite struct/enum names embedded in a descriptor to their final JS
     /// identities as seen from the current program's crate.
     fn resolve_descriptor(&self, descriptor: &mut Descriptor) -> Result<(), Error> {
-        descriptor.visit_named_types_mut(&mut |name| self.resolve_item_ref(name))
+        descriptor.visit_named_types_mut(&mut |name, defining_crate| {
+            self.resolve_item_ref(name, defining_crate)
+        })
     }
 
     /// See [`Context::resolve_descriptor`].
     fn resolve_descriptor_function(&self, function: &mut Function) -> Result<(), Error> {
-        function.visit_named_types_mut(&mut |name| self.resolve_item_ref(name))
+        function.visit_named_types_mut(&mut |name, defining_crate| {
+            self.resolve_item_ref(name, defining_crate)
+        })
     }
 
     /// The macro emits every export shim under a crate-hash mangled symbol so
@@ -2095,7 +2104,7 @@ impl<'a> Context<'a> {
                     bare,
                 );
                 let parent_qualified = parent.clone();
-                self.resolve_item_ref(&mut parent)
+                self.resolve_item_ref(&mut parent, None)
                     .with_context(|| format!("resolving the parent class of `{qualified_name}`"))?;
                 let upcast = self.mangled(&wasm_bindgen_shared::upcast_function(
                     &qualified_name,

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -119,7 +119,7 @@ impl InstructionBuilder<'_, '_> {
                 );
             }
 
-            Descriptor::RustStruct(class) => {
+            Descriptor::RustStruct { name: class, .. } => {
                 let ptr_ty = if self.cx.memory64() {
                     AdapterType::F64
                 } else {
@@ -452,7 +452,7 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::String.option()],
                 );
             }
-            Descriptor::Enum { name, hole } => {
+            Descriptor::Enum { name, hole, .. } => {
                 self.instruction(
                     &[AdapterType::I32],
                     Instruction::OptionEnumFromI32 { hole: *hole },
@@ -466,7 +466,7 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::StringEnum(name.clone()).option()],
                 );
             }
-            Descriptor::RustStruct(name) => {
+            Descriptor::RustStruct { name, .. } => {
                 let ptr_ty = if self.cx.memory64() {
                     AdapterType::F64
                 } else {
@@ -551,7 +551,7 @@ impl InstructionBuilder<'_, '_> {
             | Descriptor::Enum { .. }
             | Descriptor::StringEnum { .. }
             | Descriptor::DynamicUnion { .. }
-            | Descriptor::RustStruct(_)
+            | Descriptor::RustStruct { .. }
             | Descriptor::Ref(_)
             | Descriptor::RefMut(_)
             | Descriptor::CachedString

--- a/crates/cli/tests/wasm-bindgen/diagnostics.rs
+++ b/crates/cli/tests/wasm-bindgen/diagnostics.rs
@@ -351,6 +351,87 @@ fn duplicate_public_class_across_crates_errors() {
     assert_contains!(&err, "#[wasm_bindgen(private)]");
 }
 
+#[test]
+fn external_private_type_ref_binds_to_public_collision() {
+    let out_dir = Project::new("external_private_type_ref_binds_to_public_collision")
+        .file("public-widget/Cargo.toml", &dep_crate_toml("public-widget"))
+        .file(
+            "public-widget/src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen]
+                pub struct Widget { pub public_value: u32 }
+
+                #[wasm_bindgen]
+                pub enum Mode { Public = 1 }
+
+                pub fn make() -> Widget { Widget { public_value: 1 } }
+                pub fn mode() -> Mode { Mode::Public }
+            "#,
+        )
+        .file(
+            "private-widget/Cargo.toml",
+            &dep_crate_toml("private-widget"),
+        )
+        .file(
+            "private-widget/src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen(private)]
+                pub struct Widget { pub private_value: u32 }
+
+                #[wasm_bindgen(private)]
+                pub enum Mode { Private = 2 }
+
+                pub fn make() -> Widget { Widget { private_value: 2 } }
+                pub fn mode() -> Mode { Mode::Private }
+            "#,
+        )
+        .dep("public-widget = { path = 'public-widget' }")
+        .dep("private-widget = { path = 'private-widget' }")
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen]
+                pub fn make_public_widget() -> public_widget::Widget {
+                    public_widget::make()
+                }
+
+                #[wasm_bindgen]
+                pub fn make_private_widget() -> private_widget::Widget {
+                    private_widget::make()
+                }
+
+                #[wasm_bindgen]
+                pub fn public_mode() -> public_widget::Mode {
+                    public_widget::mode()
+                }
+
+                #[wasm_bindgen]
+                pub fn private_mode() -> private_widget::Mode {
+                    private_widget::mode()
+                }
+            "#,
+        )
+        .wasm_bindgen("--target web")
+        .unwrap();
+    let js =
+        fs::read_to_string(out_dir.join("external_private_type_ref_binds_to_public_collision.js"))
+            .unwrap();
+    let dts = fs::read_to_string(
+        out_dir.join("external_private_type_ref_binds_to_public_collision.d.ts"),
+    )
+    .unwrap();
+
+    assert_contains!(&js, "return Widget2.__wrap(ret);");
+    assert_contains!(&dts, "export function make_private_widget(): Widget2;");
+    assert_contains!(&dts, "export function private_mode(): Mode2;");
+}
+
 /// Functions have no `private` form, so the collision is caught when the
 /// second export's canonical name is restored.
 #[test]

--- a/crates/cli/tests/wasm-bindgen/diagnostics.rs
+++ b/crates/cli/tests/wasm-bindgen/diagnostics.rs
@@ -430,6 +430,87 @@ fn external_private_type_ref_binds_to_public_collision() {
     assert_contains!(&js, "return Widget2.__wrap(ret);");
     assert_contains!(&dts, "export function make_private_widget(): Widget2;");
     assert_contains!(&dts, "export function private_mode(): Mode2;");
+    assert_contains!(&dts, "export function make_public_widget(): Widget;");
+    assert_contains!(&dts, "export function public_mode(): Mode;");
+}
+
+/// When every colliding definition is `private`, references from outside the
+/// defining crates used to hit the ambiguity error; with the defining crate
+/// embedded in type descriptors they now resolve to the numbered identities.
+#[test]
+fn external_all_private_type_collision_resolves() {
+    let out_dir = Project::new("external_all_private_type_collision_resolves")
+        .file("widget-a/Cargo.toml", &dep_crate_toml("widget-a"))
+        .file(
+            "widget-a/src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen(private)]
+                pub struct Widget { pub a_value: u32 }
+
+                #[wasm_bindgen(private)]
+                pub enum Mode { A = 1 }
+
+                pub fn make() -> Widget { Widget { a_value: 1 } }
+                pub fn mode() -> Mode { Mode::A }
+            "#,
+        )
+        .file("widget-b/Cargo.toml", &dep_crate_toml("widget-b"))
+        .file(
+            "widget-b/src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen(private)]
+                pub struct Widget { pub b_value: u32 }
+
+                #[wasm_bindgen(private)]
+                pub enum Mode { B = 2 }
+
+                pub fn make() -> Widget { Widget { b_value: 2 } }
+                pub fn mode() -> Mode { Mode::B }
+            "#,
+        )
+        .dep("widget-a = { path = 'widget-a' }")
+        .dep("widget-b = { path = 'widget-b' }")
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen]
+                pub fn make_a_widget() -> widget_a::Widget {
+                    widget_a::make()
+                }
+
+                #[wasm_bindgen]
+                pub fn make_b_widget() -> widget_b::Widget {
+                    widget_b::make()
+                }
+
+                #[wasm_bindgen]
+                pub fn a_mode() -> widget_a::Mode {
+                    widget_a::mode()
+                }
+
+                #[wasm_bindgen]
+                pub fn b_mode() -> widget_b::Mode {
+                    widget_b::mode()
+                }
+            "#,
+        )
+        .wasm_bindgen("--target web")
+        .unwrap();
+    let dts = fs::read_to_string(out_dir.join("external_all_private_type_collision_resolves.d.ts"))
+        .unwrap();
+
+    // Identity assignment orders definitions by unique crate identifier, so
+    // `widget-a` keeps the canonical names and `widget-b` gets numbered ones.
+    assert_contains!(&dts, "export function make_a_widget(): Widget;");
+    assert_contains!(&dts, "export function make_b_widget(): Widget2;");
+    assert_contains!(&dts, "export function a_mode(): Mode;");
+    assert_contains!(&dts, "export function b_mode(): Mode2;");
 }
 
 /// Functions have no `private` form, so the collision is caught when the

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -222,6 +222,9 @@ impl ToTokens for ast::Struct {
         let name_str = self.qualified_name.to_string();
         let name_len = name_str.chars().count() as u32;
         let name_chars: Vec<u32> = name_str.chars().map(|c| c as u32).collect();
+        let unique_crate_identifier = crate::hash::unique_crate_identifier();
+        let unique_crate_identifier_len = unique_crate_identifier.chars().count() as u32;
+        let unique_crate_identifier_chars = unique_crate_identifier.chars().map(|c| c as u32);
         // The Rust idents stay canonical so rustc diagnostics read cleanly;
         // only the wasm symbols carry the per-crate hash.
         let new_fn = Ident::new(&shared::new_function(&name_str), Span::call_site());
@@ -250,6 +253,8 @@ impl ToTokens for ast::Struct {
                     inform(RUST_STRUCT);
                     inform(#name_len);
                     #(inform(#name_chars);)*
+                    inform(#unique_crate_identifier_len);
+                    #(inform(#unique_crate_identifier_chars);)*
                 }
             }
 
@@ -3817,6 +3822,9 @@ impl ToTokens for ast::Enum {
         let name_str = shared::qualified_name(self.js_namespace.as_deref(), &self.js_name);
         let name_len = name_str.chars().count() as u32;
         let name_chars = name_str.chars().map(|c| c as u32);
+        let unique_crate_identifier = crate::hash::unique_crate_identifier();
+        let unique_crate_identifier_len = unique_crate_identifier.chars().count() as u32;
+        let unique_crate_identifier_chars = unique_crate_identifier.chars().map(|c| c as u32);
         let hole = &self.hole;
         let underlying = if self.signed {
             quote! { i32 }
@@ -3876,6 +3884,8 @@ impl ToTokens for ast::Enum {
                     inform(#name_len);
                     #(inform(#name_chars);)*
                     inform(#hole);
+                    inform(#unique_crate_identifier_len);
+                    #(inform(#unique_crate_identifier_chars);)*
                 }
             }
 

--- a/crates/macro-support/src/encode.rs
+++ b/crates/macro-support/src/encode.rs
@@ -1,4 +1,3 @@
-use crate::hash::ShortHash;
 use proc_macro2::{Ident, Span};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -44,7 +43,6 @@ struct Interner {
     bump: bumpalo::Bump,
     files: RefCell<HashMap<String, LocalFile>>,
     root: PathBuf,
-    crate_name: String,
     has_package_json: Cell<bool>,
 }
 
@@ -60,12 +58,10 @@ impl Interner {
         let root = env::var_os("CARGO_MANIFEST_DIR")
             .expect("should have CARGO_MANIFEST_DIR env var")
             .into();
-        let crate_name = env::var("CARGO_PKG_NAME").expect("should have CARGO_PKG_NAME env var");
         Interner {
             bump: bumpalo::Bump::new(),
             files: RefCell::new(HashMap::new()),
             root,
-            crate_name,
             has_package_json: Cell::new(false),
         }
     }
@@ -121,7 +117,7 @@ impl Interner {
     }
 
     fn unique_crate_identifier(&self) -> String {
-        format!("{}-{}", self.crate_name, ShortHash(0))
+        crate::hash::unique_crate_identifier()
     }
 
     fn check_for_package_json(&self) {

--- a/crates/macro-support/src/hash.rs
+++ b/crates/macro-support/src/hash.rs
@@ -16,6 +16,14 @@ use std::sync::atomic::Ordering::SeqCst;
 #[derive(Debug)]
 pub struct ShortHash<T>(pub T);
 
+pub fn unique_crate_identifier() -> String {
+    format!(
+        "{}-{}",
+        env::var("CARGO_PKG_NAME").expect("should have CARGO_PKG_NAME env var"),
+        ShortHash(0)
+    )
+}
+
 /// Mangle an export shim symbol with the per-crate hash, matching the hash
 /// suffix of `unique_crate_identifier` so cli-support can recompute the name.
 pub fn crate_mangled_symbol(base: &str) -> String {


### PR DESCRIPTION
Similar to #5293 but for type descriptors. This prevents two types (one marked `#[wasm_bindgen(private)]` and one not) in different crates from colliding. See the regression test for an example: https://github.com/wasm-bindgen/wasm-bindgen/pull/5299/changes#diff-a2169ecc87020b51e343e4974cade0bda6762512b6d8ae0fd279cff089fb9038