### PR TITLE
Error helpfully when the wasm-bindgen custom section has been stripped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@
 
 ### Fixed
 
+* The CLI now reports an actionable error when the `__wasm_bindgen_unstable`
+  custom section is missing from a module that still contains wasm-bindgen
+  shims (e.g. stripped by `llvm-objcopy --strip-all`, which removes all custom
+  sections since LLVM 23), instead of the confusing
+  ``import of `X` doesn't have an adapter listed``.
+  [#5268](https://github.com/wasm-bindgen/wasm-bindgen/issues/5268)
+
 * Fix `js-sys` wasm64 build with `atomics` feature.
   [#5274](https://github.com/wasm-bindgen/wasm-bindgen/issues/5274)
 

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -2833,6 +2833,37 @@ to open an issue at https://github.com/wasm-bindgen/wasm-bindgen/issues!
             ret.push(<decode::Program as decode::Decode>::decode_all(next));
         }
     }
+
+    // If the module clearly went through the wasm-bindgen macro (shim imports
+    // or descriptor exports are present) but no programs were found, the
+    // custom section was stripped by some post-link processing. Give an
+    // actionable error now rather than a confusing missing-adapter error
+    // later.
+    if ret.is_empty() {
+        let has_shims = module
+            .imports
+            .iter()
+            .any(|i| i.module == PLACEHOLDER_MODULE)
+            || module
+                .exports
+                .iter()
+                .any(|e| e.name.starts_with("__wbindgen_describe"));
+        if has_shims {
+            bail!(
+                "the `__wasm_bindgen_unstable` custom section is missing, but the module \
+                 still contains wasm-bindgen shims
+
+This section carries the metadata wasm-bindgen needs to process the module, and
+is usually lost by running a post-processing tool that strips custom sections,
+such as `llvm-objcopy --strip-all` (which removes all custom sections since
+LLVM 23) or `wasm-strip`, on the module before `wasm-bindgen`.
+
+Make sure `wasm-bindgen` runs on the Wasm file directly produced by the linker,
+before any such stripping tool."
+            );
+        }
+    }
+
     Ok(ret)
 }
 

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -4293,3 +4293,61 @@ describe('jspi async-only module', () => {
 "#,
     );
 }
+
+#[test]
+fn stripped_custom_section_errors_helpfully() {
+    // Post-processing tools (e.g. `llvm-objcopy --strip-all`, which since
+    // LLVM 23 removes all custom sections) can strip `__wasm_bindgen_unstable`
+    // from a module before the CLI runs. The module still contains all the
+    // wasm-bindgen shims, so this must produce an actionable error rather
+    // than the confusing "import of `X` doesn't have an adapter listed".
+    let mut project = Project::new("stripped_custom_section_errors_helpfully");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            extern "C" {
+                fn alert(s: &str);
+            }
+
+            #[wasm_bindgen]
+            pub fn greet() {
+                alert("hi");
+            }
+        "#,
+    );
+
+    let built = project.build();
+    let mut module = ModuleConfig::new().parse_file(&built).unwrap();
+    while module
+        .customs
+        .remove_raw("__wasm_bindgen_unstable")
+        .is_some()
+    {}
+    let stripped = project.root.join("stripped.wasm");
+    module.emit_wasm_file(&stripped).unwrap();
+
+    let out_dir = project.root.join("pkg-stripped");
+    fs::create_dir_all(&out_dir).unwrap();
+    let err = wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--target".as_ref(),
+        "web".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir.as_os_str(),
+        stripped.as_os_str(),
+    ])
+    .unwrap_err();
+
+    let err = format!("{err:#}");
+    assert!(
+        err.contains("`__wasm_bindgen_unstable` custom section is missing"),
+        "expected an actionable missing-section error, got: {err}"
+    );
+    assert!(
+        err.contains("strip"),
+        "error should point at custom-section stripping, got: {err}"
+    );
+}


### PR DESCRIPTION
This improves the CLI error for stripped modules, related to #5268 (the primary bug there lives in the build pipeline that strips the module before running wasm-bindgen, so this does not fully resolve it).

When a post-processing tool removes custom sections from a linked module before `wasm-bindgen` runs, the `__wasm_bindgen_unstable` section carrying all of the bindgen metadata silently disappears while the wasm-bindgen shims themselves survive. The CLI then decodes zero programs, registers no adapters, and eventually fails deep in the verification pass with:

```
error: import of `__wbg_location_5d269cf0aa99107a` doesn't have an adapter listed
```

which gives no hint about the actual problem. This has become much easier to hit since LLVM 23, where `llvm-objcopy --strip-all` now removes all non-engine-interpreted custom sections from Wasm files (llvm/llvm-project#180246) — toolchains invoking `rust-objcopy --strip-all` between the link and `wasm-bindgen` now destroy the metadata section where they previously preserved it.

* `extract_programs` now bails with an actionable error when no `__wasm_bindgen_unstable` section is found but the module still contains `__wbindgen_placeholder__` imports or `__wbindgen_describe_*` exports, pointing at custom-section stripping as the cause.
* Modules with no wasm-bindgen usage at all are unaffected and continue to pass through.

Test coverage: a new CLI test builds a normal wasm-bindgen project, strips the `__wasm_bindgen_unstable` section from the produced module, and asserts the CLI reports the missing-section error (previously it reproduced the misleading missing-adapter error above). Also verified manually against a real dioxus-cli-produced module from the #5268 pipeline.
