### PR TITLE
Fix `--no-modules-global` being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@
   could remove.
   [#5292](https://github.com/wasm-bindgen/wasm-bindgen/issues/5292)
 
+* Fix `--no-modules-global` being ignored: the custom global name is now used
+  for the generated JS binding and TypeScript declarations, and the name is
+  validated as a JS identifier.
+  [#5286](https://github.com/wasm-bindgen/wasm-bindgen/issues/5286)
+
 ### Removed
 
 ## [0.2.127](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.126...0.2.127)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -920,15 +920,16 @@ impl<'a> Context<'a> {
 
         let mut ts = String::new();
 
-        if self.config.mode.no_modules() {
-            let mut iife = "
-            let wasm_bindgen = (function(exports) {
+        if let OutputMode::NoModules { global } = &self.config.mode {
+            let mut iife = format!(
+                "
+            let {global} = (function(exports) {{
             let script_src;
-            if (typeof document !== 'undefined' && document.currentScript !== null) {
+            if (typeof document !== 'undefined' && document.currentScript !== null) {{
                 script_src = new URL(document.currentScript.src, location.href).toString();
-            }
+            }}
             "
-            .to_owned();
+            );
             iife.push_str(&self.globals);
             iife.push_str(
                 "
@@ -937,7 +938,7 @@ impl<'a> Context<'a> {
                 ",
             );
             self.globals = iife;
-            ts = String::from("declare namespace wasm_bindgen {\n");
+            ts = format!("declare namespace {global} {{\n");
             ts.push_str(&self.typescript);
             ts.push_str("\n}");
         } else if matches!(self.config.mode, OutputMode::Emscripten) {
@@ -1276,7 +1277,6 @@ impl<'a> Context<'a> {
         let setup_function_declaration;
         let mut sync_init_function = String::new();
         let declare_or_export;
-
         let init_sync_fn = format!(
             "\
             /**\n\
@@ -1292,17 +1292,15 @@ impl<'a> Context<'a> {
             "
         );
 
-        if self.config.mode.no_modules() {
+        if let OutputMode::NoModules { global } = &self.config.mode {
             declare_or_export = "declare";
-            setup_function_declaration = "declare function wasm_bindgen";
+            setup_function_declaration = format!("declare function {global}");
 
-            // `initSync` is attached to the `wasm_bindgen` function object at
-            // runtime, so declare it in a namespace that merges with the
-            // `declare function wasm_bindgen` below.
+            // `initSync` is attached to the init function object at runtime.
             sync_init_function.push_str(&format!(
                 "\
                 declare type SyncInitInput = BufferSource | WebAssembly.Module;\n\n\
-                declare namespace wasm_bindgen {{\n\
+                declare namespace {global} {{\n\
                 {init_sync_fn}\
                 }}\n\n\
                 "
@@ -1317,7 +1315,7 @@ impl<'a> Context<'a> {
                 "
             ));
 
-            setup_function_declaration = "export default function __wbg_init";
+            setup_function_declaration = "export default function __wbg_init".to_string();
         }
         Ok(format!(
             "\n\

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -241,6 +241,9 @@ impl Bindgen {
     }
 
     pub fn no_modules_global(&mut self, name: &str) -> Result<&mut Bindgen, Error> {
+        if !wasm_bindgen_shared::identifier::is_valid_ident(name) {
+            bail!("`--no-modules-global` must be a valid JS identifier, got `{name}`");
+        }
         match &mut self.mode {
             OutputMode::NoModules { global } => *global = name.to_string(),
             _ => bail!("can only specify `--no-modules-global` with `--target no-modules`"),

--- a/crates/cli/tests/reference/no-modules-global.d.ts
+++ b/crates/cli/tests/reference/no-modules-global.d.ts
@@ -14,6 +14,20 @@ declare interface InitOutput {
     readonly __wbindgen_start: () => void;
 }
 
+declare type SyncInitInput = BufferSource | WebAssembly.Module;
+
+declare namespace custom_global {
+    /**
+     * Instantiates the given `module`, which can either be bytes or
+     * a precompiled `WebAssembly.Module`.
+     *
+     * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+     *
+     * @returns {InitOutput}
+     */
+    export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+}
+
 /**
  * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
  * for everything else, calls `WebAssembly.instantiate` directly.

--- a/crates/cli/tests/reference/no-modules-global.d.ts
+++ b/crates/cli/tests/reference/no-modules-global.d.ts
@@ -1,0 +1,25 @@
+declare namespace custom_global {
+    /* tslint:disable */
+    /* eslint-disable */
+
+    export function add(a: number, b: number): number;
+
+}
+declare type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+declare interface InitOutput {
+    readonly memory: WebAssembly.Memory;
+    readonly add: (a: number, b: number) => number;
+    readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_start: () => void;
+}
+
+/**
+ * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+ * for everything else, calls `WebAssembly.instantiate` directly.
+ *
+ * @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+ *
+ * @returns {Promise<InitOutput>}
+ */
+declare function custom_global (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/crates/cli/tests/reference/no-modules-global.js
+++ b/crates/cli/tests/reference/no-modules-global.js
@@ -1,0 +1,131 @@
+let custom_global = (function(exports) {
+    let script_src;
+    if (typeof document !== 'undefined' && document.currentScript !== null) {
+        script_src = new URL(document.currentScript.src, location.href).toString();
+    }
+
+    /**
+     * @param {number} a
+     * @param {number} b
+     * @returns {number}
+     */
+    function add(a, b) {
+        const ret = wasm.add(a, b);
+        return ret >>> 0;
+    }
+    exports.add = add;
+    function __wbg_get_imports() {
+        const import0 = {
+            __proto__: null,
+            __wbindgen_init_externref_table: function() {
+                const table = wasm.__wbindgen_externrefs;
+                const offset = table.grow(4);
+                table.set(0, undefined);
+                table.set(offset + 0, undefined);
+                table.set(offset + 1, null);
+                table.set(offset + 2, true);
+                table.set(offset + 3, false);
+            },
+        };
+        return {
+            __proto__: null,
+            "./reference_test_bg.js": import0,
+        };
+    }
+
+    let wasmModule, wasmInstance, wasm;
+    function __wbg_finalize_init(instance, module) {
+        wasmInstance = instance;
+        wasm = instance.exports;
+        wasmModule = module;
+        wasm.__wbindgen_start();
+        return wasm;
+    }
+
+    async function __wbg_load(module, imports) {
+        if (typeof Response === 'function' && module instanceof Response) {
+            if (!module.ok) {
+                throw new Error(`failed to fetch Wasm: ${module.status} ${module.statusText} fetching '${module.url}'`);
+            }
+
+            if (typeof WebAssembly.instantiateStreaming === 'function') {
+                try {
+                    return await WebAssembly.instantiateStreaming(module, imports);
+                } catch (e) {
+                    const validResponse = expectedResponseType(module.type);
+
+                    if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                        console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                    } else { throw e; }
+                }
+            }
+
+            const bytes = await module.arrayBuffer();
+            return await WebAssembly.instantiate(bytes, imports);
+        } else {
+            const instance = await WebAssembly.instantiate(module, imports);
+
+            if (instance instanceof WebAssembly.Instance) {
+                return { instance, module };
+            } else {
+                return instance;
+            }
+        }
+
+        function expectedResponseType(type) {
+            switch (type) {
+                case 'basic': case 'cors': case 'default': return true;
+            }
+            return false;
+        }
+    }
+
+    function initSync(module) {
+        if (wasm !== undefined) return wasm;
+
+
+        if (module !== undefined) {
+            if (Object.getPrototypeOf(module) === Object.prototype) {
+                ({module} = module)
+            } else {
+                console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+            }
+        }
+
+        const imports = __wbg_get_imports();
+        if (!(module instanceof WebAssembly.Module)) {
+            module = new WebAssembly.Module(module);
+        }
+        const instance = new WebAssembly.Instance(module, imports);
+        return __wbg_finalize_init(instance, module);
+    }
+
+    async function __wbg_init(module_or_path) {
+        if (wasm !== undefined) return wasm;
+
+
+        if (module_or_path !== undefined) {
+            if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+                ({module_or_path} = module_or_path)
+            } else {
+                console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+            }
+        }
+
+        if (module_or_path === undefined && script_src !== undefined) {
+            module_or_path = script_src.replace(/\.js$/, "_bg.wasm");
+        }
+        const imports = __wbg_get_imports();
+
+        if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+            module_or_path = fetch(module_or_path);
+        }
+
+        const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+        return __wbg_finalize_init(instance, module);
+    }
+
+    return Object.assign(__wbg_init, { initSync }, exports);
+})({ __proto__: null });

--- a/crates/cli/tests/reference/no-modules-global.rs
+++ b/crates/cli/tests/reference/no-modules-global.rs
@@ -1,0 +1,8 @@
+// FLAGS: --target=no-modules --no-modules-global=custom_global
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}

--- a/crates/cli/tests/reference/no-modules-global.wat
+++ b/crates/cli/tests/reference/no-modules-global.wat
@@ -1,0 +1,13 @@
+(module $no_modules_global_reftest.wasm
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (type (;1;) (func))
+  (import "./reference_test_bg.js" "__wbindgen_init_externref_table" (func (;0;) (type 1)))
+  (table $__wbindgen_externrefs (;0;) 1024 externref)
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "add" (func $add))
+  (export "__wbindgen_externrefs" (table $__wbindgen_externrefs))
+  (export "__wbindgen_start" (func 0))
+  (func $add (;1;) (type 0) (param i32 i32) (result i32))
+  (@custom "target_features" (after code) "\08+\0bbulk-memory+\0fbulk-memory-opt+\16call-indirect-overlong+\0amultivalue+\0fmutable-globals+\13nontrapping-fptoint+\0freference-types+\08sign-ext")
+)


### PR DESCRIPTION
This fixes the `--no-modules-global` flag, resolves #5286.

The flag is parsed and stored into `OutputMode::NoModules { global }`, but codegen never read the field back — every match used `NoModules { .. }` — so the generated output always hardcoded `wasm_bindgen`. The JS side regressed in #4879 when the finalize refactor replaced the interpolated global with a hardcoded IIFE binding, while the TypeScript declarations had hardcoded the name since before that.

* The no-modules IIFE binding, `declare namespace`, and `declare function` init declaration now all use the configured global name.
* `Bindgen::no_modules_global` now validates the name as a JS identifier, since an invalid name previously produced syntactically broken JS silently.

```js
let wasm_bindgen = (function(exports) {
```

now respects the flag:

```js
let custom_global = (function(exports) {
```

Test coverage is a new `no-modules-global` reference test fixture passing `--target=no-modules --no-modules-global=custom_global`, which fails against the previous codegen and would have caught the original regression.