### PR TITLE
web-sys: include OffscreenCanvas in WebGL texImage* functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ### Added
 
+* Added `OffscreenCanvas` overloads for the WebGL `texImage2D`, `texSubImage2D`,
+  `texImage3D` and `texSubImage3D` functions, matching the `TexImageSource`
+  typedef in the WebGL specification.
+  [#5312](https://github.com/wasm-bindgen/wasm-bindgen/pull/5312)
+
 * Added `--split-debug-info` to the CLI. This option extracts the DWARF debug
   info to a separate `*_bg.debug.wasm` file. Use `--debug-info-url` to set
   the recorded URL for the debug info. [#5279](https://github.com/wasm-bindgen/wasm-bindgen/pull/5279)

--- a/crates/web-sys/src/features/gen_WebGl2RenderingContext.rs
+++ b/crates/web-sys/src/features/gen_WebGl2RenderingContext.rs
@@ -3291,6 +3291,27 @@ extern "C" {
         type_: u32,
         source: &HtmlVideoElement,
     ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGL2RenderingContext",
+        js_name = "texImage2D"
+    )]
+    #[doc = "The `texImage2D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texImage2D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGl2RenderingContext`*"]
+    pub fn tex_image_2d_with_u32_and_u32_and_offscreen_canvas(
+        this: &WebGl2RenderingContext,
+        target: u32,
+        level: i32,
+        internalformat: i32,
+        format: u32,
+        type_: u32,
+        source: &OffscreenCanvas,
+    ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(
         catch,
@@ -3471,6 +3492,30 @@ extern "C" {
         format: u32,
         type_: u32,
         source: &HtmlVideoElement,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGL2RenderingContext",
+        js_name = "texImage2D"
+    )]
+    #[doc = "The `texImage2D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texImage2D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGl2RenderingContext`*"]
+    pub fn tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_offscreen_canvas(
+        this: &WebGl2RenderingContext,
+        target: u32,
+        level: i32,
+        internalformat: i32,
+        width: i32,
+        height: i32,
+        border: i32,
+        format: u32,
+        type_: u32,
+        source: &OffscreenCanvas,
     ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(
@@ -3738,6 +3783,31 @@ extern "C" {
         format: u32,
         type_: u32,
         source: &HtmlVideoElement,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGL2RenderingContext",
+        js_name = "texImage3D"
+    )]
+    #[doc = "The `texImage3D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texImage3D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGl2RenderingContext`*"]
+    pub fn tex_image_3d_with_offscreen_canvas(
+        this: &WebGl2RenderingContext,
+        target: u32,
+        level: i32,
+        internalformat: i32,
+        width: i32,
+        height: i32,
+        depth: i32,
+        border: i32,
+        format: u32,
+        type_: u32,
+        source: &OffscreenCanvas,
     ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(
@@ -4125,6 +4195,28 @@ extern "C" {
         type_: u32,
         source: &HtmlVideoElement,
     ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGL2RenderingContext",
+        js_name = "texSubImage2D"
+    )]
+    #[doc = "The `texSubImage2D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage2D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGl2RenderingContext`*"]
+    pub fn tex_sub_image_2d_with_u32_and_u32_and_offscreen_canvas(
+        this: &WebGl2RenderingContext,
+        target: u32,
+        level: i32,
+        xoffset: i32,
+        yoffset: i32,
+        format: u32,
+        type_: u32,
+        source: &OffscreenCanvas,
+    ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(
         catch,
@@ -4308,6 +4400,30 @@ extern "C" {
         format: u32,
         type_: u32,
         source: &HtmlVideoElement,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGL2RenderingContext",
+        js_name = "texSubImage2D"
+    )]
+    #[doc = "The `texSubImage2D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage2D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGl2RenderingContext`*"]
+    pub fn tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_offscreen_canvas(
+        this: &WebGl2RenderingContext,
+        target: u32,
+        level: i32,
+        xoffset: i32,
+        yoffset: i32,
+        width: i32,
+        height: i32,
+        format: u32,
+        type_: u32,
+        source: &OffscreenCanvas,
     ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(
@@ -4580,6 +4696,32 @@ extern "C" {
         format: u32,
         type_: u32,
         source: &HtmlVideoElement,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGL2RenderingContext",
+        js_name = "texSubImage3D"
+    )]
+    #[doc = "The `texSubImage3D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage3D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGl2RenderingContext`*"]
+    pub fn tex_sub_image_3d_with_offscreen_canvas(
+        this: &WebGl2RenderingContext,
+        target: u32,
+        level: i32,
+        xoffset: i32,
+        yoffset: i32,
+        zoffset: i32,
+        width: i32,
+        height: i32,
+        depth: i32,
+        format: u32,
+        type_: u32,
+        source: &OffscreenCanvas,
     ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(

--- a/crates/web-sys/src/features/gen_WebGlRenderingContext.rs
+++ b/crates/web-sys/src/features/gen_WebGlRenderingContext.rs
@@ -572,6 +572,27 @@ extern "C" {
         type_: u32,
         video: &HtmlVideoElement,
     ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGLRenderingContext",
+        js_name = "texImage2D"
+    )]
+    #[doc = "The `texImage2D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGlRenderingContext`*"]
+    pub fn tex_image_2d_with_u32_and_u32_and_offscreen_canvas(
+        this: &WebGlRenderingContext,
+        target: u32,
+        level: i32,
+        internalformat: i32,
+        format: u32,
+        type_: u32,
+        offscreen_canvas: &OffscreenCanvas,
+    ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(
         catch,
@@ -771,6 +792,28 @@ extern "C" {
         format: u32,
         type_: u32,
         video: &HtmlVideoElement,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(
+        catch,
+        method,
+        js_class = "WebGLRenderingContext",
+        js_name = "texSubImage2D"
+    )]
+    #[doc = "The `texSubImage2D()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WebGlRenderingContext`*"]
+    pub fn tex_sub_image_2d_with_u32_and_u32_and_offscreen_canvas(
+        this: &WebGlRenderingContext,
+        target: u32,
+        level: i32,
+        xoffset: i32,
+        yoffset: i32,
+        format: u32,
+        type_: u32,
+        offscreen_canvas: &OffscreenCanvas,
     ) -> Result<(), JsValue>;
     #[cfg(feature = "VideoFrame")]
     #[wasm_bindgen(

--- a/crates/web-sys/webidls/enabled/WebGL2RenderingContext.webidl
+++ b/crates/web-sys/webidls/enabled/WebGL2RenderingContext.webidl
@@ -366,6 +366,9 @@ interface mixin WebGL2RenderingContextBase
                     GLenum format, GLenum type, HTMLVideoElement source); // May throw DOMException
     [Throws]
     undefined texImage2D(GLenum target, GLint level, GLint internalformat,
+                    GLenum format, GLenum type, OffscreenCanvas source); // May throw DOMException
+    [Throws]
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, VideoFrame source); // May throw DOMException
     [Throws] // Another overhead throws.
     undefined texImage2D(GLenum target, GLint level, GLint internalformat,
@@ -387,6 +390,9 @@ interface mixin WebGL2RenderingContextBase
     [Throws]
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLVideoElement source); // May throw DOMException
+    [Throws]
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                       GLenum format, GLenum type, OffscreenCanvas source); // May throw DOMException
     [Throws]
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, VideoFrame source); // May throw DOMException
@@ -413,6 +419,10 @@ interface mixin WebGL2RenderingContextBase
     undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type,
                     HTMLVideoElement source); // May throw DOMException
+    [Throws]
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                    GLint border, GLenum format, GLenum type,
+                    OffscreenCanvas source); // May throw DOMException
     [Throws]
     undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type,
@@ -445,6 +455,10 @@ interface mixin WebGL2RenderingContextBase
     undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type,
                     HTMLVideoElement source); // May throw DOMException
+    [Throws]
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                    GLsizei depth, GLint border, GLenum format, GLenum type,
+                    OffscreenCanvas source); // May throw DOMException
     [Throws]
     undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type,
@@ -483,6 +497,10 @@ interface mixin WebGL2RenderingContextBase
     [Throws]
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type,
+                       OffscreenCanvas source); // May throw DOMException
+    [Throws]
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+                       GLsizei height, GLenum format, GLenum type,
                        VideoFrame source); // May throw DOMException
     [Throws] // Another overhead throws.
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
@@ -513,6 +531,10 @@ interface mixin WebGL2RenderingContextBase
     undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        HTMLVideoElement source); // May throw DOMException
+    [Throws]
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+                       GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+                       OffscreenCanvas source); // May throw DOMException
     [Throws]
     undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,

--- a/crates/web-sys/webidls/enabled/WebGLRenderingContext.webidl
+++ b/crates/web-sys/webidls/enabled/WebGLRenderingContext.webidl
@@ -759,6 +759,9 @@ interface WebGLRenderingContext {
                     GLenum format, GLenum type, HTMLVideoElement video); // May throw DOMException
     [Throws]
     undefined texImage2D(GLenum target, GLint level, GLint internalformat,
+                    GLenum format, GLenum type, OffscreenCanvas offscreen_canvas); // May throw DOMException
+    [Throws]
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, VideoFrame video_frame); // May throw DOMException
 
     // texSubImage2D has WebGL2 overloads.
@@ -781,6 +784,9 @@ interface WebGLRenderingContext {
     [Throws]
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLVideoElement video); // May throw DOMException
+    [Throws]
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                       GLenum format, GLenum type, OffscreenCanvas offscreen_canvas); // May throw DOMException
     [Throws]
     undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, VideoFrame video_frame); // May throw DOMException


### PR DESCRIPTION
### Description

The WebGL specification's [`TexImageSource` typedef](https://registry.khronos.org/webgl/specs/latest/1.0/#5.14) includes `OffscreenCanvas`, but the vendored WebIDL predates it, so `web-sys` exposes no `OffscreenCanvas` overloads for `texImage2D` / `texSubImage2D` / `texImage3D` / `texSubImage3D`. Callers currently have to re-wrap an `OffscreenCanvas` as `HtmlCanvasElement` via `unchecked_ref()` to upload it (wgpu's GLES backend, for example, [marks this path `unreachable!()`](https://github.com/gfx-rs/wgpu/blob/d5fde4291f8ecf1c070324a46018a7c2fce09310/wgpu-hal/src/gles/queue.rs#L590)).

This adds the missing union members to `WebGLRenderingContext.webidl` / `WebGL2RenderingContext.webidl` and regenerates the bindings — the same approach as #3077, which added `VideoFrame` to these overloads. Purely additive; the new functions are gated on the existing stable `OffscreenCanvas` feature.

### Checklist

- [x] Verified changelog requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
