### PR TITLE
Rename generic_per_mono to experimental_generic_mono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,21 @@
   info to a separate `*_bg.debug.wasm` file. Use `--debug-info-url` to set
   the recorded URL for the debug info. [#5279](https://github.com/wasm-bindgen/wasm-bindgen/pull/5279)
 
-* `generic_per_mono` imports now support argument-position `impl Trait`
-  (including nested, e.g. `Vec<impl Trait>`), which is desugared into a
-  synthesized named type parameter with the same bound; see
-  [the guide](https://wasm-bindgen.github.io/wasm-bindgen/reference/attributes/on-js-imports/generic_per_mono.html)
-  for the supported surface and the shapes that are rejected.
+* Added `#[wasm_bindgen(experimental_generic_mono)]` for imported functions,
+  which binds a generic import once per monomorphisation instead of erasing
+  its type parameters to `JsValue`. It can be applied to an individual import
+  or to a whole `extern "C"` block, which every generic function in the block
+  then inherits. Each instantiation gets its own descriptor, so arguments and
+  return values are marshalled at their concrete types (a `u32` crosses as a
+  number, a `String` as a string) rather than being boxed. Trait bounds,
+  `where` predicates (including higher-ranked ones), associated-type
+  projections, lifetime parameters, argument-position `impl Trait`, `async`,
+  `catch`, and `slice_to_array` are all supported; see
+  [the guide](https://wasm-bindgen.github.io/wasm-bindgen/reference/attributes/on-js-imports/experimental_generic_mono.html)
+  for the supported surface and the shapes that are rejected. The attribute
+  is experimental and may change as it stabilizes.
+  [#5230](https://github.com/wasm-bindgen/wasm-bindgen/pull/5230)
+  [#5272](https://github.com/wasm-bindgen/wasm-bindgen/pull/5272)
 
 * Added an experimental `--experimental-memory-discard` flag which replaces an
   `env.__wbindgen_memory_discard` function import with a local trampoline
@@ -52,18 +62,6 @@
 
 * [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API)
   to `web-sys` [#5247](https://github.com/wasm-bindgen/wasm-bindgen/pull/5247)
-
-* Added `#[wasm_bindgen(generic_per_mono)]` for imported functions, which binds a
-  generic import once per monomorphisation instead of erasing its type
-  parameters to `JsValue`. It can be applied to an individual import or to a
-  whole `extern "C"` block, which every function in the block then inherits.
-  Each instantiation gets its own descriptor, so
-  arguments and return values are marshalled at their concrete types (a `u32`
-  crosses as a number, a `String` as a string) rather than being boxed. Trait
-  bounds, `where` predicates (including higher-ranked ones), associated-type
-  projections, lifetime parameters, `async`, `catch`, and `slice_to_array` are
-  all supported; see [the guide](https://wasm-bindgen.github.io/wasm-bindgen/reference/attributes/on-js-imports/generic_per_mono.html)
-  for the supported surface and the shapes that are rejected.
 
 * Added `riscv64gc-unknown-linux-gnu` release artifacts.
   [#5265](https://github.com/wasm-bindgen/wasm-bindgen/pull/5265)

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -21,7 +21,7 @@ pub enum GenericImportKey {
     /// AST metadata: it is bound as JS that returns its single argument
     /// unchanged.
     Cast,
-    /// A `#[wasm_bindgen(generic_per_mono)]` import. The string is the shim key
+    /// A `#[wasm_bindgen(experimental_generic_mono)]` import. The string is the shim key
     /// identifying which generic-import AST entry supplies the JS binding
     /// metadata (name, kind, namespace, catch, ...).
     Shim(String),

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -2169,7 +2169,7 @@ impl Invocation {
                     *guard = ExportGuard::None;
                 }
                 // Label manufactured bindings whose name says nothing about what
-                // they bind. A `generic_per_mono` monomorphisation is emitted as
+                // they bind. A `experimental_generic_mono` monomorphisation is emitted as
                 // `__wbindgen_generic_<hash>`, so without this the glue is a wall of
                 // near-identical anonymous shims.
                 if let Some(comment) = cx.aux.import_comments.get(id) {

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -83,7 +83,7 @@ struct Context<'a> {
 /// interpreted monomorphisation.
 ///
 /// Note there is deliberately no `assert_no_shim`: the macro rejects
-/// `assert_no_shim` combined with `generic_per_mono` at parse time, so it is
+/// `assert_no_shim` combined with `experimental_generic_mono` at parse time, so it is
 /// always `false` on this path and `bind_generic_imports` passes the constant
 /// through to `finish_import_binding` (which still needs the parameter for the
 /// normal import path).
@@ -648,7 +648,7 @@ impl<'a> Context<'a> {
                         .import_comments
                         .insert(id, format!("generic import `{display}`: {mono}"));
                     // `assert_no_shim` and `suspending` are rejected in
-                    // combination with `generic_per_mono` by the macro (see
+                    // combination with `experimental_generic_mono` by the macro (see
                     // `parser.rs`), so both are always false on this path.
                     self.finish_import_binding(id, aux_import, catch, variadic, false, false);
                 }
@@ -1354,7 +1354,7 @@ impl<'a> Context<'a> {
             // reaches the CLI from an older or hand-built macro.
             if import.reexport.is_some() {
                 bail!(
-                    "#[wasm_bindgen] `generic_per_mono` imports cannot be reexported; \
+                    "#[wasm_bindgen] `experimental_generic_mono` imports cannot be reexported; \
                      remove the reexport or use the type-erasure generic path"
                 );
             }
@@ -1438,7 +1438,7 @@ impl<'a> Context<'a> {
                     if previous.identity() != meta.identity() {
                         let previous = &previous.display;
                         bail!(
-                            "two `generic_per_mono` imports collided on the shim key `{shim}`: \
+                            "two `experimental_generic_mono` imports collided on the shim key `{shim}`: \
                              `{previous}` and `{display}`.\n\
                              \n\
                              This happens when two generic imports have the same Rust function \

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -37,7 +37,7 @@ pub struct WasmBindgenAux {
     /// Comments to emit above a manufactured import's generated JS body.
     ///
     /// Bindings that wasm-bindgen synthesises rather than names after a Rust item
-    /// — currently `generic_per_mono` monomorphisations, which are emitted as
+    /// — currently `experimental_generic_mono` monomorphisations, which are emitted as
     /// `__wbindgen_generic_<hash>` — carry no hint in their name about which
     /// import or which instantiation they correspond to. Two instantiations can
     /// even have byte-identical bodies while differing in wasm signature, so the

--- a/crates/cli/tests/reference/generic-import.rs
+++ b/crates/cli/tests/reference/generic-import.rs
@@ -1,5 +1,5 @@
 // Reference output for the experimental per-monomorphisation generic import
-// path (`#[wasm_bindgen(generic_per_mono)]`). Each concrete instantiation is
+// path (`#[wasm_bindgen(experimental_generic_mono)]`). Each concrete instantiation is
 // discovered by the descriptor interpreter and bound to its own manufactured
 // `__wbindgen_generic_*` JS shim, rather than erasing type parameters to
 // `JsValue`.
@@ -10,20 +10,20 @@ use wasm_bindgen::prelude::*;
 extern "C" {
     // Free function, generic owned argument, unit return. Two instantiations
     // (`u32` and `f64`) each get their own shim with the correct marshalling.
-    #[wasm_bindgen(generic_per_mono, js_name = log)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = log)]
     fn log_generic<T>(x: T);
 
     // Generic pass-through return `-> T`.
-    #[wasm_bindgen(generic_per_mono, js_name = identity)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = identity)]
     fn identity<T>(x: T) -> T;
 
     // A concrete argument mixed with a generic one. Two instantiations exercise
     // per-mono shim manufacture for a mixed signature.
-    #[wasm_bindgen(generic_per_mono, js_name = mix)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = mix)]
     fn mix<T>(label: u32, value: T);
 
     // Multiple generic type parameters in a single import.
-    #[wasm_bindgen(generic_per_mono, js_name = pair)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = pair)]
     fn pair<T, U>(a: T, b: U);
 
     // Argument-position `impl Trait` desugars into a synthesized named type
@@ -31,16 +31,16 @@ extern "C" {
     // as a real named generic parameter — pinned here to prove it produces
     // the same shape of manufactured binding as `log_generic` above, with no
     // named type parameter of its own.
-    #[wasm_bindgen(generic_per_mono, js_name = logImplTrait)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = logImplTrait)]
     fn log_impl_trait(x: impl Clone);
 
     // `impl Trait` mixed with a real, named type parameter in the same
     // signature; each gets its own synthesized/declared generic slot.
-    #[wasm_bindgen(generic_per_mono, js_name = mixImplTrait)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = mixImplTrait)]
     fn mix_impl_trait<T>(label: T, value: impl Clone);
 
     // `impl Trait` nested inside another type (`Vec<impl Trait>`).
-    #[wasm_bindgen(generic_per_mono, js_name = logNestedImplTrait)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = logNestedImplTrait)]
     fn log_nested_impl_trait(xs: Vec<impl Clone>);
 
     // A trait-bounded generic import. The bound has to be re-emitted onto the
@@ -48,95 +48,95 @@ extern "C" {
     // part of the per-monomorphisation codegen and is otherwise pinned only by
     // the wasm test suite, where a regression shows up as a runtime failure with
     // no diff to read.
-    #[wasm_bindgen(generic_per_mono, js_name = sumItems)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = sumItems)]
     fn sum_items<T: IntoIterator<Item = u32>>(xs: T) -> f64;
 
-    // Declared but never instantiated. A `generic_per_mono` import with no
+    // Declared but never instantiated. A `experimental_generic_mono` import with no
     // monomorphisations is what any library crate hits for the imports its
     // consumers do not call, and it takes a different path: the binding table
     // gains an entry with no matching descriptor, and the anchoring descriptor
     // export has to be interpreted and deleted rather than leaking into the
     // output. Nothing should be emitted for it below.
-    #[wasm_bindgen(generic_per_mono, js_name = neverCalled)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = neverCalled)]
     fn never_called<T>(x: T);
 
     // A bare shared reference to a generic type parameter (`&T`). `&JsValue`
     // marshals as an externref, JS handle referents by handle index. Each
     // instantiation gets its own per-mono shim.
-    #[wasm_bindgen(generic_per_mono, js_name = logRef)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = logRef)]
     fn log_ref<T>(x: &T);
 
     // A shared slice with a *generic* element type. `&[T]` takes the same
     // route as `&T` above (an HRTB `for<'a> &'a [T]: IntoWasmAbi` bound), so
     // each element type marshals as its own typed-array view.
-    #[wasm_bindgen(generic_per_mono, js_name = logGenericSlice)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = logGenericSlice)]
     fn log_generic_slice<T>(xs: &[T]);
 
     // ...including as the `variadic` argument, which the non-sequence variadic
     // diagnostic explicitly recommends.
-    #[wasm_bindgen(generic_per_mono, variadic, js_name = spreadGeneric)]
+    #[wasm_bindgen(experimental_generic_mono, variadic, js_name = spreadGeneric)]
     fn spread_generic<T>(first: u32, rest: &[T]);
 
     // `catch` produces a `handleError`-wrapped shim.
-    #[wasm_bindgen(generic_per_mono, catch, js_name = tryLog)]
+    #[wasm_bindgen(experimental_generic_mono, catch, js_name = tryLog)]
     fn try_log<T>(x: T) -> Result<(), JsValue>;
 
     // `variadic` spreads the final argument. The variadic argument must be a
     // concrete iterable (here `Vec<T>`), which marshals to a spreadable JS
     // array; a bare generic `T` is rejected because it may monomorphise to a
     // non-iterable scalar.
-    #[wasm_bindgen(generic_per_mono, variadic, js_name = variadicLog)]
+    #[wasm_bindgen(experimental_generic_mono, variadic, js_name = variadicLog)]
     fn variadic_log<T>(first: u32, rest: Vec<T>);
 
     // `slice_to_array` hands JS a plain `Array` it owns rather than a
     // typed-array view into wasm memory. The slice element type must be
     // concrete, so the rewrite is independent of which monomorphisation is
     // being generated.
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = logSlice)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = logSlice)]
     fn log_slice<T>(xs: &[u16], other: T);
 
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = logOptSlice)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = logOptSlice)]
     fn log_opt_slice<T>(xs: Option<&[u16]>, other: T);
 
     // A `String` element type takes the *other* ownership path: JS receives a
     // freshly allocated index buffer that it must free, unlike the primitive
     // case above which borrows the caller's slice.
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = logStrSlice)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = logStrSlice)]
     fn log_str_slice<T>(xs: &[String], other: T);
 
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = logOptStrSlice)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = logOptStrSlice)]
     fn log_opt_str_slice<T>(xs: Option<&[String]>, other: T);
 
     // `async` imports return a `Promise` across the ABI whatever they resolve
     // to, so the descriptor is an externref and the resolved value is converted
     // separately inside `JsFuture<T>`. That makes a monomorphised `-> T` work,
     // including for a `T` that is not itself handle-shaped.
-    #[wasm_bindgen(generic_per_mono, js_name = asyncIdentity)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = asyncIdentity)]
     async fn async_identity<T>(x: T) -> T;
 
     // Same, but resolving to a concrete non-handle type.
-    #[wasm_bindgen(generic_per_mono, js_name = asyncCount)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = asyncCount)]
     async fn async_count<T>(x: T) -> u32;
 
     // And through the `Ok` type of a `catch` import.
-    #[wasm_bindgen(generic_per_mono, catch, js_name = asyncTry)]
+    #[wasm_bindgen(experimental_generic_mono, catch, js_name = asyncTry)]
     async fn async_try<T>(x: T) -> Result<T, JsValue>;
 
     // Non-async `catch` with a *generic* `Ok` type. Unlike `try_log` above
     // (whose `Ok` is `()`) the success value has to be marshalled at each
     // monomorphisation's concrete type, while the error stays `JsValue`.
-    #[wasm_bindgen(generic_per_mono, catch, js_name = tryGet)]
+    #[wasm_bindgen(experimental_generic_mono, catch, js_name = tryGet)]
     fn try_get<T>(key: u32) -> Result<T, JsValue>;
 
-    // `&mut` to a *concrete* type inside a `generic_per_mono` import. These bind
+    // `&mut` to a *concrete* type inside a `experimental_generic_mono` import. These bind
     // exactly as they do on the non-generic import path: a `&mut [u16]` is a
     // mutable typed-array view into wasm memory that is written back, and a
     // `&mut dyn FnMut` gets a reentrancy-guarded JS wrapper. Only a `&mut` whose
     // referent mentions a type parameter is rejected.
-    #[wasm_bindgen(generic_per_mono, js_name = fillSlice)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = fillSlice)]
     fn fill_slice<T>(xs: &mut [u16], other: T);
 
-    #[wasm_bindgen(generic_per_mono, js_name = withCallback)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = withCallback)]
     fn with_callback<T>(f: &mut dyn FnMut(u32), other: T);
 }
 
@@ -154,18 +154,18 @@ extern "C" {
 }
 
 // `slice_to_array` is inheritable from the enclosing block and applies to every
-// slice-shaped argument of every function it covers, `generic_per_mono` included.
+// slice-shaped argument of every function it covers, `experimental_generic_mono` included.
 #[wasm_bindgen(slice_to_array)]
 extern "C" {
-    #[wasm_bindgen(generic_per_mono, js_name = logBlockSlice)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = logBlockSlice)]
     fn log_block_slice<T>(xs: &[u16], other: T);
 }
 
-// `generic_per_mono` is itself inheritable from the enclosing block, so the
+// `experimental_generic_mono` is itself inheritable from the enclosing block, so the
 // generic functions here take the per-monomorphisation path without repeating the
 // attribute — each instantiation still gets its own `__wbindgen_generic_*` shim
 // rather than a single erased binding.
-#[wasm_bindgen(generic_per_mono)]
+#[wasm_bindgen(experimental_generic_mono)]
 extern "C" {
     #[wasm_bindgen(js_name = blockInherited)]
     fn block_inherited<T>(x: T);
@@ -195,10 +195,10 @@ extern "C" {
 // monomorphisation binds through the same namespaced value.
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(js_namespace = console, generic_per_mono, js_name = log)]
+    #[wasm_bindgen(js_namespace = console, experimental_generic_mono, js_name = log)]
     fn ns_log<T>(x: T);
 
-    #[wasm_bindgen(js_namespace = ["a", "b"], generic_per_mono, js_name = deepLog)]
+    #[wasm_bindgen(js_namespace = ["a", "b"], experimental_generic_mono, js_name = deepLog)]
     fn ns_deep_log<T>(x: T);
 }
 
@@ -207,41 +207,41 @@ extern "C" {
     #[wasm_bindgen(js_name = Widget)]
     type Widget;
 
-    // `constructor` + `generic_per_mono`. This has dedicated codegen:
+    // `constructor` + `experimental_generic_mono`. This has dedicated codegen:
     // `class_return_path()` retargets the generated `impl` block to the *return*
     // type's class, so the manufactured binding attaches to `new Widget(..)`
     // rather than to the free-function path.
-    #[wasm_bindgen(constructor, generic_per_mono, js_class = "Widget")]
+    #[wasm_bindgen(constructor, experimental_generic_mono, js_class = "Widget")]
     fn new<T>(value: T) -> Widget;
 
     // A generic method binds as an instance method call. Two instantiations
     // prove distinct per-mono shims for the method path.
-    #[wasm_bindgen(method, generic_per_mono, js_class = "Widget", js_name = set)]
+    #[wasm_bindgen(method, experimental_generic_mono, js_class = "Widget", js_name = set)]
     fn set<T>(this: &Widget, value: T);
 
     // `impl Trait` on a method argument: the receiver is untouched and the
     // synthesized type parameter behaves like any other method-level generic.
-    #[wasm_bindgen(method, generic_per_mono, js_class = "Widget", js_name = setImplTrait)]
+    #[wasm_bindgen(method, experimental_generic_mono, js_class = "Widget", js_name = setImplTrait)]
     fn set_impl_trait(this: &Widget, value: impl Clone);
 
     // A generic method taking a bare shared reference `&T`. Here `T`
     // monomorphises to the JS-handle `Widget`, so `&Widget` marshals via the
     // handle's `IntoWasmAbi for &Widget` impl.
-    #[wasm_bindgen(method, generic_per_mono, js_class = "Widget", js_name = attach)]
+    #[wasm_bindgen(method, experimental_generic_mono, js_class = "Widget", js_name = attach)]
     fn attach<T>(this: &Widget, other: &T);
 
     // A generic static method. Two instantiations prove distinct per-mono shims
     // for the static path.
-    #[wasm_bindgen(static_method_of = Widget, generic_per_mono, js_name = of)]
+    #[wasm_bindgen(static_method_of = Widget, experimental_generic_mono, js_name = of)]
     fn of<T>(value: T) -> Widget;
 
     // A getter with a generic *return*: each monomorphisation reads the same JS
     // property but marshals the result at its concrete type.
-    #[wasm_bindgen(method, getter, generic_per_mono, js_class = "Widget", js_name = value)]
+    #[wasm_bindgen(method, getter, experimental_generic_mono, js_class = "Widget", js_name = value)]
     fn value<T>(this: &Widget) -> T;
 
     // A setter with a generic argument.
-    #[wasm_bindgen(method, setter, generic_per_mono, js_class = "Widget", js_name = value)]
+    #[wasm_bindgen(method, setter, experimental_generic_mono, js_class = "Widget", js_name = value)]
     fn set_value<T>(this: &Widget, v: T);
 
     // `structural` accessors go through a property access on the receiver rather
@@ -250,7 +250,7 @@ extern "C" {
         method,
         getter,
         structural,
-        generic_per_mono,
+        experimental_generic_mono,
         js_class = "Widget",
         js_name = tag
     )]
@@ -260,7 +260,7 @@ extern "C" {
         method,
         setter,
         structural,
-        generic_per_mono,
+        experimental_generic_mono,
         js_class = "Widget",
         js_name = tag
     )]
@@ -268,22 +268,22 @@ extern "C" {
 
     // `final` is the opposite of `structural`: the property is looked up once at
     // instantiation time rather than on every call.
-    #[wasm_bindgen(method, getter, final, generic_per_mono, js_class = "Widget", js_name = kind)]
+    #[wasm_bindgen(method, getter, final, experimental_generic_mono, js_class = "Widget", js_name = kind)]
     fn kind<T>(this: &Widget) -> T;
 
     // The `indexing_*` operations emit `obj[prop]`, `obj[prop] = val` and
     // `delete obj[prop]`. They always require `structural` + `method`. Here the
     // index is concrete and the value generic, so each monomorphisation differs
     // only in how the value crosses.
-    #[wasm_bindgen(method, structural, indexing_getter, generic_per_mono)]
+    #[wasm_bindgen(method, structural, indexing_getter, experimental_generic_mono)]
     fn get<T>(this: &Widget, prop: &str) -> T;
 
-    #[wasm_bindgen(method, structural, indexing_setter, generic_per_mono)]
+    #[wasm_bindgen(method, structural, indexing_setter, experimental_generic_mono)]
     fn set_indexed<T>(this: &Widget, prop: &str, val: T);
 
     // A deleter has no value parameter, so its type parameter appears only in the
     // *index* position.
-    #[wasm_bindgen(method, structural, indexing_deleter, generic_per_mono)]
+    #[wasm_bindgen(method, structural, indexing_deleter, experimental_generic_mono)]
     fn delete_indexed<T>(this: &Widget, prop: T);
 }
 

--- a/crates/cli/tests/wasm-bindgen/diagnostics.rs
+++ b/crates/cli/tests/wasm-bindgen/diagnostics.rs
@@ -129,7 +129,7 @@ fn typo_in_js_class_suggests_nearest_struct() {
 // behaviour is exercised by `typo_in_js_class_suggests_nearest_struct`
 // above, so we deliberately don't duplicate the integration test here.
 
-/// Two `generic_per_mono` imports that agree on everything else and differ only
+/// Two `experimental_generic_mono` imports that agree on everything else and differ only
 /// in `js_namespace` must get distinct shim keys, and both must bind.
 ///
 /// The key is `__wbg_<wasm.name>_<ShortHash(ns, sig tokens, module, cfg attrs)>`
@@ -140,8 +140,8 @@ fn typo_in_js_class_suggests_nearest_struct() {
 /// so their `sig` token streams are byte-identical (`fn log<T>(x: T)`) and every
 /// other hashed input agrees, which is exactly the case that used to fail.
 #[test]
-fn generic_per_mono_js_namespace_does_not_collide_on_the_shim_key() {
-    let out_dir = Project::new("generic_per_mono_js_namespace_shim_key")
+fn experimental_generic_mono_js_namespace_does_not_collide_on_the_shim_key() {
+    let out_dir = Project::new("experimental_generic_mono_js_namespace_shim_key")
         .file(
             "src/lib.rs",
             r#"
@@ -154,7 +154,7 @@ fn generic_per_mono_js_namespace_does_not_collide_on_the_shim_key() {
                     use wasm_bindgen::prelude::*;
                     #[wasm_bindgen]
                     extern "C" {
-                        #[wasm_bindgen(js_namespace = a, generic_per_mono)]
+                        #[wasm_bindgen(js_namespace = a, experimental_generic_mono)]
                         pub fn log<T>(x: T);
                     }
                 }
@@ -163,7 +163,7 @@ fn generic_per_mono_js_namespace_does_not_collide_on_the_shim_key() {
                     use wasm_bindgen::prelude::*;
                     #[wasm_bindgen]
                     extern "C" {
-                        #[wasm_bindgen(js_namespace = b, generic_per_mono)]
+                        #[wasm_bindgen(js_namespace = b, experimental_generic_mono)]
                         pub fn log<T>(x: T);
                     }
                 }
@@ -177,7 +177,8 @@ fn generic_per_mono_js_namespace_does_not_collide_on_the_shim_key() {
         )
         .wasm_bindgen("--target web")
         .unwrap();
-    let js = fs::read_to_string(out_dir.join("generic_per_mono_js_namespace_shim_key.js")).unwrap();
+    let js = fs::read_to_string(out_dir.join("experimental_generic_mono_js_namespace_shim_key.js"))
+        .unwrap();
 
     // Both namespaces must actually be bound; if the two imports still shared a
     // key one of them would be silently dropped (or the build would fail).
@@ -185,7 +186,7 @@ fn generic_per_mono_js_namespace_does_not_collide_on_the_shim_key() {
     assert_contains!(&js, "b.log(");
 }
 
-/// The same `generic_per_mono` import declared twice must deduplicate, not
+/// The same `experimental_generic_mono` import declared twice must deduplicate, not
 /// abort the build.
 ///
 /// Two byte-identical declarations in two modules of one crate necessarily
@@ -201,8 +202,8 @@ fn generic_per_mono_js_namespace_does_not_collide_on_the_shim_key() {
 /// Note `ShortHash` mixes in `CARGO_PKG_NAME`/`CARGO_PKG_VERSION`, so the
 /// cross-crate form of this never collided; it has to be one crate to bite.
 #[test]
-fn generic_per_mono_identical_imports_deduplicate() {
-    let out_dir = Project::new("generic_per_mono_identical_imports_deduplicate")
+fn experimental_generic_mono_identical_imports_deduplicate() {
+    let out_dir = Project::new("experimental_generic_mono_identical_imports_deduplicate")
         .file(
             "src/lib.rs",
             r#"
@@ -215,7 +216,7 @@ fn generic_per_mono_identical_imports_deduplicate() {
                     use wasm_bindgen::prelude::*;
                     #[wasm_bindgen]
                     extern "C" {
-                        #[wasm_bindgen(js_namespace = console, generic_per_mono)]
+                        #[wasm_bindgen(js_namespace = console, experimental_generic_mono)]
                         pub fn log<T>(x: T);
                     }
                 }
@@ -224,7 +225,7 @@ fn generic_per_mono_identical_imports_deduplicate() {
                     use wasm_bindgen::prelude::*;
                     #[wasm_bindgen]
                     extern "C" {
-                        #[wasm_bindgen(js_namespace = console, generic_per_mono)]
+                        #[wasm_bindgen(js_namespace = console, experimental_generic_mono)]
                         pub fn log<T>(x: T);
                     }
                 }
@@ -240,8 +241,10 @@ fn generic_per_mono_identical_imports_deduplicate() {
         )
         .wasm_bindgen("--target web")
         .unwrap();
-    let js = fs::read_to_string(out_dir.join("generic_per_mono_identical_imports_deduplicate.js"))
-        .unwrap();
+    let js = fs::read_to_string(
+        out_dir.join("experimental_generic_mono_identical_imports_deduplicate.js"),
+    )
+    .unwrap();
 
     // Both monomorphisations bind, through the one shared entry.
     assert_contains!(&js, "console.log(");
@@ -257,8 +260,8 @@ fn generic_per_mono_identical_imports_deduplicate() {
 /// one would silently mis-bind every monomorphisation of the other, so this
 /// has to stay an error -- the dedup above must not swallow it.
 #[test]
-fn generic_per_mono_genuine_collision_is_reported() {
-    let err = Project::new("generic_per_mono_genuine_collision_is_reported")
+fn experimental_generic_mono_genuine_collision_is_reported() {
+    let err = Project::new("experimental_generic_mono_genuine_collision_is_reported")
         .file(
             "src/lib.rs",
             r#"
@@ -268,7 +271,7 @@ fn generic_per_mono_genuine_collision_is_reported() {
                     use wasm_bindgen::prelude::*;
                     #[wasm_bindgen]
                     extern "C" {
-                        #[wasm_bindgen(js_namespace = console, generic_per_mono)]
+                        #[wasm_bindgen(js_namespace = console, experimental_generic_mono)]
                         pub fn log<T>(xs: Vec<T>);
                     }
                 }
@@ -280,7 +283,7 @@ fn generic_per_mono_genuine_collision_is_reported() {
                         // Differs from `one::log` only in `variadic`, which is
                         // not hashed into the shim key and leaves the signature
                         // tokens byte-identical.
-                        #[wasm_bindgen(js_namespace = console, generic_per_mono, variadic)]
+                        #[wasm_bindgen(js_namespace = console, experimental_generic_mono, variadic)]
                         pub fn log<T>(xs: Vec<T>);
                     }
                 }

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -262,7 +262,7 @@ fn one_export_works() {
         .unwrap();
 }
 
-/// A `generic_per_mono` import declared in an upstream crate must still bind
+/// A `experimental_generic_mono` import declared in an upstream crate must still bind
 /// when that crate's `extern "C"` block contains *nothing else*.
 ///
 /// The crate's `#[link_section = "__wasm_bindgen_unstable"]` AST metadata lives
@@ -278,8 +278,8 @@ fn one_export_works() {
 /// non-LTO build — `lto = true` merges everything and masks the problem
 /// entirely, which is why this regressed without CI noticing.
 #[test]
-fn cross_crate_generic_per_mono_only_block() {
-    let mut project = Project::new("cross_crate_generic_per_mono_only_block");
+fn cross_crate_experimental_generic_mono_only_block() {
+    let mut project = Project::new("cross_crate_experimental_generic_mono_only_block");
     project
         .dep("upstream_generic = { path = 'upstream_generic' }")
         .file(
@@ -307,7 +307,7 @@ fn cross_crate_generic_per_mono_only_block() {
                 use wasm_bindgen::prelude::*;
                 #[wasm_bindgen]
                 extern "C" {
-                    #[wasm_bindgen(generic_per_mono)]
+                    #[wasm_bindgen(experimental_generic_mono)]
                     pub fn shared_log<T>(x: T);
                 }
             "#,
@@ -326,7 +326,8 @@ fn cross_crate_generic_per_mono_only_block() {
 
     let out_dir = project.wasm_bindgen("--target web").unwrap();
     let js =
-        fs::read_to_string(out_dir.join("cross_crate_generic_per_mono_only_block.js")).unwrap();
+        fs::read_to_string(out_dir.join("cross_crate_experimental_generic_mono_only_block.js"))
+            .unwrap();
 
     // One manufactured shim per monomorphisation, each calling the upstream
     // import. `u32` crosses as a number, `&str` as a (ptr, len) pair.
@@ -361,8 +362,8 @@ fn cross_crate_generic_per_mono_only_block() {
 /// same applies to any prelude crate name, so `alloc` and `std` are shadowed here
 /// too to keep the whole expansion honest.
 #[test]
-fn generic_per_mono_shim_paths_survive_shadowing() {
-    let mut project = Project::new("generic_per_mono_shim_paths_survive_shadowing");
+fn experimental_generic_mono_shim_paths_survive_shadowing() {
+    let mut project = Project::new("experimental_generic_mono_shim_paths_survive_shadowing");
     project.file(
         "src/lib.rs",
         r#"
@@ -376,18 +377,18 @@ fn generic_per_mono_shim_paths_survive_shadowing() {
             #[wasm_bindgen]
             extern "C" {
                 // Covers the `WasmRet<..>`-returning shim shape.
-                #[wasm_bindgen(generic_per_mono)]
+                #[wasm_bindgen(experimental_generic_mono)]
                 fn echo<T>(x: T) -> T;
                 // Covers the unit-returning shim shape, which builds its marker
                 // call as a statement rather than a tail expression.
-                #[wasm_bindgen(generic_per_mono)]
+                #[wasm_bindgen(experimental_generic_mono)]
                 fn sink<T>(x: T);
                 // Covers the `slice_to_array` rewrite, which names both
                 // `alloc::vec::Vec` (in the describe type) and `core::option::Option`
                 // (in the ABI conversion for the `Option<&[T]>` shape).
-                #[wasm_bindgen(generic_per_mono, slice_to_array)]
+                #[wasm_bindgen(experimental_generic_mono, slice_to_array)]
                 fn take_slice<T>(xs: &[u32], t: T);
-                #[wasm_bindgen(generic_per_mono, slice_to_array)]
+                #[wasm_bindgen(experimental_generic_mono, slice_to_array)]
                 fn take_opt_slice<T>(xs: Option<&[u32]>, t: T);
             }
 
@@ -420,8 +421,8 @@ fn generic_per_mono_shim_paths_survive_shadowing() {
 /// controls, so pin it: if it ever stops holding, this fails at the point the
 /// toolchain changes rather than in a user's bug report.
 #[test]
-fn generic_per_mono_unsafe_op_in_unsafe_fn() {
-    let mut project = Project::new("generic_per_mono_unsafe_op_in_unsafe_fn");
+fn experimental_generic_mono_unsafe_op_in_unsafe_fn() {
+    let mut project = Project::new("experimental_generic_mono_unsafe_op_in_unsafe_fn");
     project.file(
         "src/lib.rs",
         r#"
@@ -432,15 +433,15 @@ fn generic_per_mono_unsafe_op_in_unsafe_fn() {
             #[wasm_bindgen]
             extern "C" {
                 // Covers the `WasmRet<..>`-returning shim shape.
-                #[wasm_bindgen(generic_per_mono)]
+                #[wasm_bindgen(experimental_generic_mono)]
                 fn echo<T>(x: T) -> T;
                 // Covers the unit-returning shim shape, which builds its marker
                 // call as a statement rather than a tail expression.
-                #[wasm_bindgen(generic_per_mono)]
+                #[wasm_bindgen(experimental_generic_mono)]
                 fn sink<T>(x: T);
                 // Covers the `slice_to_array` rewrite, whose ABI conversion is
                 // spliced into the same unsafe body.
-                #[wasm_bindgen(generic_per_mono, slice_to_array)]
+                #[wasm_bindgen(experimental_generic_mono, slice_to_array)]
                 fn take_slice<T>(xs: &[u32], t: T);
             }
 

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -2822,7 +2822,7 @@ impl ast::ImportFunction {
         if type_params.is_empty() {
             bail_span!(
                 self.rust_name,
-                "generic_per_mono requires at least one type parameter"
+                "experimental_generic_mono requires at least one type parameter"
             );
         }
         let lifetime_params = generics::lifetime_params(&self.generics);
@@ -2860,7 +2860,7 @@ impl ast::ImportFunction {
             {
                 bail_span!(
                     self.rust_name,
-                    "generic_per_mono does not support class-level generic parameters yet; \
+                    "experimental_generic_mono does not support class-level generic parameters yet; \
                      use the type-erasure generic path instead"
                 );
             }
@@ -2881,7 +2881,7 @@ impl ast::ImportFunction {
                 if generics::uses_generic_params(ty, &type_params) && !is_spreadable_sequence(ty) {
                     bail_span!(
                         ty,
-                        "generic_per_mono requires the `variadic` argument to be a sequence when \
+                        "experimental_generic_mono requires the `variadic` argument to be a sequence when \
                          it mentions a type parameter, because it is spread with `...` on the JS \
                          side and must be iterable for every monomorphisation; use `Vec<T>`, \
                          `[T; N]` or `&[T]`, or the type-erasure generic path instead"
@@ -2952,7 +2952,7 @@ impl ast::ImportFunction {
                 syn::Pat::Wild(_) => Ident::new(&format!("__genarg_{i}"), Span::call_site()),
                 _ => bail_span!(
                     arg.pat_type.pat,
-                    "unsupported pattern in generic_per_mono imported function",
+                    "unsupported pattern in experimental_generic_mono imported function",
                 ),
             };
 
@@ -2989,7 +2989,7 @@ impl ast::ImportFunction {
                 } else if generics::references_generic_param(ty, &type_params) {
                     bail_span!(
                         ty,
-                        "generic_per_mono only supports a bare shared reference to a generic \
+                        "experimental_generic_mono only supports a bare shared reference to a generic \
                          type parameter (`&T`); mutable references (`&mut T`) and references \
                          nested inside another type (e.g. `Option<&T>`) are not supported — \
                          take the argument by value or use the type-erasure generic path"
@@ -3700,7 +3700,7 @@ impl TryToTokens for DescribeImport<'_> {
         // archive member out of an rlib if something in the link references one
         // of its symbols. The monomorphised shim is instantiated in the
         // *downstream* crate's CGU, so it does not reference anything here — an
-        // upstream `extern "C"` block containing only `generic_per_mono`
+        // upstream `extern "C"` block containing only `experimental_generic_mono`
         // imports would leave no referenced symbol at all, the member would
         // never be pulled, and the crate's AST metadata would silently go
         // missing. The CLI then fails with "generic import monomorphisation
@@ -4237,7 +4237,7 @@ fn respan(input: TokenStream, span: &dyn ToTokens) -> TokenStream {
 /// async-import tests all resolve to `JsValue`/`JsString`.
 ///
 /// Both import codegen paths must agree here — [`DescribeImport`] for ordinary
-/// imports and [`ImportFunction::try_to_tokens_generic`] for `generic_per_mono`
+/// imports and [`ImportFunction::try_to_tokens_generic`] for `experimental_generic_mono`
 /// ones. They used to carry separate copies of this logic with a "keep the two in
 /// sync" comment; this helper is what makes that drift impossible.
 fn import_describe_ret(

--- a/crates/macro-support/src/generics.rs
+++ b/crates/macro-support/src/generics.rs
@@ -380,7 +380,7 @@ impl<'ast> Visit<'ast> for ImplTraitPresenceVisitor {
 /// Argument-position `impl Trait` desugars to an anonymous generic type
 /// parameter, so it never shows up in `fn.generics` — callers that need to
 /// know whether a signature is "generic" at all (e.g. deciding whether a
-/// block-level `generic_per_mono` applies) have to check argument types
+/// block-level `experimental_generic_mono` applies) have to check argument types
 /// directly rather than `fn.generics.type_params()`.
 pub(crate) fn has_impl_trait(ty: &syn::Type) -> bool {
     let mut visitor = ImplTraitPresenceVisitor { found: false };
@@ -395,7 +395,7 @@ pub(crate) fn has_impl_trait(ty: &syn::Type) -> bool {
 ///
 /// Argument-position `impl Trait` desugars to an anonymous generic type
 /// parameter that never appears in `fn.generics`, so there is no name for
-/// `generic_per_mono` codegen to hang a `where` bound, shim generic
+/// `experimental_generic_mono` codegen to hang a `where` bound, shim generic
 /// parameter, or `breaks_if_inlined::<..>` turbofish argument off of. This
 /// visitor "un-desugars" it back into the named form a user would otherwise
 /// have to write by hand (`fn f<T: Trait>(x: T)`), giving each occurrence a

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -130,7 +130,7 @@ macro_rules! attrgen {
             // Opt-in to the experimental per-monomorphisation generic import
             // codegen path (interpreter-discovered, marker-terminated) instead
             // of the type-erasure path.
-            (generic_per_mono, true, GenericPerMono(Span)),
+            (experimental_generic_mono, true, GenericPerMono(Span)),
 
             // For testing purposes only.
             (assert_no_shim, false, AssertNoShim(Span)),
@@ -1069,7 +1069,7 @@ impl<'a>
         }
 
         let assert_no_shim = opts.assert_no_shim();
-        // `generic_per_mono` is inherited from the enclosing `extern "C"` block,
+        // `experimental_generic_mono` is inherited from the enclosing `extern "C"` block,
         // optionally OR'd with a fn-level attribute, exactly like
         // `slice_to_array` above.
         //
@@ -1083,12 +1083,12 @@ impl<'a>
         // Writing the attribute *on* a non-generic function is still an error
         // (raised in codegen): there the user named a specific function and the
         // request cannot be honoured, so silence would hide a real mistake.
-        let fn_generic_per_mono = opts.generic_per_mono().is_some();
+        let fn_generic_per_mono = opts.experimental_generic_mono().is_some();
         // A named type parameter isn't the only way a signature is generic:
         // argument-position `impl Trait` desugars to an anonymous one that
         // never appears in `self.sig.generics`, so it has to be checked for
         // separately, or a bare-`impl Trait` function would look non-generic
-        // to the block-level flag above (despite `generic_per_mono` fully
+        // to the block-level flag above (despite `experimental_generic_mono` fully
         // supporting it; see `codegen::try_to_tokens_generic`).
         let is_generic = self.sig.generics.type_params().next().is_some()
             || self.sig.inputs.iter().any(|arg| match arg {
@@ -1106,7 +1106,7 @@ impl<'a>
             if let Some(span) = assert_no_shim {
                 return Err(Diagnostic::span_error(
                     *span,
-                    "`assert_no_shim` cannot be used with `generic_per_mono`, which always \
+                    "`assert_no_shim` cannot be used with `experimental_generic_mono`, which always \
                      generates one shim per monomorphisation",
                 ));
             }
@@ -1116,7 +1116,7 @@ impl<'a>
             if let Some(span) = opts.suspending() {
                 return Err(Diagnostic::span_error(
                     *span,
-                    "`suspending` cannot be used with `generic_per_mono`; use the \
+                    "`suspending` cannot be used with `experimental_generic_mono`; use the \
                      type-erasure generic path for suspending imports",
                 ));
             }
@@ -1125,7 +1125,7 @@ impl<'a>
             if opts.reexport().is_some() {
                 return Err(Diagnostic::span_error(
                     self.sig.ident.span(),
-                    "`reexport` cannot be used with `generic_per_mono`, because one binding is \
+                    "`reexport` cannot be used with `experimental_generic_mono`, because one binding is \
                      manufactured per monomorphisation and there is no single shim to reexport; \
                      remove the reexport or use the type-erasure generic path",
                 ));
@@ -2729,7 +2729,7 @@ impl MacroParse<BindgenAttrs> for syn::ItemForeignMod {
             .map_err(|e| errors.push(e))
             .unwrap_or_default();
         let slice_to_array = opts.slice_to_array().is_some();
-        let generic_per_mono = opts.generic_per_mono().is_some();
+        let generic_per_mono = opts.experimental_generic_mono().is_some();
         for item in self.items.into_iter() {
             let ctx = ForeignItemCtx {
                 module: module.clone(),
@@ -2754,9 +2754,9 @@ struct ForeignItemCtx {
     /// function inside the `extern "C"` block. Per-fn / per-arg
     /// `slice_to_array` ORs on top of this.
     slice_to_array: bool,
-    /// Block-level `generic_per_mono` flag inherited by every *generic* foreign
+    /// Block-level `experimental_generic_mono` flag inherited by every *generic* foreign
     /// function inside the `extern "C"` block, opting them onto the
-    /// per-monomorphisation codegen path. A per-fn `generic_per_mono` ORs on
+    /// per-monomorphisation codegen path. A per-fn `experimental_generic_mono` ORs on
     /// top of this.
     ///
     /// Like `slice_to_array`, this is a no-op where it cannot apply: the

--- a/crates/macro/ui-tests/generic-per-mono-bounds.rs
+++ b/crates/macro/ui-tests/generic-per-mono-bounds.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 // Trait bounds declared on a per-monomorphisation generic import
-// (`#[wasm_bindgen(generic_per_mono)]`) are part of its contract: they are
+// (`#[wasm_bindgen(experimental_generic_mono)]`) are part of its contract: they are
 // carried through codegen, so a caller that violates one is rejected, and the
 // diagnostic points at the user's own bound. Both an inline bound and a `where`
 // predicate are exercised, since they reach the generated wrapper by different
@@ -19,18 +19,18 @@ trait Marker {}
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn inline_bound<T: Marker>(x: T);
 
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn where_bound<T>(x: T)
     where
         T: Marker;
 
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn iter_bound<T: Iterator>(x: T);
 
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn iter_item_bound<T>(x: T)
     where
         T: IntoIterator<Item = String>;

--- a/crates/macro/ui-tests/generic-per-mono-impl-trait.rs
+++ b/crates/macro/ui-tests/generic-per-mono-impl-trait.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 // Argument-position `impl Trait` in a per-monomorphisation generic import
-// (`#[wasm_bindgen(generic_per_mono)]`) is desugared into a synthesized named
+// (`#[wasm_bindgen(experimental_generic_mono)]`) is desugared into a synthesized named
 // type parameter with the same bounds, exactly as if the user had written it
 // out by hand (`fn f<T: Trait>(x: T)`). The declarations below all take that
 // path silently; only the call sites at the bottom, which violate the
@@ -14,20 +14,20 @@ extern "C" {
     // A bare `impl Trait` argument on a function with no named type
     // parameter of its own: this is the shape `generic-per-mono-unsupported.rs`
     // notes would otherwise look like it has none.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn bare_impl_trait(x: impl Marker);
 
     // `impl Trait` mixed with a real, named type parameter.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn impl_trait_with_type_param<T>(x: impl Marker, y: T);
 
     // `impl Trait` nested inside another type.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn nested_impl_trait<T>(x: Vec<impl Marker>, y: T);
 
     // Two `impl Trait` arguments in the same function, each with a different
     // bound: both need their own synthesized parameter with distinct names.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn two_impl_trait_args(x: impl Marker, y: impl Iterator);
 }
 

--- a/crates/macro/ui-tests/generic-per-mono-invalid-position.rs
+++ b/crates/macro/ui-tests/generic-per-mono-invalid-position.rs
@@ -1,18 +1,18 @@
 use wasm_bindgen::prelude::*;
 
-// `generic_per_mono` only means something on an imported function, or on an
+// `experimental_generic_mono` only means something on an imported function, or on an
 // `extern "C"` block whose functions inherit it. Anywhere else it would silently
 // change nothing while looking like it changed the ABI, so it is rejected
 // outright rather than warned about.
 
 // Not an import at all: exported functions are never generic.
-#[wasm_bindgen(generic_per_mono)]
+#[wasm_bindgen(experimental_generic_mono)]
 pub fn exported_fn(x: u32) -> u32 {
     x
 }
 
 // Exported types have no imported-function ABI to opt in to.
-#[wasm_bindgen(generic_per_mono)]
+#[wasm_bindgen(experimental_generic_mono)]
 pub struct Exported {
     pub field: u32,
 }
@@ -20,12 +20,12 @@ pub struct Exported {
 #[wasm_bindgen]
 extern "C" {
     // An imported `type` is bound by its class, not by a per-call shim.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     pub type ImportedType;
 
     // An imported `static` is read through a single getter shim, and cannot be
     // generic.
-    #[wasm_bindgen(generic_per_mono, js_name = someGlobal, thread_local_v2)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = someGlobal, thread_local_v2)]
     static SOME_GLOBAL: JsValue;
 }
 

--- a/crates/macro/ui-tests/generic-per-mono-invalid-position.stderr
+++ b/crates/macro/ui-tests/generic-per-mono-invalid-position.stderr
@@ -1,23 +1,23 @@
-error: invalid attribute generic_per_mono in this position
+error: invalid attribute experimental_generic_mono in this position
  --> ui-tests/generic-per-mono-invalid-position.rs:9:16
   |
-9 | #[wasm_bindgen(generic_per_mono)]
-  |                ^^^^^^^^^^^^^^^^
+9 | #[wasm_bindgen(experimental_generic_mono)]
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid attribute generic_per_mono in this position
+error: invalid attribute experimental_generic_mono in this position
   --> ui-tests/generic-per-mono-invalid-position.rs:15:16
    |
-15 | #[wasm_bindgen(generic_per_mono)]
-   |                ^^^^^^^^^^^^^^^^
+15 | #[wasm_bindgen(experimental_generic_mono)]
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid attribute generic_per_mono in this position
+error: invalid attribute experimental_generic_mono in this position
   --> ui-tests/generic-per-mono-invalid-position.rs:23:20
    |
-23 |     #[wasm_bindgen(generic_per_mono)]
-   |                    ^^^^^^^^^^^^^^^^
+23 |     #[wasm_bindgen(experimental_generic_mono)]
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid attribute generic_per_mono in this position
+error: invalid attribute experimental_generic_mono in this position
   --> ui-tests/generic-per-mono-invalid-position.rs:28:20
    |
-28 |     #[wasm_bindgen(generic_per_mono, js_name = someGlobal, thread_local_v2)]
-   |                    ^^^^^^^^^^^^^^^^
+28 |     #[wasm_bindgen(experimental_generic_mono, js_name = someGlobal, thread_local_v2)]
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/macro/ui-tests/generic-per-mono-unsupported.rs
+++ b/crates/macro/ui-tests/generic-per-mono-unsupported.rs
@@ -1,95 +1,95 @@
 use wasm_bindgen::prelude::*;
 
 // The experimental per-monomorphisation generic import path
-// (`#[wasm_bindgen(generic_per_mono)]`) rejects a handful of shapes with a
+// (`#[wasm_bindgen(experimental_generic_mono)]`) rejects a handful of shapes with a
 // clear diagnostic, deferring them to the type-erasure generic path. Each
 // function below exercises one of those aborting paths.
 #[wasm_bindgen]
 extern "C" {
-    // `generic_per_mono` requires at least one type parameter. Argument-position
+    // `experimental_generic_mono` requires at least one type parameter. Argument-position
     // `impl Trait` (see `generic-per-mono-impl-trait.rs` for the supported case)
     // counts as one, since it desugars to an anonymous type parameter, so it
     // does not satisfy this check on its own.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn without_type_param(x: u32);
 
     // A bare shared reference to a generic type parameter (`&T`) *is* now
     // supported, but a mutable reference (`&mut T`) is not.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn mut_ref_to_generic<T>(x: &mut T);
 
     // Nor is a reference to a generic parameter nested inside another type
     // (e.g. `Option<&T>`).
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn nested_ref_to_generic<T>(x: Option<&T>);
 
     // Returning a reference is not supported.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn return_ref<T>(x: T) -> &JsValue;
 
     // A bare generic type parameter cannot be the `variadic` argument, since it
     // may monomorphise to a non-iterable scalar.
-    #[wasm_bindgen(generic_per_mono, variadic)]
+    #[wasm_bindgen(experimental_generic_mono, variadic)]
     fn variadic_scalar<T>(first: u32, rest: T);
 
     // Nor can a reference to one: `&T` crosses the ABI as whatever `T` does, so
     // it is just as unspreadable.
-    #[wasm_bindgen(generic_per_mono, variadic)]
+    #[wasm_bindgen(experimental_generic_mono, variadic)]
     fn variadic_ref<T>(first: u32, rest: &T);
 
     // Nor any other non-sequence container. These are rejected by the same
     // allow-list: `Option<T>` is `undefined` or a bare value, `Box<T>` marshals
     // as its pointee, and an associated type is whatever the bound resolves it
     // to — none of which is iterable for every monomorphisation.
-    #[wasm_bindgen(generic_per_mono, variadic)]
+    #[wasm_bindgen(experimental_generic_mono, variadic)]
     fn variadic_option<T>(first: u32, rest: Option<T>);
 
-    #[wasm_bindgen(generic_per_mono, variadic)]
+    #[wasm_bindgen(experimental_generic_mono, variadic)]
     fn variadic_box<T>(first: u32, rest: Box<T>);
 
-    #[wasm_bindgen(generic_per_mono, variadic)]
+    #[wasm_bindgen(experimental_generic_mono, variadic)]
     fn variadic_assoc<T: IntoIterator>(first: u32, rest: T::Item);
 
     // `catch` hard-codes the error type to `JsValue` and monomorphises only the
     // `Ok` type, so a type parameter in the error position is rejected.
-    #[wasm_bindgen(generic_per_mono, catch)]
+    #[wasm_bindgen(experimental_generic_mono, catch)]
     fn catch_generic_err<T>(x: T) -> Result<JsValue, T>;
 
     // The rejection is on *any* `&mut` whose referent mentions a type
     // parameter, not just a bare `&mut T`.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn mut_ref_to_nested_generic<T>(x: &mut Vec<T>);
 
     // The four further nested-reference shapes `references_generic_param`
     // documents. Each has a reference to `T` somewhere inside a larger type, so
     // none of them is a *top-level* shared ref and all need the erasure path.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn ref_ref_to_generic<T>(x: &&T);
 
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn tuple_with_ref_to_generic<T>(x: (T, &T));
 
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn array_of_refs_to_generic<T>(x: [&T; 2]);
 
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn boxed_ref_to_generic<T>(x: Box<&T>);
 
     // An argument whose pattern is not a plain ident or `_` has no name for the
     // generated shim to forward, so per-mono codegen rejects it.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn tuple_pattern_arg<T>((a, b): (u32, u32), x: T);
 }
 
 // Class-level generics on the imported type need the erasure machinery
-// (`fn_class_generics`), so a `generic_per_mono` method on a generic imported
+// (`fn_class_generics`), so a `experimental_generic_mono` method on a generic imported
 // type is rejected. Kept in its own block so the `type Holder<T>` declaration
 // can't interfere with the diagnostics above.
 #[wasm_bindgen]
 extern "C" {
     type Holder<T>;
 
-    #[wasm_bindgen(method, generic_per_mono)]
+    #[wasm_bindgen(method, experimental_generic_mono)]
     fn get<T>(this: &Holder<T>) -> T;
 }
 
@@ -102,7 +102,7 @@ extern "C" {
 extern "C" {
     type LifetimeHolder<'a>;
 
-    #[wasm_bindgen(method, generic_per_mono)]
+    #[wasm_bindgen(method, experimental_generic_mono)]
     fn get_lifetime<'a, T>(this: &'a LifetimeHolder<'a>) -> T;
 }
 
@@ -114,25 +114,25 @@ extern "C" {
 extern "C" {
     // `assert_no_shim` asserts that no shim is generated, which per-mono codegen
     // can never satisfy: it manufactures one shim per monomorphisation.
-    #[wasm_bindgen(generic_per_mono, assert_no_shim)]
+    #[wasm_bindgen(experimental_generic_mono, assert_no_shim)]
     fn asserted_no_shim<T>(x: T);
 
     // `reexport` names a single descriptor shim, and a per-mono import has no
     // single shim to name.
-    #[wasm_bindgen(generic_per_mono, reexport)]
+    #[wasm_bindgen(experimental_generic_mono, reexport)]
     fn reexported<T>(x: T);
 
     // Const generic parameters are rejected by `validate_generics` for *every*
     // wasm-bindgen generic, erased or per-mono, so this surfaces as the shared
     // "unsupported in wasm-bindgen generics" error rather than a per-mono one.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn const_generic<const N: usize, T>(x: T);
 
     // A `?Sized` bound relaxes an implicit bound rather than adding one, which
     // `validate_generics` rejects for *every* wasm-bindgen generic. Like the
     // const-generic case above this is the shared parse-time error, not a
     // per-mono one -- the erasure path already covers the same message.
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn unsized_type_param<T: ?Sized>(x: &T);
 
     // `slice_to_array` needs a concrete element type: `VectorRefIntoWasmAbi` is
@@ -140,20 +140,20 @@ extern "C" {
     // also a parse-time rejection, so it belongs in this block: leaving it in the
     // codegen-time block above would abort that block and swallow every
     // diagnostic in it.
-    #[wasm_bindgen(generic_per_mono, slice_to_array)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array)]
     fn slice_to_array_generic_elem<T>(xs: &[T], other: T);
 
     // Also rejected when only nested inside the element type...
-    #[wasm_bindgen(generic_per_mono, slice_to_array)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array)]
     fn slice_to_array_nested_elem<T>(xs: &[Vec<T>], other: T);
 
     // ...and through the `Option<&[T]>` form.
-    #[wasm_bindgen(generic_per_mono, slice_to_array)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array)]
     fn slice_to_array_option_elem<T>(xs: Option<&[T]>, other: T);
 }
 
 // `slice_to_array` is inherited from the enclosing block, and the same rejection
-// applies on the type-erasure generic path, which has no `generic_per_mono`.
+// applies on the type-erasure generic path, which has no `experimental_generic_mono`.
 #[wasm_bindgen(slice_to_array)]
 extern "C" {
     fn erased_slice_to_array_generic_elem<T>(xs: &[T]);

--- a/crates/macro/ui-tests/generic-per-mono-unsupported.stderr
+++ b/crates/macro/ui-tests/generic-per-mono-unsupported.stderr
@@ -1,16 +1,16 @@
-error: generic_per_mono requires at least one type parameter
+error: experimental_generic_mono requires at least one type parameter
   --> ui-tests/generic-per-mono-unsupported.rs:14:8
    |
 14 |     fn without_type_param(x: u32);
    |        ^^^^^^^^^^^^^^^^^^
 
-error: generic_per_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
+error: experimental_generic_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
   --> ui-tests/generic-per-mono-unsupported.rs:19:33
    |
 19 |     fn mut_ref_to_generic<T>(x: &mut T);
    |                                 ^^^^^^
 
-error: generic_per_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
+error: experimental_generic_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
   --> ui-tests/generic-per-mono-unsupported.rs:24:36
    |
 24 |     fn nested_ref_to_generic<T>(x: Option<&T>);
@@ -22,31 +22,31 @@ error: cannot return references in #[wasm_bindgen] imports yet
 28 |     fn return_ref<T>(x: T) -> &JsValue;
    |                               ^^^^^^^^
 
-error: generic_per_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
+error: experimental_generic_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
   --> ui-tests/generic-per-mono-unsupported.rs:33:45
    |
 33 |     fn variadic_scalar<T>(first: u32, rest: T);
    |                                             ^
 
-error: generic_per_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
+error: experimental_generic_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
   --> ui-tests/generic-per-mono-unsupported.rs:38:42
    |
 38 |     fn variadic_ref<T>(first: u32, rest: &T);
    |                                          ^^
 
-error: generic_per_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
+error: experimental_generic_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
   --> ui-tests/generic-per-mono-unsupported.rs:45:45
    |
 45 |     fn variadic_option<T>(first: u32, rest: Option<T>);
    |                                             ^^^^^^^^^
 
-error: generic_per_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
+error: experimental_generic_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
   --> ui-tests/generic-per-mono-unsupported.rs:48:42
    |
 48 |     fn variadic_box<T>(first: u32, rest: Box<T>);
    |                                          ^^^^^^
 
-error: generic_per_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
+error: experimental_generic_mono requires the `variadic` argument to be a sequence when it mentions a type parameter, because it is spread with `...` on the JS side and must be iterable for every monomorphisation; use `Vec<T>`, `[T; N]` or `&[T]`, or the type-erasure generic path instead
   --> ui-tests/generic-per-mono-unsupported.rs:51:58
    |
 51 |     fn variadic_assoc<T: IntoIterator>(first: u32, rest: T::Item);
@@ -58,61 +58,61 @@ error: the error type of a `catch` import must be `JsValue`, not a type paramete
 56 |     fn catch_generic_err<T>(x: T) -> Result<JsValue, T>;
    |                                                      ^
 
-error: generic_per_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
+error: experimental_generic_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
   --> ui-tests/generic-per-mono-unsupported.rs:61:40
    |
 61 |     fn mut_ref_to_nested_generic<T>(x: &mut Vec<T>);
    |                                        ^^^^^^^^^^^
 
-error: generic_per_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
+error: experimental_generic_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
   --> ui-tests/generic-per-mono-unsupported.rs:67:33
    |
 67 |     fn ref_ref_to_generic<T>(x: &&T);
    |                                 ^^^
 
-error: generic_per_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
+error: experimental_generic_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
   --> ui-tests/generic-per-mono-unsupported.rs:70:40
    |
 70 |     fn tuple_with_ref_to_generic<T>(x: (T, &T));
    |                                        ^^^^^^^
 
-error: generic_per_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
+error: experimental_generic_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
   --> ui-tests/generic-per-mono-unsupported.rs:73:39
    |
 73 |     fn array_of_refs_to_generic<T>(x: [&T; 2]);
    |                                       ^^^^^^^
 
-error: generic_per_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
+error: experimental_generic_mono only supports a bare shared reference to a generic type parameter (`&T`); mutable references (`&mut T`) and references nested inside another type (e.g. `Option<&T>`) are not supported — take the argument by value or use the type-erasure generic path
   --> ui-tests/generic-per-mono-unsupported.rs:76:35
    |
 76 |     fn boxed_ref_to_generic<T>(x: Box<&T>);
    |                                   ^^^^^^^
 
-error: unsupported pattern in generic_per_mono imported function
+error: unsupported pattern in experimental_generic_mono imported function
   --> ui-tests/generic-per-mono-unsupported.rs:81:29
    |
 81 |     fn tuple_pattern_arg<T>((a, b): (u32, u32), x: T);
    |                             ^^^^^^
 
-error: generic_per_mono does not support class-level generic parameters yet; use the type-erasure generic path instead
+error: experimental_generic_mono does not support class-level generic parameters yet; use the type-erasure generic path instead
   --> ui-tests/generic-per-mono-unsupported.rs:93:8
    |
 93 |     fn get<T>(this: &Holder<T>) -> T;
    |        ^^^
 
-error: generic_per_mono does not support class-level generic parameters yet; use the type-erasure generic path instead
+error: experimental_generic_mono does not support class-level generic parameters yet; use the type-erasure generic path instead
    --> ui-tests/generic-per-mono-unsupported.rs:106:8
     |
 106 |     fn get_lifetime<'a, T>(this: &'a LifetimeHolder<'a>) -> T;
     |        ^^^^^^^^^^^^
 
-error: `assert_no_shim` cannot be used with `generic_per_mono`, which always generates one shim per monomorphisation
-   --> ui-tests/generic-per-mono-unsupported.rs:117:38
+error: `assert_no_shim` cannot be used with `experimental_generic_mono`, which always generates one shim per monomorphisation
+   --> ui-tests/generic-per-mono-unsupported.rs:117:47
     |
-117 |     #[wasm_bindgen(generic_per_mono, assert_no_shim)]
-    |                                      ^^^^^^^^^^^^^^
+117 |     #[wasm_bindgen(experimental_generic_mono, assert_no_shim)]
+    |                                               ^^^^^^^^^^^^^^
 
-error: `reexport` cannot be used with `generic_per_mono`, because one binding is manufactured per monomorphisation and there is no single shim to reexport; remove the reexport or use the type-erasure generic path
+error: `reexport` cannot be used with `experimental_generic_mono`, because one binding is manufactured per monomorphisation and there is no single shim to reexport; remove the reexport or use the type-erasure generic path
    --> ui-tests/generic-per-mono-unsupported.rs:123:8
     |
 123 |     fn reexported<T>(x: T);

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -74,7 +74,7 @@ macro_rules! shared_api {
             structural: bool,
             function: Function<'a>,
             // Whether this import uses the per-monomorphisation generic path
-            // (`#[wasm_bindgen(generic_per_mono)]`) and is therefore bound per
+            // (`#[wasm_bindgen(experimental_generic_mono)]`) and is therefore bound per
             // concrete instantiation via the `__wbindgen_describe_generic_import`
             // marker rather than a single named descriptor shim. (Type-erasure
             // generic imports do not set this; they bind like normal imports.)

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -24,7 +24,7 @@
 // CLI's exact-string check (`verify_schema_matches` in `wasm-bindgen-cli-support`) would then
 // wave through a genuinely incompatible macro/CLI pair. Hence "next unreleased version", and
 // hence only one bump per release cycle however many schema changes land in it.
-const APPROVED_SCHEMA_FILE_HASH: &str = "17878099116568217446";
+const APPROVED_SCHEMA_FILE_HASH: &str = "3669243020486715919";
 
 #[test]
 fn schema_version() {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -77,7 +77,7 @@
       - [`catch`](./reference/attributes/on-js-imports/catch.md)
       - [`constructor`](./reference/attributes/on-js-imports/constructor.md)
       - [`extends`](./reference/attributes/on-js-imports/extends.md)
-      - [`generic_per_mono`](./reference/attributes/on-js-imports/generic_per_mono.md)
+      - [`experimental_generic_mono`](./reference/attributes/on-js-imports/experimental_generic_mono.md)
       - [`getter` and `setter`](./reference/attributes/on-js-imports/getter-and-setter.md)
       - [`final`](./reference/attributes/on-js-imports/final.md)
       - [`indexing_getter`, `indexing_setter`, and `indexing_deleter`](./reference/attributes/on-js-imports/indexing-getter-setter-deleter.md)

--- a/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
+++ b/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
@@ -1,4 +1,4 @@
-# `generic_per_mono`
+# `experimental_generic_mono`
 
 > **⚠️ Experimental.** This attribute is experimental and its behaviour may
 > change, or it may be removed, in any release. The set of supported signature
@@ -14,7 +14,7 @@ generated works for all instantiations. That is described in
 [Working with wasm-bindgen Generics](../../working-with-generics.md), and it is
 why `T` normally has to be a JS type (`JsGeneric`) rather than a Rust one.
 
-`generic_per_mono` opts a single import out of erasure. Instead of one erased
+`experimental_generic_mono` opts a single import out of erasure. Instead of one erased
 binding, `wasm-bindgen` generates **one binding per monomorphisation**, each with
 its own descriptor, so arguments and return values are marshalled at their
 concrete types:
@@ -24,7 +24,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(js_namespace = console, generic_per_mono)]
+    #[wasm_bindgen(js_namespace = console, experimental_generic_mono)]
     fn log<T>(value: T);
 }
 
@@ -39,7 +39,7 @@ which the erasure path does not allow.
 
 ## When to use it
 
-Reach for `generic_per_mono` when you want one Rust signature to serve several
+Reach for `experimental_generic_mono` when you want one Rust signature to serve several
 *Rust* types and you care about how they marshal. Reach for the default erasure
 path when you are modelling JS generics (`Array<T>`, `Promise<T>`) and want a
 single binding for all of them.
@@ -59,12 +59,12 @@ predicates all work:
 ```rust
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn sum_items<T>(items: T) -> f64
     where
         T: IntoIterator<Item = u32>;
 
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn double<T>(value: T) -> T
     where
         for<'a> &'a T: core::ops::Add<&'a T, Output = T>;
@@ -93,7 +93,7 @@ interchangeable:
 ```rust
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(js_namespace = console, generic_per_mono)]
+    #[wasm_bindgen(js_namespace = console, experimental_generic_mono)]
     fn log(value: impl core::fmt::Debug);
 }
 
@@ -113,7 +113,7 @@ synthesized parameter:
 ```rust
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn mix<T>(label: T, values: Vec<impl Clone>);
 }
 ```
@@ -130,7 +130,7 @@ Lifetime parameters on the function are supported, including lifetime bounds
 ```rust
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     fn log_ref<'a, T>(value: &'a T);
 }
 ```
@@ -143,7 +143,7 @@ receiver to the rest of the call:
 extern "C" {
     type Widget;
 
-    #[wasm_bindgen(method, generic_per_mono)]
+    #[wasm_bindgen(method, experimental_generic_mono)]
     fn set<'a, T>(this: &'a Widget, value: &'a T);
 }
 ```
@@ -158,7 +158,7 @@ needs the same hoisting machinery class-level type parameters do; see
 
 ## Other attributes
 
-`generic_per_mono` composes with the usual import attributes — `method`,
+`experimental_generic_mono` composes with the usual import attributes — `method`,
 `static_method_of`, `constructor`, `getter`, `setter`, `structural`, `final`,
 `indexing_getter`, `indexing_setter`, `indexing_deleter`, `js_namespace`,
 `js_name`, `catch`, `variadic`, and `slice_to_array` — and the resulting JS
@@ -172,18 +172,18 @@ rejected, see [Unsupported shapes](#unsupported-shapes).
 ```rust
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(generic_per_mono)]
+    #[wasm_bindgen(experimental_generic_mono)]
     async fn round_trip<T>(value: T) -> T;
 }
 ```
 
 ## Applying it to a whole block
 
-`generic_per_mono` can also go on the `extern "C"` block, which every function in
+`experimental_generic_mono` can also go on the `extern "C"` block, which every function in
 the block then inherits:
 
 ```rust
-#[wasm_bindgen(generic_per_mono)]
+#[wasm_bindgen(experimental_generic_mono)]
 extern "C" {
     fn log_one<T>(x: T);
     fn log_two<T>(a: u32, b: T) -> T;
@@ -195,21 +195,21 @@ least one type parameter, so a non-generic import in the block is left alone and
 binds through the ordinary single shim. A block can therefore mix the two freely:
 
 ```rust
-#[wasm_bindgen(generic_per_mono)]
+#[wasm_bindgen(experimental_generic_mono)]
 extern "C" {
     fn log_generic<T>(x: T); // per-monomorphisation
     fn log_u32(x: u32);      // ordinary import, unaffected
 }
 ```
 
-Writing `generic_per_mono` directly on a non-generic function is still an error,
+Writing `experimental_generic_mono` directly on a non-generic function is still an error,
 since there you asked for something that cannot be done.
 
 ## Unsupported shapes
 
 These are rejected at compile time with a diagnostic pointing at the offending
 declaration. Each generally keeps working on the type-erasure path, so the fix is
-usually to drop `generic_per_mono`:
+usually to drop `experimental_generic_mono`:
 
 * **Generic parameters on the imported *type*** (class-level generics),
   whether a type parameter (`this: &Holder<T>`) or a lifetime
@@ -242,20 +242,20 @@ usually to drop `generic_per_mono`:
   rejected rather than silently ignored.
 * **An argument whose pattern is not a plain name or `_`** (for example a tuple
   pattern such as `fn f<T>((a, b): (u32, u32), x: T)`), reported as
-  `unsupported pattern in generic_per_mono imported function`. The generated
+  `unsupported pattern in experimental_generic_mono imported function`. The generated
   per-monomorphisation shim has to forward each argument by name, so it needs a
   binding it can name. Give the argument a single identifier instead.
 
-**Const generic parameters** are also rejected, but not by `generic_per_mono`:
+**Const generic parameters** are also rejected, but not by `experimental_generic_mono`:
 `wasm-bindgen` does not support them on *any* generic import, erased or not, and
-reports `unsupported in wasm-bindgen generics`. Dropping `generic_per_mono` will
+reports `unsupported in wasm-bindgen generics`. Dropping `experimental_generic_mono` will
 not help.
 
 ### Colliding imports
 
 Everything above is reported by the macro, at compile time. One failure is
 reported later, by the `wasm-bindgen` CLI, because it cannot be detected until
-the whole module is linked: two `generic_per_mono` imports that agree on every
+the whole module is linked: two `experimental_generic_mono` imports that agree on every
 input to the shim key and differ *only* in an attribute that the key does not
 hash.
 

--- a/guide/src/reference/attributes/on-js-imports/slice_to_array.md
+++ b/guide/src/reference/attributes/on-js-imports/slice_to_array.md
@@ -82,7 +82,7 @@ fresh JS string.
   parameter `T` is rejected at compile time, because
   `VectorRefIntoWasmAbi` is implemented per concrete ABI shape and no
   bound the caller can write makes an arbitrary `T` satisfy it. This
-  applies on both the type-erasure generic path and `generic_per_mono`.
+  applies on both the type-erasure generic path and `experimental_generic_mono`.
   The element type must be concrete, e.g. `&[u16]`. A concrete element type
   in a generic function is fine — it is the element type that has to be
   concrete, not the function. Note that `slice_to_array` is inheritable

--- a/guide/src/reference/working-with-generics.md
+++ b/guide/src/reference/working-with-generics.md
@@ -26,7 +26,7 @@ Wasm-bindgen generics use **type erasure** to provide rich typing information in
 
 Currently, all of `js-sys` now supports experimental type erased generics, with `web-sys` still pending.
 
-> Type erasure is the default, and is what the rest of this page describes. An individual *imported function* can opt out of it with [`#[wasm_bindgen(generic_per_mono)]`](./attributes/on-js-imports/generic_per_mono.md), which generates one binding per monomorphisation instead of one erased binding. That lets a generic import be instantiated at ordinary Rust types (`u32`, `String`, `bool`) — which erasure does not allow, since erasure requires `T` to be a JS type — at the cost of a JS shim per instantiation. See [Choosing between the two](#choosing-between-the-two) below.
+> Type erasure is the default, and is what the rest of this page describes. An individual *imported function* can opt out of it with [`#[wasm_bindgen(experimental_generic_mono)]`](./attributes/on-js-imports/experimental_generic_mono.md), which generates one binding per monomorphisation instead of one erased binding. That lets a generic import be instantiated at ordinary Rust types (`u32`, `String`, `bool`) — which erasure does not allow, since erasure requires `T` to be a JS type — at the cost of a JS shim per instantiation. See [Choosing between the two](#choosing-between-the-two) below.
 
 > When passing a typed value (e.g., `Array<Number>`) to a function expecting a wider type (e.g., `&Array<JsValue>`), use the [`upcast()`](#upcasting-types) method: `my_array.upcast()`. This is a zero-cost compile-time conversion.
 
@@ -121,7 +121,7 @@ extern "C" {
 
 There are two ways a generic import can be bound, and they suit different jobs:
 
-|                             | Type erasure (default)                        | [`generic_per_mono`](./attributes/on-js-imports/generic_per_mono.md) |
+|                             | Type erasure (default)                        | [`experimental_generic_mono`](./attributes/on-js-imports/experimental_generic_mono.md) |
 | --------------------------- | --------------------------------------------- | ------------------------------------------------------------------- |
 | JS bindings generated       | One, shared by all instantiations             | One per monomorphisation                                            |
 | How `T` crosses the ABI     | Boxed to `JsValue` (via `ErasableGeneric`)    | At its concrete type (`u32` as a number, `String` as a string)      |
@@ -131,14 +131,14 @@ There are two ways a generic import can be bound, and they suit different jobs:
 
 Use erasure when you are modelling a JS generic — `Array<T>`, `Promise<T>`, a
 container whose element type only matters to Rust's type checker. Use
-`generic_per_mono` when one Rust signature should serve several *Rust* types and
+`experimental_generic_mono` when one Rust signature should serve several *Rust* types and
 the concrete marshalling is the point, e.g. a `log<T>` that should pass a `u32`
 as a number rather than boxing it.
 
-`generic_per_mono` also rejects a number of shapes that erasure accepts
+`experimental_generic_mono` also rejects a number of shapes that erasure accepts
 (generic parameters on the imported *type*, `&mut T`, generic `slice_to_array`
 element types, and others); those are listed on
-[its own page](./attributes/on-js-imports/generic_per_mono.md#unsupported-shapes).
+[its own page](./attributes/on-js-imports/experimental_generic_mono.md#unsupported-shapes).
 
 ## The ErasableGeneric Trait
 

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -1,5 +1,5 @@
 //! Runtime coverage for argument and return shapes in
-//! `#[wasm_bindgen(generic_per_mono)]` imports whose failure modes are silent —
+//! `#[wasm_bindgen(experimental_generic_mono)]` imports whose failure modes are silent —
 //! the generated JS looks correct in a snapshot either way.
 //!
 //! - `&mut [u16]`: must be a live view into wasm memory, so JS's writes reach
@@ -24,41 +24,41 @@ use wasm_bindgen_test::*;
 extern "C" {
     // `&mut` to a *concrete* type inside a generic import. Binds exactly as on
     // the non-generic path: a mutable typed-array view that is written back.
-    #[wasm_bindgen(generic_per_mono, js_name = fillSlice)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = fillSlice)]
     fn fill_slice<T>(xs: &mut [u16], base: T);
 
-    #[wasm_bindgen(generic_per_mono, js_name = withCallback)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = withCallback)]
     fn with_callback<T>(f: &mut dyn FnMut(u32), times: T);
 
-    #[wasm_bindgen(generic_per_mono, catch, js_name = tryGet)]
+    #[wasm_bindgen(experimental_generic_mono, catch, js_name = tryGet)]
     fn try_get<T>(key: u32) -> Result<T, JsValue>;
 
-    #[wasm_bindgen(generic_per_mono, catch, js_name = tryGetString)]
+    #[wasm_bindgen(experimental_generic_mono, catch, js_name = tryGetString)]
     fn try_get_string<T>(key: u32) -> Result<T, JsValue>;
 
-    #[wasm_bindgen(generic_per_mono, js_name = optEcho)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = optEcho)]
     fn opt_echo<T>(x: Option<T>) -> Option<T>;
 
-    #[wasm_bindgen(generic_per_mono, js_name = optDescribe)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = optDescribe)]
     fn opt_describe<T>(x: Option<T>) -> String;
 
     // One import across the three string/number wire shapes: `&str` crosses as
     // a borrowed (ptr, len) pair with no free, `String` as an owned buffer the
     // shim frees, `u32` as a plain scalar. JS reports `typeof` plus the value,
     // so marshalling the wrong wire form surfaces as a mismatched value.
-    #[wasm_bindgen(generic_per_mono, js_name = describeAny)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = describeAny)]
     fn describe_any<T>(x: T) -> String;
 
     // A shared slice with a *generic* element type: `&[T]` takes the `&T`
     // HRTB route (`for<'a> &'a [T]: IntoWasmAbi`) rather than the
     // concrete-slice route, and each element type gets its own typed-array
     // view.
-    #[wasm_bindgen(generic_per_mono, js_name = sumSlice)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = sumSlice)]
     fn sum_slice<T>(xs: &[T]) -> f64;
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_mut_slice_is_written_back() {
+fn experimental_generic_mono_mut_slice_is_written_back() {
     let mut xs = [0u16; 4];
 
     fill_slice(&mut xs, 10u32);
@@ -73,7 +73,7 @@ fn generic_per_mono_mut_slice_is_written_back() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_mut_closure_is_invoked() {
+fn experimental_generic_mono_mut_closure_is_invoked() {
     let mut seen = Vec::new();
     {
         let mut push = |v: u32| seen.push(v);
@@ -92,7 +92,7 @@ fn generic_per_mono_mut_closure_is_invoked() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_catch_ok_path() {
+fn experimental_generic_mono_catch_ok_path() {
     // Generic `Ok`, marshalled at each concrete type.
     assert_eq!(try_get::<u32>(3).unwrap(), 6);
     assert_eq!(try_get::<f64>(4).unwrap(), 8.0);
@@ -100,7 +100,7 @@ fn generic_per_mono_catch_ok_path() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_catch_throw_path() {
+fn experimental_generic_mono_catch_throw_path() {
     // A JS `throw` must surface as `Err`, not as a trap or a garbage `Ok`.
     let err = try_get::<u32>(0).unwrap_err();
     assert!(
@@ -115,7 +115,7 @@ fn generic_per_mono_catch_throw_path() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_option_in_signature() {
+fn experimental_generic_mono_option_in_signature() {
     // `Option<T>` as both argument and return, at two concrete `T`s.
     assert_eq!(opt_echo(Some(5u32)), Some(5u32));
     assert_eq!(opt_echo::<u32>(None), None);
@@ -135,18 +135,18 @@ extern "C" {
     // `variadic` spreads the final argument. It must be a sequence shape when it
     // mentions a type parameter, because iterability then depends on the
     // instantiation rather than on the declaration.
-    #[wasm_bindgen(generic_per_mono, variadic, js_name = variadicJoin)]
+    #[wasm_bindgen(experimental_generic_mono, variadic, js_name = variadicJoin)]
     fn variadic_join<T>(first: u32, rest: Vec<T>) -> String;
 
     // The same JS function fed from a borrowed generic-element slice instead
     // of an owned `Vec<T>` — the other sequence shape the non-sequence
     // variadic diagnostic recommends.
-    #[wasm_bindgen(generic_per_mono, variadic, js_name = variadicJoin)]
+    #[wasm_bindgen(experimental_generic_mono, variadic, js_name = variadicJoin)]
     fn variadic_join_slice<T>(first: u32, rest: &[T]) -> String;
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_variadic_actually_spreads() {
+fn experimental_generic_mono_variadic_actually_spreads() {
     // The JS side reports `rest.length`, so a binding that passed the `Vec` as a
     // single array argument instead of spreading it reports 1 rather than 3.
     assert_eq!(variadic_join(7, vec![1u32, 2, 3]), "7:3:1|2|3");
@@ -157,7 +157,7 @@ fn generic_per_mono_variadic_actually_spreads() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_string_and_number_wire_shapes() {
+fn experimental_generic_mono_string_and_number_wire_shapes() {
     assert_eq!(describe_any("borrowed"), "string:borrowed");
     assert_eq!(describe_any(String::from("owned")), "string:owned");
     assert_eq!(describe_any(13u32), "number:13");
@@ -165,14 +165,14 @@ fn generic_per_mono_string_and_number_wire_shapes() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_generic_element_slice() {
+fn experimental_generic_mono_generic_element_slice() {
     assert_eq!(sum_slice(&[1u32, 2, 3]), 6.0);
     assert_eq!(sum_slice(&[1.5f64, 2.5]), 4.0);
     assert_eq!(sum_slice::<u32>(&[]), 0.0);
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_variadic_slice_spreads() {
+fn experimental_generic_mono_variadic_slice_spreads() {
     assert_eq!(variadic_join_slice(7, &[1u32, 2, 3]), "7:3:1|2|3");
     assert_eq!(variadic_join_slice(8, &[1.5f64]), "8:1:1.5");
     assert_eq!(variadic_join_slice::<u32>(9, &[]), "9:0:");

--- a/tests/wasm/generic_import_async.rs
+++ b/tests/wasm/generic_import_async.rs
@@ -1,5 +1,5 @@
 //! Runtime coverage for `async` and `slice_to_array` per-monomorphisation
-//! generic imports (`#[wasm_bindgen(generic_per_mono)]`).
+//! generic imports (`#[wasm_bindgen(experimental_generic_mono)]`).
 //!
 //! These assert the *observable* behaviour, which a reference snapshot cannot:
 //! the reference test only pins the JS text, so it would happily accept a
@@ -14,19 +14,19 @@ use wasm_bindgen_test::*;
 extern "C" {
     // An `async` import returns a `Promise` across the ABI whatever it resolves
     // to, so a monomorphised `-> T` works even when `T` is not handle-shaped.
-    #[wasm_bindgen(generic_per_mono, js_name = asyncEcho)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = asyncEcho)]
     async fn async_echo<T>(x: T) -> T;
 
     // A concrete, non-handle return type through the same path.
-    #[wasm_bindgen(generic_per_mono, js_name = asyncLen)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = asyncLen)]
     async fn async_len<T>(x: T) -> u32;
 
     // `catch` monomorphises the `Ok` type and hard-codes `JsValue` as the error.
-    #[wasm_bindgen(generic_per_mono, catch, js_name = asyncTryEcho)]
+    #[wasm_bindgen(experimental_generic_mono, catch, js_name = asyncTryEcho)]
     async fn async_try_echo<T>(x: T, fail: bool) -> Result<T, JsValue>;
 
     // An `async` import with no return value still resolves to `JsValue`.
-    #[wasm_bindgen(generic_per_mono, js_name = asyncRecord)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = asyncRecord)]
     async fn async_record<T>(x: T);
 
     #[wasm_bindgen(js_name = takeLog)]
@@ -35,35 +35,35 @@ extern "C" {
     // `slice_to_array` hands JS an owned `Array`, not a view into wasm memory.
     // A primitive element type borrows the caller's slice; a `String` element
     // type hands over a freshly allocated buffer JS must free.
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = kindOf)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = kindOf)]
     fn kind_of_slice<T>(xs: &[u16], other: T) -> String;
 
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = kindOf)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = kindOf)]
     fn kind_of_str_slice<T>(xs: &[String], other: T) -> String;
 
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = kindOf)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = kindOf)]
     fn kind_of_opt_slice<T>(xs: Option<&[u16]>, other: T) -> String;
 
     // `Option<&[String]>` is the allocating-and-freeing element path *and* the
     // `Option` path at once.
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = joinOf)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = joinOf)]
     fn join_of_opt_str_slice<T>(xs: Option<&[String]>, other: T) -> String;
 
     // Without the attribute the same signature must still hand JS a view, so
     // these two together prove the attribute is what makes the difference.
-    #[wasm_bindgen(generic_per_mono, js_name = kindOf)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = kindOf)]
     fn kind_of_slice_plain<T>(xs: &[u16], other: T) -> String;
 
     // `slice_to_array` is not slice-shaped-only-by-accident: `Vec<T>` is not a
     // slice, so the attribute is a documented no-op there.
-    #[wasm_bindgen(generic_per_mono, slice_to_array, js_name = kindOf)]
+    #[wasm_bindgen(experimental_generic_mono, slice_to_array, js_name = kindOf)]
     fn kind_of_vec<T>(xs: Vec<T>) -> String;
 }
 
 // `slice_to_array` is inheritable from the enclosing block.
 #[wasm_bindgen(module = "tests/wasm/generic_import_async.js", slice_to_array)]
 extern "C" {
-    #[wasm_bindgen(generic_per_mono, js_name = kindOf)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = kindOf)]
     fn kind_of_block_slice<T>(xs: &[u16], other: T) -> String;
 }
 

--- a/tests/wasm/generic_import_bounds.rs
+++ b/tests/wasm/generic_import_bounds.rs
@@ -1,5 +1,5 @@
 //! Runtime coverage for user-written trait bounds on a per-monomorphisation
-//! generic import (`#[wasm_bindgen(generic_per_mono)]`).
+//! generic import (`#[wasm_bindgen(experimental_generic_mono)]`).
 //!
 //! Bounds are part of the declared signature's contract, so they must be carried
 //! through codegen rather than dropped. Two routes are exercised, because they
@@ -51,17 +51,17 @@ extern "C" {
     fn take_log() -> String;
 
     // Inline bound.
-    #[wasm_bindgen(generic_per_mono, js_name = record)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = record)]
     fn record_inline<T: Copy + Clone>(x: T);
 
     // `where` predicate.
-    #[wasm_bindgen(generic_per_mono, js_name = record)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = record)]
     fn record_where<T>(x: T)
     where
         T: Clone;
 
     // Inline and `where` bounds on the same signature, across two parameters.
-    #[wasm_bindgen(generic_per_mono, js_name = sum)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = sum)]
     fn sum_bounded<T: Copy, U>(a: T, b: U) -> f64
     where
         U: Copy;
@@ -70,23 +70,23 @@ extern "C" {
     // parameter with the same bound, so it exercises the identical
     // bound-carrying machinery as `record_inline` above, just declared the
     // sugared way with no named type parameter of its own.
-    #[wasm_bindgen(generic_per_mono, js_name = record)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = record)]
     fn record_impl_trait(x: impl Copy + Clone);
 
     // `impl Trait` mixed with a real, named, bounded type parameter in the
     // same signature.
-    #[wasm_bindgen(generic_per_mono, js_name = sum)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = sum)]
     fn sum_impl_trait_mixed<U: Copy>(a: impl Copy, b: U) -> f64;
 
     // The bound's associated type appears in argument and return position, so
     // the bound has to reach the shim for `T::Wire`'s ABI to resolve.
-    #[wasm_bindgen(generic_per_mono, js_name = echo)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = echo)]
     fn echo_wire<T>(x: T::Wire) -> T::Wire
     where
         T: Wire;
 
     // Higher-ranked `where` predicate.
-    #[wasm_bindgen(generic_per_mono, js_name = echo)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = echo)]
     fn echo_hrtb<T>(x: T) -> T
     where
         for<'a> &'a T: Clone,
@@ -97,27 +97,27 @@ extern "C" {
     // Inline bound on a real trait whose path carries an associated-type
     // binding. `T` is named nowhere else in the signature, so callers turbofish
     // and the binding is what makes the argument's type concrete.
-    #[wasm_bindgen(generic_per_mono, js_name = record)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = record)]
     fn record_iter_item<T: Iterator<Item = u32>>(x: T::Item);
 
     // The same trait as a `where` predicate, with the projection left open in
     // both argument and return position: the bound has to reach the shim for
     // `T::Item`'s ABI to resolve there.
-    #[wasm_bindgen(generic_per_mono, js_name = echo)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = echo)]
     fn echo_iter_item<T>(x: T::Item) -> T::Item
     where
         T: Iterator;
 
     // Only `ExactSizeIterator` is named, so `T::Item` resolves through its
     // `Iterator` supertrait rather than the bound's own trait.
-    #[wasm_bindgen(generic_per_mono, js_name = echo)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = echo)]
     fn echo_exact_size_item<T>(x: T::Item) -> T::Item
     where
         T: ExactSizeIterator;
 
     // A predicate whose bounded type is a projection rather than a bare
     // parameter, next to the bound that makes the projection nameable.
-    #[wasm_bindgen(generic_per_mono, js_name = echo)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = echo)]
     fn echo_cloneable_item<T>(x: T::Item) -> T::Item
     where
         T: Iterator,
@@ -127,12 +127,12 @@ extern "C" {
     // user's bounds and the synthesized `IntoWasmAbi`/`WasmDescribe` ones land
     // on the same parameter. `AsRef<[u32]>` also puts a plain type argument
     // (rather than an associated-type binding) in a bound path.
-    #[wasm_bindgen(generic_per_mono, js_name = sumAll)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = sumAll)]
     fn sum_all<T: IntoIterator<Item = u32> + AsRef<[u32]>>(xs: T) -> f64;
 
     // Higher-ranked predicate over a real trait: it is the *reference* that must
     // be iterable, which `T: IntoIterator` alone would not give.
-    #[wasm_bindgen(generic_per_mono, js_name = sumAll)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = sumAll)]
     fn sum_all_by_ref<T>(xs: T) -> f64
     where
         for<'a> &'a T: IntoIterator;

--- a/tests/wasm/generic_import_lifetime.rs
+++ b/tests/wasm/generic_import_lifetime.rs
@@ -1,5 +1,5 @@
 //! Runtime coverage for lifetime parameters on
-//! `#[wasm_bindgen(generic_per_mono)]` imports.
+//! `#[wasm_bindgen(experimental_generic_mono)]` imports.
 //!
 //! Lifetimes carry no runtime information — they are erased before the wasm
 //! ABI boundary — so the interesting part isn't marshalling, it's that the
@@ -16,11 +16,11 @@ use wasm_bindgen_test::*;
 extern "C" {
     // A named (rather than elided) lifetime on a bare shared reference to a
     // generic type parameter (`&'a T`).
-    #[wasm_bindgen(generic_per_mono, js_name = takeRefPrimitive)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = takeRefPrimitive)]
     fn take_ref_lifetime<'a, T>(x: &'a T) -> f64;
 
     // The same lifetime also appears in a `where T: 'a` bound.
-    #[wasm_bindgen(generic_per_mono, js_name = doubleRef)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = doubleRef)]
     fn double_ref<'a, T: 'a>(x: &'a T) -> T;
 
     // A named lifetime on a concrete (non-generic) argument, alongside an
@@ -29,14 +29,14 @@ extern "C" {
     // all — it's just an ordinary borrow of a concrete type — so this
     // exercises the shim redeclaring `'a` purely to name
     // `<&'a str as IntoWasmAbi>::Abi` in its own signature.
-    #[wasm_bindgen(generic_per_mono, js_name = concatStr)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = concatStr)]
     fn concat_str<'a, T>(s: &'a str, suffix: T) -> String;
 
     // Two lifetimes related by an *inline* outlives predicate (`<'a: 'b, 'b>`),
     // which — unlike a `where` predicate — has no carrier other than the
     // parameter list itself, so the shim has to reproduce the whole
     // declaration rather than just the bare names.
-    #[wasm_bindgen(generic_per_mono, js_name = joinStrs)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = joinStrs)]
     fn join_outlives<'a: 'b, 'b, T>(a: &'a str, b: &'b str, suffix: T) -> String;
 
     type Scaler;
@@ -48,35 +48,35 @@ extern "C" {
     // as `<&'a Scaler as IntoWasmAbi>`, so the generated wrapper has to bind
     // it as `&'a self`; a plain `&self` would borrow at an anonymous
     // caller-chosen lifetime that rustc cannot prove outlives `'a`.
-    #[wasm_bindgen(method, generic_per_mono, js_name = scale)]
+    #[wasm_bindgen(method, experimental_generic_mono, js_name = scale)]
     fn scale<'a, T>(this: &'a Scaler, x: T) -> f64;
 
     // The receiver's lifetime is shared with another argument, tying the two
     // borrows together for the duration of the call.
-    #[wasm_bindgen(method, generic_per_mono, js_name = scaleRef)]
+    #[wasm_bindgen(method, experimental_generic_mono, js_name = scaleRef)]
     fn scale_ref<'a, T>(this: &'a Scaler, x: &'a T) -> f64;
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_named_lifetime_ref() {
+fn experimental_generic_mono_named_lifetime_ref() {
     assert_eq!(take_ref_lifetime(&JsValue::from(5u32)), 6.0);
     assert_eq!(take_ref_lifetime(&JsValue::from(2.5f64)), 3.5);
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_lifetime_bound_on_type_param() {
+fn experimental_generic_mono_lifetime_bound_on_type_param() {
     assert_eq!(double_ref(&JsValue::from(4u32)), JsValue::from(8u32));
     assert_eq!(double_ref(&JsValue::from(1.5f64)), JsValue::from(3.0f64));
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_lifetime_on_unrelated_concrete_arg() {
+fn experimental_generic_mono_lifetime_on_unrelated_concrete_arg() {
     assert_eq!(concat_str("hi", 42u32), "hi:42");
     assert_eq!(concat_str("hi", String::from("there")), "hi:there");
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_inline_lifetime_outlives_bound() {
+fn experimental_generic_mono_inline_lifetime_outlives_bound() {
     let long = String::from("outer");
     {
         let short = String::from("inner");
@@ -89,14 +89,14 @@ fn generic_per_mono_inline_lifetime_outlives_bound() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_named_lifetime_on_receiver() {
+fn experimental_generic_mono_named_lifetime_on_receiver() {
     let scaler = Scaler::new(3.0);
     assert_eq!(scaler.scale(4u32), 12.0);
     assert_eq!(scaler.scale(0.5f64), 1.5);
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_receiver_lifetime_shared_with_argument() {
+fn experimental_generic_mono_receiver_lifetime_shared_with_argument() {
     let scaler = Scaler::new(10.0);
     let x = JsValue::from(7u32);
     assert_eq!(scaler.scale_ref(&x), 70.0);

--- a/tests/wasm/generic_import_methods.rs
+++ b/tests/wasm/generic_import_methods.rs
@@ -1,4 +1,4 @@
-//! Runtime coverage for `#[wasm_bindgen(generic_per_mono)]` on every
+//! Runtime coverage for `#[wasm_bindgen(experimental_generic_mono)]` on every
 //! *method-shaped* import: constructors, instance methods, static methods,
 //! getters and setters (plain, `structural` and `final`), and the `indexing_*`
 //! operations.
@@ -16,59 +16,59 @@ use wasm_bindgen_test::*;
 extern "C" {
     type Widget;
 
-    // `constructor` + `generic_per_mono`: `class_return_path()` retargets the
+    // `constructor` + `experimental_generic_mono`: `class_return_path()` retargets the
     // generated `impl` block to the *return* type's class, so the manufactured
     // binding attaches to `new Widget(..)`.
-    #[wasm_bindgen(constructor, generic_per_mono)]
+    #[wasm_bindgen(constructor, experimental_generic_mono)]
     fn new<T>(value: T) -> Widget;
 
     // Instance method. Two instantiations prove distinct per-mono shims on the
     // method path.
-    #[wasm_bindgen(method, generic_per_mono, js_name = set)]
+    #[wasm_bindgen(method, experimental_generic_mono, js_name = set)]
     fn set<T>(this: &Widget, value: T);
 
     // `&T` in a method argument, monomorphised at a JS-handle type, so the
     // handle's `IntoWasmAbi for &Widget` impl is what marshals it.
-    #[wasm_bindgen(method, generic_per_mono, js_name = attach)]
+    #[wasm_bindgen(method, experimental_generic_mono, js_name = attach)]
     fn attach<T>(this: &Widget, other: &T);
 
     // Static method.
-    #[wasm_bindgen(static_method_of = Widget, generic_per_mono, js_name = of)]
+    #[wasm_bindgen(static_method_of = Widget, experimental_generic_mono, js_name = of)]
     fn of<T>(value: T) -> Widget;
 
     // Getter with a generic *return*: every monomorphisation reads the same JS
     // property but marshals the result at its own concrete type.
-    #[wasm_bindgen(method, getter, generic_per_mono, js_name = value)]
+    #[wasm_bindgen(method, getter, experimental_generic_mono, js_name = value)]
     fn value<T>(this: &Widget) -> T;
 
-    #[wasm_bindgen(method, setter, generic_per_mono, js_name = value)]
+    #[wasm_bindgen(method, setter, experimental_generic_mono, js_name = value)]
     fn set_value<T>(this: &Widget, v: T);
 
     // `structural` accessors read/write the property directly on the receiver
     // rather than through a captured descriptor.
-    #[wasm_bindgen(method, getter, structural, generic_per_mono, js_name = tag)]
+    #[wasm_bindgen(method, getter, structural, experimental_generic_mono, js_name = tag)]
     fn tag<T>(this: &Widget) -> T;
 
-    #[wasm_bindgen(method, setter, structural, generic_per_mono, js_name = tag)]
+    #[wasm_bindgen(method, setter, structural, experimental_generic_mono, js_name = tag)]
     fn set_tag<T>(this: &Widget, v: T);
 
     // `final` captures the property descriptor from `Widget.prototype` once, at
     // instantiation time, and invokes it with `.call(receiver)`. Getting the
     // receiver wrong here is exactly the silent failure a snapshot cannot see.
-    #[wasm_bindgen(method, getter, final, generic_per_mono, js_name = kind)]
+    #[wasm_bindgen(method, getter, final, experimental_generic_mono, js_name = kind)]
     fn kind<T>(this: &Widget) -> T;
 
     // `indexing_*` emit `obj[prop]`, `obj[prop] = val` and `delete obj[prop]`,
     // and always require `structural` + `method`.
-    #[wasm_bindgen(method, structural, indexing_getter, generic_per_mono)]
+    #[wasm_bindgen(method, structural, indexing_getter, experimental_generic_mono)]
     fn get<T>(this: &Widget, prop: &str) -> T;
 
-    #[wasm_bindgen(method, structural, indexing_setter, generic_per_mono)]
+    #[wasm_bindgen(method, structural, indexing_setter, experimental_generic_mono)]
     fn set_indexed<T>(this: &Widget, prop: &str, val: T);
 
     // The deleter has no value parameter, so its type parameter appears only in
     // the *index* position.
-    #[wasm_bindgen(method, structural, indexing_deleter, generic_per_mono)]
+    #[wasm_bindgen(method, structural, indexing_deleter, experimental_generic_mono)]
     fn delete_indexed<T>(this: &Widget, prop: T);
 
     #[wasm_bindgen(js_name = widgetValue)]
@@ -86,7 +86,7 @@ extern "C" {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_constructor() {
+fn experimental_generic_mono_constructor() {
     let a = Widget::new(7u32);
     assert_eq!(widget_value(&a), JsValue::from(7u32));
     // The constructor ran, rather than the argument being handed to some other
@@ -100,7 +100,7 @@ fn generic_per_mono_constructor() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_method_receives_correct_receiver_and_value() {
+fn experimental_generic_mono_method_receives_correct_receiver_and_value() {
     let a = Widget::new(0u32);
     let b = Widget::new(0u32);
 
@@ -116,7 +116,7 @@ fn generic_per_mono_method_receives_correct_receiver_and_value() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_method_with_handle_ref_arg() {
+fn experimental_generic_mono_method_with_handle_ref_arg() {
     let host = Widget::new(0u32);
     let guest = Widget::new(42u32);
 
@@ -128,7 +128,7 @@ fn generic_per_mono_method_with_handle_ref_arg() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_static_method() {
+fn experimental_generic_mono_static_method() {
     let a = Widget::of(5u32);
     assert_eq!(widget_value(&a), JsValue::from(5u32));
     // `of` sets a distinct `_kind`, so this fails if the call was routed to the
@@ -140,7 +140,7 @@ fn generic_per_mono_static_method() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_getter_and_setter() {
+fn experimental_generic_mono_getter_and_setter() {
     let w = Widget::new(1u32);
 
     // Generic return, marshalled at each concrete type.
@@ -158,7 +158,7 @@ fn generic_per_mono_getter_and_setter() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_structural_getter_and_setter() {
+fn experimental_generic_mono_structural_getter_and_setter() {
     let w = Widget::new(0u32);
 
     w.set_tag(3u32);
@@ -170,7 +170,7 @@ fn generic_per_mono_structural_getter_and_setter() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_final_getter_resolves_against_the_receiver() {
+fn experimental_generic_mono_final_getter_resolves_against_the_receiver() {
     // `final` captures `Widget.prototype`'s descriptor once and invokes it with
     // `.call(receiver)`. Two receivers with different `_kind` values prove the
     // captured getter is applied to the argument rather than to a fixed object.
@@ -182,7 +182,7 @@ fn generic_per_mono_final_getter_resolves_against_the_receiver() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_indexing_getter_and_setter() {
+fn experimental_generic_mono_indexing_getter_and_setter() {
     let w = Widget::new(0u32);
 
     w.set_indexed("a", 1u32);
@@ -198,7 +198,7 @@ fn generic_per_mono_indexing_getter_and_setter() {
 }
 
 #[wasm_bindgen_test]
-fn generic_per_mono_indexing_deleter() {
+fn experimental_generic_mono_indexing_deleter() {
     let w = Widget::new(0u32);
 
     widget_set_prop(&w, "gone", &JsValue::from(1u32));

--- a/tests/wasm/generic_import_ref.rs
+++ b/tests/wasm/generic_import_ref.rs
@@ -1,6 +1,6 @@
 //! Runtime coverage for a bare shared reference to a generic type parameter
 //! (`&T`) in a per-monomorphisation generic import
-//! (`#[wasm_bindgen(generic_per_mono)]`).
+//! (`#[wasm_bindgen(experimental_generic_mono)]`).
 //!
 //! Each instantiation exercises a distinct referent shape:
 //! - `&RefThing`: a JS-handle type, marshalled by handle index.
@@ -18,11 +18,11 @@ extern "C" {
 
     // `&T` where `T` monomorphises to a JS-handle type: marshalled via the
     // handle's `IntoWasmAbi for &RefThing` impl.
-    #[wasm_bindgen(generic_per_mono, js_name = readRefThing)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = readRefThing)]
     fn read_ref_thing<T>(x: &T) -> f64;
 
     // `&T` where `T` monomorphises to `JsValue`: marshalled as an externref.
-    #[wasm_bindgen(generic_per_mono, js_name = echoRef)]
+    #[wasm_bindgen(experimental_generic_mono, js_name = echoRef)]
     fn echo_ref<T>(x: &T) -> JsValue;
 }
 


### PR DESCRIPTION
This renames the `generic_per_mono` attribute to `experimental_generic_mono`, applying the naming feedback from the #5230 review (https://github.com/wasm-bindgen/wasm-bindgen/pull/5230#issuecomment-5270299168) that was acknowledged but dropped before merge. The attribute has not shipped in a release — the 0.2.127 tag predates the #5230 merge — so the rename is non-breaking.

* Renames the attribute parse name and updates all user-facing error messages in `macro-support` and `cli-support` to match; internal identifiers keep the mechanism name since the experimental prefix is a temporary opt-in gate.
* Updates all attribute usages across ui-tests (with regenerated `.stderr` spans), `tests/wasm/generic_import_*`, cli tests, and reference tests.
* Renames the guide page to `experimental_generic_mono.md` and updates all cross-references.
* Consolidates the feature's changelog entries (#5230, #5272) into a single Unreleased entry under the new name. The #5230 entry had been added to the already-released 0.2.127 section, which it never shipped in, so it also moves to Unreleased as part of this.

Verified with the macro ui tests, the cli generic diagnostics tests, and the reference tests (reference outputs are unchanged, confirming the attribute name does not feed the shim key hash).
