### PR TITLE
Take immutable slices in unstable Bluetooth and WebUSB write APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@
 * Changed WebGPU `setImmediates` APIs to take immutable u8 slice.
   [#5289](https://github.com/wasm-bindgen/wasm-bindgen/pull/5289)
 
+* Changed Web Bluetooth `writeValue` / `writeValueWithResponse` /
+  `writeValueWithoutResponse` and WebUSB `controlTransferOut` / `transferOut`
+  / `isochronousTransferOut` APIs to take immutable u8 slices.
+  [#5309](https://github.com/wasm-bindgen/wasm-bindgen/pull/5309)
+
 * Emscripten glue no longer reads `wasmExports['name']` inline inside inner
   functions. It now references the asmjs-mangled identifiers emcc's own
   top-level `assignWasmExports` receiving code binds for every wasm export

--- a/crates/web-sys/src/features/gen_BluetoothRemoteGattCharacteristic.rs
+++ b/crates/web-sys/src/features/gen_BluetoothRemoteGattCharacteristic.rs
@@ -307,7 +307,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn write_value_with_u8_slice(
         this: &BluetoothRemoteGattCharacteristic,
-        value: &mut [u8],
+        value: &[u8],
     ) -> Result<::js_sys::Promise<::js_sys::Undefined>, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
@@ -364,7 +364,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn write_value_with_response_with_u8_slice(
         this: &BluetoothRemoteGattCharacteristic,
-        value: &mut [u8],
+        value: &[u8],
     ) -> Result<::js_sys::Promise<::js_sys::Undefined>, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(
@@ -421,7 +421,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn write_value_without_response_with_u8_slice(
         this: &BluetoothRemoteGattCharacteristic,
-        value: &mut [u8],
+        value: &[u8],
     ) -> Result<::js_sys::Promise<::js_sys::Undefined>, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(

--- a/crates/web-sys/src/features/gen_BluetoothRemoteGattDescriptor.rs
+++ b/crates/web-sys/src/features/gen_BluetoothRemoteGattDescriptor.rs
@@ -124,7 +124,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn write_value_with_u8_slice(
         this: &BluetoothRemoteGattDescriptor,
-        value: &mut [u8],
+        value: &[u8],
     ) -> Result<::js_sys::Promise<::js_sys::Undefined>, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(

--- a/crates/web-sys/src/features/gen_UsbDevice.rs
+++ b/crates/web-sys/src/features/gen_UsbDevice.rs
@@ -328,7 +328,7 @@ extern "C" {
     pub fn control_transfer_out_with_u8_slice(
         this: &UsbDevice,
         setup: &UsbControlTransferParameters,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise<UsbOutTransferResult>, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(all(
@@ -417,7 +417,7 @@ extern "C" {
     pub fn isochronous_transfer_out_with_u8_slice(
         this: &UsbDevice,
         endpoint_number: u8,
-        data: &mut [u8],
+        data: &[u8],
         packet_lengths: &[::js_sys::Number],
     ) -> Result<::js_sys::Promise<UsbIsochronousOutTransferResult>, JsValue>;
     #[cfg(web_sys_unstable_apis)]
@@ -553,7 +553,7 @@ extern "C" {
     pub fn transfer_out_with_u8_slice(
         this: &UsbDevice,
         endpoint_number: u8,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise<UsbOutTransferResult>, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "UsbOutTransferResult")]

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -113,6 +113,14 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "setImmediates",
         "writeBuffer",
         "writeTexture",
+        // Bluetooth
+        "writeValue",
+        "writeValueWithResponse",
+        "writeValueWithoutResponse",
+        // WebUSB
+        "controlTransferOut",
+        "isochronousTransferOut",
+        "transferOut",
         // AudioBuffer
         "copyToChannel",
         // FontFace
@@ -128,6 +136,18 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "verify",
         // TextDecoder
         "decode",
+        // Further read-only candidates in stable APIs, held back as breaking
+        // signature changes for the next major version: appendBuffer /
+        // appendBufferAsync (SourceBuffer), generateRequest / update
+        // (MediaKeySession), setServerCertificate (MediaKeys), get / has
+        // (MediaKeyStatusMap), sendBeacon (Navigator), createPeriodicWave
+        // (BaseAudioContext), setValueCurveAtTime (AudioParam),
+        // vertexAttribI4iv / vertexAttribI4uiv (WebGL2), multiDraw*WEBGL
+        // (WEBGL_multi_draw).
+        //
+        // sendReport / sendFeatureReport (WebHID) are excluded: the spec
+        // references `data` inside its in-parallel steps without a
+        // synchronous copy step, so a synchronous read is not guaranteed.
     ])
 });
 


### PR DESCRIPTION
This extends the immutable slice whitelist from #5289 to write-direction buffer arguments in APIs gated behind `web_sys_unstable_apis`, where the spec guarantees the input buffer is copied synchronously during the method call (before any in-parallel steps), so the passed slice view is never retained or read after the call returns:

* Web Bluetooth: `writeValue`, `writeValueWithResponse`, `writeValueWithoutResponse` — spec performs "let bytes be a copy of the bytes held by value" in the synchronous method steps
* WebUSB: `controlTransferOut`, `transferOut`, `isochronousTransferOut` — spec performs "get a copy of the buffer source data" before "run the following steps in parallel"

```rs
pub fn write_value_with_u8_slice(this: &BluetoothRemoteGattCharacteristic, value: &mut [u8])
```

becomes

```rs
pub fn write_value_with_u8_slice(this: &BluetoothRemoteGattCharacteristic, value: &[u8])
```

WebHID `sendReport` / `sendFeatureReport` are deliberately excluded: the WebHID spec references `data` inside its in-parallel steps without a synchronous copy step, so a synchronous read is not spec-guaranteed. They are noted in a comment on the whitelist should the spec gain a copy step.

All affected bindings are behind `--cfg=web_sys_unstable_apis`, which carries no stability guarantee, so this follows the same release considerations as #5289.

Equivalent read-only candidates in stable APIs (MSE `appendBuffer`, EME `update`/`generateRequest`/`setServerCertificate`, `sendBeacon`, WebGL2 `vertexAttribI4iv`/`vertexAttribI4uiv`, `multiDraw*WEBGL`, and others) are breaking signature changes, so they are recorded in a comment on the whitelist for the next major version instead.

web-sys was regenerated; only the unstable-gated feature files changed.