### PR TITLE
Avoid RefCell::borrow_mut panic paths in externref table management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@
 * Fix `js-sys` wasm64 build with `atomics` feature.
   [#5274](https://github.com/wasm-bindgen/wasm-bindgen/issues/5274)
 
+* Removed the last panicking code paths from `externref` table management:
+  `RefCell::borrow_mut()` embedded panic location data (including the source
+  path string) in `.rodata` of optimized builds, which not even `wasm-opt`
+  could remove.
+  [#5292](https://github.com/wasm-bindgen/wasm-bindgen/issues/5292)
+
 ### Removed
 
 ## [0.2.127](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.126...0.2.127)

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -853,6 +853,64 @@ fn constructor_cannot_return_option_struct() {
         .unwrap_err();
 }
 
+/// The externref table management in `src/externref.rs` must not pull in any
+/// panicking infrastructure in optimized builds: `RefCell::borrow_mut()`'s
+/// `#[track_caller]` panic path materializes a `core::panic::Location`
+/// (including the full source path string) in `.rodata`, which not even
+/// `wasm-opt` can remove (data segments are never GC'd). With debug assertions
+/// disabled no `externref.rs` location data may remain in the compiled wasm.
+#[test]
+fn externref_table_ops_have_no_panic_location_data() {
+    let mut project = Project::new("externref_no_panic_location_data");
+    project
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+                #[wasm_bindgen]
+                pub fn take(v: JsValue) -> JsValue {
+                    v
+                }
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            &format!(
+                "
+                    [package]
+                    name = \"externref_no_panic_location_data\"
+                    authors = []
+                    version = \"1.0.0\"
+                    edition = '2021'
+
+                    [dependencies]
+                    wasm-bindgen = {{ path = '{}' }}
+
+                    [lib]
+                    crate-type = ['cdylib']
+
+                    [workspace]
+
+                    [profile.dev]
+                    opt-level = 's'
+                    debug = false
+                    debug-assertions = false
+                    overflow-checks = false
+                    codegen-units = 1
+                ",
+                REPO_ROOT.display(),
+            ),
+        );
+    let wasm = project.build().to_owned();
+
+    let bytes = fs::read(&wasm).unwrap();
+    let needle = b"src/externref.rs";
+    assert!(
+        !bytes.windows(needle.len()).any(|w| w == needle),
+        "optimized wasm embeds panic location data for src/externref.rs"
+    );
+}
+
 /// Shared Rust source for termination / reset-state tests.
 const TERMINATION_LIB_RS: &str = r#"
                 use wasm_bindgen::prelude::*;

--- a/src/externref.rs
+++ b/src/externref.rs
@@ -128,8 +128,14 @@ static HEAP_SLAB: __rt::ThreadLocalWrapper<RefCell<Slab>> =
 
 #[no_mangle]
 pub extern "C" fn __externref_table_alloc() -> u32 {
+    // usage of `try_borrow_mut` thwarts panicking infrastructure (including
+    // `#[track_caller]` location data) in optimized builds
+    //
     // Table indices are always 32-bit, even on wasm64.
-    HEAP_SLAB.0.borrow_mut().alloc() as u32
+    match HEAP_SLAB.0.try_borrow_mut() {
+        Ok(mut slab) => slab.alloc() as u32,
+        Err(_) => internal_error("slab already borrowed"),
+    }
 }
 
 #[no_mangle]
@@ -143,7 +149,10 @@ pub extern "C" fn __externref_table_dealloc(idx: u32) {
     unsafe {
         __wbindgen_externref_table_set_null(idx as u32);
     }
-    HEAP_SLAB.0.borrow_mut().dealloc(idx)
+    match HEAP_SLAB.0.try_borrow_mut() {
+        Ok(mut slab) => slab.dealloc(idx),
+        Err(_) => internal_error("slab already borrowed"),
+    }
 }
 
 #[no_mangle]
@@ -158,5 +167,8 @@ pub unsafe extern "C" fn __externref_drop_slice(ptr: WasmPtr<JsValue>, len: Wasm
 // Implementation of `__wbindgen_externref_heap_live_count` for when we are using
 // `externref` instead of the JS `heap`.
 pub fn __wbindgen_externref_heap_live_count() -> u32 {
-    HEAP_SLAB.0.borrow_mut().live_count()
+    match HEAP_SLAB.0.try_borrow_mut() {
+        Ok(slab) => slab.live_count(),
+        Err(_) => internal_error("slab already borrowed"),
+    }
 }


### PR DESCRIPTION
This removes the last panicking code paths from the externref table management in `src/externref.rs`, resolves #5292.

`RefCell::borrow_mut()` panics through core's `#[cold] #[track_caller] panic_already_borrowed`, which makes the caller materialize a `core::panic::Location` — the full source path string plus line/column records — in `.rodata`. Under `opt-level = "s"` without fat LTO this survives codegen even with `panic = "immediate-abort"`, since the cold core function can't be inlined away, and while `wasm-opt` can drop the dead call it never GCs data segments, so the location data (including a host path leak) stays baked into shipped binaries. The `Slab` methods in this file already carefully route every failure through `internal_error` for exactly this reason; the `RefCell` borrows were the only remaining panic edges.

* `__externref_table_alloc`, `__externref_table_dealloc` and `__wbindgen_externref_heap_live_count` now use `try_borrow_mut()` with the `Err` arm routed to `internal_error`, matching the file's existing panic-avoidance idiom

Before:

```rs
HEAP_SLAB.0.borrow_mut().alloc() as u32
```

After:

```rs
match HEAP_SLAB.0.try_borrow_mut() {
    Ok(mut slab) => slab.alloc() as u32,
    Err(_) => internal_error("slab already borrowed"),
}
```

Debug builds keep full diagnostics (`internal_error` is `throw_str` under `debug_assertions`), while optimized builds compile the failure arm to a bare `unreachable` with no location data.

Test coverage: a new CLI test builds a fixture crate with a release-like profile (debug assertions off, `opt-level = "s"`) and asserts the compiled wasm contains no `src/externref.rs` location bytes — this reproduces the bug on stable without needing nightly `immediate-abort` builds, since the `#[track_caller]` location is emitted regardless of panic strategy, and fails prior to this change.