### PR TITLE
Report a proper error when the struct derive path cannot be resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@
 
 ### Fixed
 
+* `#[wasm_bindgen]` on a struct now reports an actionable error when the path
+  to the `wasm_bindgen` crate cannot be resolved (e.g. when `wasm-bindgen` is
+  only a transitive dependency through `web-sys`), instead of a confusing
+  recursion limit error.
+  [#5295](https://github.com/wasm-bindgen/wasm-bindgen/issues/5295)
+
 * Fixed `js_namespace` exports missing from the bundler target's entry module
   re-export list, making namespaces unreachable when importing the package.
   [#5267](https://github.com/wasm-bindgen/wasm-bindgen/issues/5267)

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -31,6 +31,25 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
     let item = syn::parse2::<syn::Item>(input)?;
     if let syn::Item::Struct(mut s) = item {
         let opts: BindgenAttrs = syn::parse2(attr.clone())?;
+
+        // If the emitted `#[derive(<path>::__rt::BindgenedStruct)]` below
+        // fails to resolve — most commonly because `wasm-bindgen` is not a
+        // direct dependency, so `::wasm_bindgen` is not in the extern
+        // prelude — rustc strips the failed derive and, since
+        // `#[wasm_bindgen(#attr)]` is then no longer an inert derive helper,
+        // falls back to re-invoking this attribute macro on the struct with
+        // identical input, recursing until the recursion limit. The emitted
+        // `__wasm_bindgen_retried` marker attribute survives that round trip
+        // (and is otherwise an inert helper of the derive), letting us detect
+        // the re-invocation and report a proper error instead.
+        if strip_retry_marker(&mut s.attrs) {
+            bail_span!(
+                s.ident,
+                "cannot resolve a path to the `wasm_bindgen` crate: add `wasm-bindgen` \
+                 as a direct dependency, or specify an explicit path with \
+                 `#[wasm_bindgen(wasm_bindgen = path::to::wasm_bindgen)]`"
+            );
+        }
         let wasm_bindgen = opts
             .wasm_bindgen()
             .cloned()
@@ -48,6 +67,7 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
         let item = quote! {
             #[derive(#wasm_bindgen::__rt::BindgenedStruct)]
             #[wasm_bindgen(#attr)]
+            #[__wasm_bindgen_retried]
             #s
         };
         return Ok(item);
@@ -65,6 +85,14 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
     parser::check_unused_attrs(&mut tokens);
 
     Ok(tokens)
+}
+
+/// Finds and removes the `#[__wasm_bindgen_retried]` marker attribute left by
+/// a previous expansion attempt whose emitted derive path failed to resolve.
+fn strip_retry_marker(attrs: &mut Vec<syn::Attribute>) -> bool {
+    let before = attrs.len();
+    attrs.retain(|attr| !attr.path().is_ident("__wasm_bindgen_retried"));
+    before != attrs.len()
 }
 
 /// Takes the parsed input from a `wasm_bindgen::link_to` macro and returns the generated link

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -61,7 +61,7 @@ pub fn __wasm_bindgen_class_marker(attr: TokenStream, input: TokenStream) -> Tok
     }
 }
 
-#[proc_macro_derive(BindgenedStruct, attributes(wasm_bindgen))]
+#[proc_macro_derive(BindgenedStruct, attributes(wasm_bindgen, __wasm_bindgen_retried))]
 pub fn __wasm_bindgen_struct_marker(item: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_struct_marker(item.into()) {
         Ok(tokens) => {

--- a/crates/macro/ui-tests/struct-derive-unresolved.rs
+++ b/crates/macro/ui-tests/struct-derive-unresolved.rs
@@ -1,0 +1,12 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+// Simulates the re-invocation that occurs when the emitted
+// `#[derive(::wasm_bindgen::__rt::BindgenedStruct)]` fails to resolve (e.g.
+// when `wasm-bindgen` is not a direct dependency): rustc strips the failed
+// derive and re-invokes the attribute macro with the marker still attached,
+// which must produce a proper error rather than recursing indefinitely.
+#[wasm_bindgen]
+#[__wasm_bindgen_retried]
+struct Foo;
+
+fn main() {}

--- a/crates/macro/ui-tests/struct-derive-unresolved.stderr
+++ b/crates/macro/ui-tests/struct-derive-unresolved.stderr
@@ -1,0 +1,5 @@
+error: cannot resolve a path to the `wasm_bindgen` crate: add `wasm-bindgen` as a direct dependency, or specify an explicit path with `#[wasm_bindgen(wasm_bindgen = path::to::wasm_bindgen)]`
+  --> ui-tests/struct-derive-unresolved.rs:10:8
+   |
+10 | struct Foo;
+   |        ^^^


### PR DESCRIPTION
This improves the diagnostics for #5295.

`#[wasm_bindgen]` on a struct expands to a `#[derive(::wasm_bindgen::__rt::BindgenedStruct)]` round trip (needed for `cfg_attr` field support, #4351). When that derive path fails to resolve — most commonly because `wasm-bindgen` is only a transitive dependency through `web-sys`, so `::wasm_bindgen` is not in the extern prelude — rustc strips the failed derive and, since the accompanying `#[wasm_bindgen(...)]` attribute is then no longer an inert derive helper, falls back to re-invoking the attribute macro with identical input. The result is expansion recursing until the recursion limit:

```txt
error: recursion limit reached while expanding `#[wasm_bindgen]`
```

Since the re-invocation receives the bare struct with all failed attributes stripped, no state survives through the item itself. Instead we emit an additional `#[__wasm_bindgen_retried]` marker attribute, registered as an inert helper of the derive so it is invisible when expansion succeeds, but passed through verbatim on the fallback re-invocation. Detecting it terminates the recursion with an actionable error:

```txt
error: cannot resolve a path to the `wasm_bindgen` crate: add `wasm-bindgen` as a direct dependency, or specify an explicit path with `#[wasm_bindgen(wasm_bindgen = path::to::wasm_bindgen)]`
```

alongside rustc's own resolution error pointing at the missing crate. Both suggested resolutions verified against the original reproduction, and the `::wasm_bindgen` default is unchanged so #4597-style projects are unaffected (verified against its reproduction as well).

Test coverage: a new UI test exercises the marker detection path end-to-end via the fallback re-invocation shape.

A follow-up could make the transitive-dependency case work outright by selecting the derive path upfront (e.g. manifest inspection), but that is left out of scope here.