### PR TITLE
Declare `initSync` in TypeScript definitions for `--target no-modules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@
 * Fix `js-sys` wasm64 build with `atomics` feature.
   [#5274](https://github.com/wasm-bindgen/wasm-bindgen/issues/5274)
 
+* Declare `initSync` in the generated TypeScript definitions for
+  `--target no-modules`, matching the `wasm_bindgen.initSync` function that
+  the JS output already exposes.
+  [#5284](https://github.com/wasm-bindgen/wasm-bindgen/issues/5284)
+
 ### Removed
 
 ## [0.2.127](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.126...0.2.127)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1276,25 +1276,44 @@ impl<'a> Context<'a> {
         let setup_function_declaration;
         let mut sync_init_function = String::new();
         let declare_or_export;
+
+        let init_sync_fn = format!(
+            "\
+            /**\n\
+            * Instantiates the given `module`, which can either be bytes or\n\
+            * a precompiled `WebAssembly.Module`.\n\
+            *\n\
+            * @param {{{{ module: SyncInitInput{memory_param}{stack_size} }}}} module - Passing `SyncInitInput` directly is deprecated.\n\
+            {memory_doc}\
+            *\n\
+            * @returns {{InitOutput}}\n\
+            */\n\
+            export function initSync(module: {{ module: SyncInitInput{memory_param}{stack_size} }} | SyncInitInput{memory_param}): InitOutput;\n\
+            "
+        );
+
         if self.config.mode.no_modules() {
             declare_or_export = "declare";
             setup_function_declaration = "declare function wasm_bindgen";
+
+            // `initSync` is attached to the `wasm_bindgen` function object at
+            // runtime, so declare it in a namespace that merges with the
+            // `declare function wasm_bindgen` below.
+            sync_init_function.push_str(&format!(
+                "\
+                declare type SyncInitInput = BufferSource | WebAssembly.Module;\n\n\
+                declare namespace wasm_bindgen {{\n\
+                {init_sync_fn}\
+                }}\n\n\
+                "
+            ));
         } else {
             declare_or_export = "export";
 
             sync_init_function.push_str(&format!(
                 "\
-                {declare_or_export} type SyncInitInput = BufferSource | WebAssembly.Module;\n\n\
-                /**\n\
-                * Instantiates the given `module`, which can either be bytes or\n\
-                * a precompiled `WebAssembly.Module`.\n\
-                *\n\
-                * @param {{{{ module: SyncInitInput{memory_param}{stack_size} }}}} module - Passing `SyncInitInput` directly is deprecated.\n\
-                {memory_doc}\
-                *\n\
-                * @returns {{InitOutput}}\n\
-                */\n\
-                export function initSync(module: {{ module: SyncInitInput{memory_param}{stack_size} }} | SyncInitInput{memory_param}): InitOutput;\n\n\
+                export type SyncInitInput = BufferSource | WebAssembly.Module;\n\n\
+                {init_sync_fn}\n\
                 "
             ));
 

--- a/crates/cli/tests/reference/jspi-intrinsics-target-no-modules.d.ts
+++ b/crates/cli/tests/reference/jspi-intrinsics-target-no-modules.d.ts
@@ -14,6 +14,20 @@ declare interface InitOutput {
     readonly __wbindgen_start: () => void;
 }
 
+declare type SyncInitInput = BufferSource | WebAssembly.Module;
+
+declare namespace wasm_bindgen {
+    /**
+     * Instantiates the given `module`, which can either be bytes or
+     * a precompiled `WebAssembly.Module`.
+     *
+     * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+     *
+     * @returns {InitOutput}
+     */
+    export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+}
+
 /**
  * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
  * for everything else, calls `WebAssembly.instantiate` directly.

--- a/crates/cli/tests/reference/targets-target-no-modules-atomics.d.ts
+++ b/crates/cli/tests/reference/targets-target-no-modules-atomics.d.ts
@@ -15,6 +15,21 @@ declare interface InitOutput {
     readonly __wbindgen_start: (a: number) => void;
 }
 
+declare type SyncInitInput = BufferSource | WebAssembly.Module;
+
+declare namespace wasm_bindgen {
+    /**
+     * Instantiates the given `module`, which can either be bytes or
+     * a precompiled `WebAssembly.Module`.
+     *
+     * @param {{ module: SyncInitInput, memory?: WebAssembly.Memory, thread_stack_size?: number }} module - Passing `SyncInitInput` directly is deprecated.
+     * @param {WebAssembly.Memory} memory - Deprecated.
+     *
+     * @returns {InitOutput}
+     */
+    export function initSync(module: { module: SyncInitInput, memory?: WebAssembly.Memory, thread_stack_size?: number } | SyncInitInput, memory?: WebAssembly.Memory): InitOutput;
+}
+
 /**
  * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
  * for everything else, calls `WebAssembly.instantiate` directly.

--- a/crates/cli/tests/reference/targets-target-no-modules-mvp.d.ts
+++ b/crates/cli/tests/reference/targets-target-no-modules-mvp.d.ts
@@ -12,6 +12,20 @@ declare interface InitOutput {
     readonly add_that_might_fail: (a: number, b: number) => number;
 }
 
+declare type SyncInitInput = BufferSource | WebAssembly.Module;
+
+declare namespace wasm_bindgen {
+    /**
+     * Instantiates the given `module`, which can either be bytes or
+     * a precompiled `WebAssembly.Module`.
+     *
+     * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+     *
+     * @returns {InitOutput}
+     */
+    export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+}
+
 /**
  * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
  * for everything else, calls `WebAssembly.instantiate` directly.

--- a/crates/cli/tests/reference/targets-target-no-modules.d.ts
+++ b/crates/cli/tests/reference/targets-target-no-modules.d.ts
@@ -14,6 +14,20 @@ declare interface InitOutput {
     readonly __wbindgen_start: () => void;
 }
 
+declare type SyncInitInput = BufferSource | WebAssembly.Module;
+
+declare namespace wasm_bindgen {
+    /**
+     * Instantiates the given `module`, which can either be bytes or
+     * a precompiled `WebAssembly.Module`.
+     *
+     * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+     *
+     * @returns {InitOutput}
+     */
+    export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+}
+
 /**
  * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
  * for everything else, calls `WebAssembly.instantiate` directly.


### PR DESCRIPTION
This implements `initSync` typings for `--target no-modules`, resolves #5284.

The no-modules JS output attaches `initSync` to the `wasm_bindgen` function object (`Object.assign(__wbg_init, { initSync }, exports)`), but `ts_for_init_fn` only emitted the `SyncInitInput` type and `initSync` declaration for the ESM targets, so the generated `.d.ts` had no typing for `wasm_bindgen.initSync` at all. This particularly affects the threads workflow, where workers are expected to call `wasm_bindgen.initSync({ module, memory })`.

* The `initSync` doc comment and signature are now shared between the two branches of `ts_for_init_fn`.
* For no-modules, `SyncInitInput` is declared at the top level alongside `InitInput`/`InitOutput`, and `initSync` is declared inside a `declare namespace wasm_bindgen { }` block that merges with the existing `declare function wasm_bindgen` declaration, typing it as `wasm_bindgen.initSync`.
* ESM target output is byte-identical to before.

```ts
declare type SyncInitInput = BufferSource | WebAssembly.Module;

declare namespace wasm_bindgen {
    export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
}
```

The reference test expectations for the no-modules variants of `targets.rs` and `jspi-intrinsics.rs` (including the mvp and atomics runs) now assert the `initSync` declaration; they were updated first to verify the failure before the fix. The merged declaration output was additionally validated against a consumer of `wasm_bindgen()`, `wasm_bindgen.initSync()`, and namespace exports under `tsc --strict` on TypeScript 5.9 and 7.0.
