### PR TITLE
Update wasm-pack documentation links

### DIFF
--- a/guide/src/introduction.md
+++ b/guide/src/introduction.md
@@ -40,4 +40,4 @@ publishing Rust-compiled-to-WebAssembly on NPM!
 [hello-online]: https://webassembly.studio/?f=gzubao6tg3
 [rustwasm]: https://rustwasm.github.io/
 [gol]: https://rustwasm.github.io/docs/book/
-[wasm-pack]: https://rustwasm.github.io/docs/wasm-pack/
+[wasm-pack]: https://wasm-bindgen.github.io/wasm-pack/book/

--- a/guide/src/reference/deployment.md
+++ b/guide/src/reference/deployment.md
@@ -148,4 +148,4 @@ This replaces the need for `compileStreaming` and platform-specific Wasm-loading
 If you'd like to deploy compiled WebAssembly to NPM, then the tool for the job
 is [`wasm-pack`]. More information on this coming soon!
 
-[`wasm-pack`]: https://rustwasm.github.io/docs/wasm-pack/
+[`wasm-pack`]: https://wasm-bindgen.github.io/wasm-pack/book/

--- a/guide/src/wasm-bindgen-test/continuous-integration.md
+++ b/guide/src/wasm-bindgen-test/continuous-integration.md
@@ -17,7 +17,7 @@ addons:
   chrome : stable
 
 install:
-  - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+  - curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 script:
 
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - run: cargo test
       - run: wasm-pack test --headless --chrome


### PR DESCRIPTION
### Description
<!-- Please describe the changes introduced by this PR. -->

Update wasm-pack references after the project moved under the wasm-bindgen organization:

- use `https://wasm-bindgen.github.io/wasm-pack/installer/init.sh` in both CI examples;
- point the introduction and deployment pages to `https://wasm-bindgen.github.io/wasm-pack/book/`.

The old `rustwasm.github.io` installer and documentation locations are obsolete. This keeps the guide's copyable installation commands and wasm-pack references current.

Related to #5294. This does not close the issue because the remaining Game of Life references are outside this focused change.



### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
