### PR TITLE
Per-monomorphization generic callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
   return values are marshalled at their concrete types (a `u32` crosses as a
   number, a `String` as a string) rather than being boxed. Trait bounds,
   `where` predicates (including higher-ranked ones), associated-type
-  projections, lifetime parameters, argument-position `impl Trait`, `async`,
-  `catch`, and `slice_to_array` are all supported; see
+  projections, lifetime parameters, argument-position `impl Trait`, raw
+  callbacks with owned generic inputs and returns, `async`, `catch`, and
+  `slice_to_array` are all supported; see
   [the guide](https://wasm-bindgen.github.io/wasm-bindgen/reference/attributes/on-js-imports/experimental_generic_mono.html)
   for the supported surface and the shapes that are rejected. The attribute
   is experimental and may change as it stabilizes.

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -3307,69 +3307,63 @@ impl ast::ImportFunction {
             };
 
             // Raw callback trait objects already have generic ABI support in
-            // `convert::closures`; only their callback signature's bounds need
-            // to be carried onto the monomorphized wrapper.
+            // `convert::closures`. Lower all of them like ordinary imports,
+            // adding bounds when their callback signature is generic.
             if let Some((is_mut, fn_bounds)) = detect_raw_fn_trait_obj(ty) {
                 if let Some((inputs, ret, higher_ranked)) = fn_trait_bound_sig(fn_bounds) {
-                    let uses_generics = inputs
-                        .iter()
-                        .any(|input| generics::uses_generic_params(input, &type_params))
-                        || generics::uses_generic_params(&ret, &type_params);
-                    if uses_generics {
-                        if higher_ranked {
-                            bail_span!(
-                                ty,
-                                "experimental_generic_mono does not support higher-ranked generic callback signatures"
-                            );
-                        }
-                        for input in &inputs {
-                            if generics::uses_generic_params(input, &type_params) {
-                                if generics::references_generic_param(input, &type_params) {
-                                    bail_span!(
-                                        input,
-                                        "experimental_generic_mono does not support borrowed generic callback arguments"
-                                    );
-                                }
-                                where_bounds.push(quote! {
-                                    #input: #wasm_bindgen::convert::FromWasmAbi
-                                });
-                            }
-                        }
-                        if generics::uses_generic_params(&ret, &type_params) {
-                            if generics::references_generic_param(&ret, &type_params) {
+                    if higher_ranked {
+                        bail_span!(
+                            ty,
+                            "experimental_generic_mono does not support higher-ranked generic callback signatures"
+                        );
+                    }
+                    for input in &inputs {
+                        if generics::uses_generic_params(input, &type_params) {
+                            if generics::references_generic_param(input, &type_params) {
                                 bail_span!(
-                                    ret,
-                                    "experimental_generic_mono does not support borrowed generic callback returns"
+                                    input,
+                                    "experimental_generic_mono does not support borrowed generic callback arguments"
                                 );
                             }
                             where_bounds.push(quote! {
-                                #ret: #wasm_bindgen::convert::ReturnWasmAbi
+                                #input: #wasm_bindgen::convert::FromWasmAbi
                             });
                         }
-
-                        let amp = if is_mut {
-                            quote! { &mut }
-                        } else {
-                            quote! { & }
-                        };
-                        wrapper_args.push(quote! {
-                            #name: #amp (impl #fn_bounds + #wasm_bindgen::__rt::marker::MaybeUnwindSafe)
-                        });
-                        let abi_ty = quote! { #amp dyn #fn_bounds };
-                        let abi = quote! { <#abi_ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi };
-                        let (args, names) = splat(wasm_bindgen, &name, &abi, Span::call_site());
-                        shim_abi_args.extend(args);
-                        arg_conversions.push(quote! {
-                            let #name = <#abi_ty as #wasm_bindgen::convert::IntoWasmAbi>
-                                ::into_abi(#name as #amp dyn #fn_bounds);
-                            let (#(#names),*) = <#abi as #wasm_bindgen::convert::WasmAbi>::split(#name);
-                        });
-                        all_prim_names.extend(names);
-                        describe_args.push(quote! {
-                            <#abi_ty as #wasm_bindgen::describe::WasmDescribe>::describe();
-                        });
-                        continue;
                     }
+                    if generics::uses_generic_params(&ret, &type_params) {
+                        if generics::references_generic_param(&ret, &type_params) {
+                            bail_span!(
+                                ret,
+                                "experimental_generic_mono does not support borrowed generic callback returns"
+                            );
+                        }
+                        where_bounds.push(quote! {
+                            #ret: #wasm_bindgen::convert::ReturnWasmAbi
+                        });
+                    }
+
+                    let amp = if is_mut {
+                        quote! { &mut }
+                    } else {
+                        quote! { & }
+                    };
+                    wrapper_args.push(quote! {
+                        #name: #amp (impl #fn_bounds + #wasm_bindgen::__rt::marker::MaybeUnwindSafe)
+                    });
+                    let abi_ty = quote! { #amp dyn #fn_bounds };
+                    let abi = quote! { <#abi_ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi };
+                    let (args, names) = splat(wasm_bindgen, &name, &abi, Span::call_site());
+                    shim_abi_args.extend(args);
+                    arg_conversions.push(quote! {
+                        let #name = <#abi_ty as #wasm_bindgen::convert::IntoWasmAbi>
+                            ::into_abi(#name as #amp dyn #fn_bounds);
+                        let (#(#names),*) = <#abi as #wasm_bindgen::convert::WasmAbi>::split(#name);
+                    });
+                    all_prim_names.extend(names);
+                    describe_args.push(quote! {
+                        <#abi_ty as #wasm_bindgen::describe::WasmDescribe>::describe();
+                    });
+                    continue;
                 }
             }
 

--- a/crates/macro-support/src/codegen.rs
+++ b/crates/macro-support/src/codegen.rs
@@ -2978,6 +2978,12 @@ impl ast::ImportFunction {
     /// none of the wrapper's generics — and, for a method whose receiver names
     /// one (`this: &'a Foo`), binding the receiver as `&'a self`.
     ///
+    /// A top-level raw `&dyn Fn(...)`/`&mut dyn FnMut(...)` callback may use
+    /// generic types in its inputs and return. Its wrapper uses the ordinary
+    /// import path's `impl Fn`/`impl FnMut` lowering while the monomorphized
+    /// shim retains the raw trait-object ABI. Borrowed and higher-ranked
+    /// generic callback signatures are not supported.
+    ///
     /// Not (yet) supported, and rejected with a diagnostic:
     /// - class argument lists `validate_class_shape` cannot faithfully hoist;
     /// - a mutable reference to a generic type parameter (`&mut T`), or a
@@ -2989,6 +2995,7 @@ impl ast::ImportFunction {
     ///   the `Ok` type is monomorphised;
     /// - `slice_to_array` on a slice whose element type mentions a type
     ///   parameter;
+    /// - borrowed or higher-ranked generic callback inputs and returns;
     /// - `reexport` and `assert_no_shim`, neither of which has a well-defined
     ///   meaning when one shim is manufactured per monomorphisation.
     ///
@@ -3298,6 +3305,73 @@ impl ast::ImportFunction {
                     "unsupported pattern in experimental_generic_mono imported function",
                 ),
             };
+
+            // Raw callback trait objects already have generic ABI support in
+            // `convert::closures`; only their callback signature's bounds need
+            // to be carried onto the monomorphized wrapper.
+            if let Some((is_mut, fn_bounds)) = detect_raw_fn_trait_obj(ty) {
+                if let Some((inputs, ret, higher_ranked)) = fn_trait_bound_sig(fn_bounds) {
+                    let uses_generics = inputs
+                        .iter()
+                        .any(|input| generics::uses_generic_params(input, &type_params))
+                        || generics::uses_generic_params(&ret, &type_params);
+                    if uses_generics {
+                        if higher_ranked {
+                            bail_span!(
+                                ty,
+                                "experimental_generic_mono does not support higher-ranked generic callback signatures"
+                            );
+                        }
+                        for input in &inputs {
+                            if generics::uses_generic_params(input, &type_params) {
+                                if generics::references_generic_param(input, &type_params) {
+                                    bail_span!(
+                                        input,
+                                        "experimental_generic_mono does not support borrowed generic callback arguments"
+                                    );
+                                }
+                                where_bounds.push(quote! {
+                                    #input: #wasm_bindgen::convert::FromWasmAbi
+                                });
+                            }
+                        }
+                        if generics::uses_generic_params(&ret, &type_params) {
+                            if generics::references_generic_param(&ret, &type_params) {
+                                bail_span!(
+                                    ret,
+                                    "experimental_generic_mono does not support borrowed generic callback returns"
+                                );
+                            }
+                            where_bounds.push(quote! {
+                                #ret: #wasm_bindgen::convert::ReturnWasmAbi
+                            });
+                        }
+
+                        let amp = if is_mut {
+                            quote! { &mut }
+                        } else {
+                            quote! { & }
+                        };
+                        wrapper_args.push(quote! {
+                            #name: #amp (impl #fn_bounds + #wasm_bindgen::__rt::marker::MaybeUnwindSafe)
+                        });
+                        let abi_ty = quote! { #amp dyn #fn_bounds };
+                        let abi = quote! { <#abi_ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi };
+                        let (args, names) = splat(wasm_bindgen, &name, &abi, Span::call_site());
+                        shim_abi_args.extend(args);
+                        arg_conversions.push(quote! {
+                            let #name = <#abi_ty as #wasm_bindgen::convert::IntoWasmAbi>
+                                ::into_abi(#name as #amp dyn #fn_bounds);
+                            let (#(#names),*) = <#abi as #wasm_bindgen::convert::WasmAbi>::split(#name);
+                        });
+                        all_prim_names.extend(names);
+                        describe_args.push(quote! {
+                            <#abi_ty as #wasm_bindgen::describe::WasmDescribe>::describe();
+                        });
+                        continue;
+                    }
+                }
+            }
 
             if generics::uses_generic_params(ty, &type_params) {
                 // A bare, shared reference to a generic type parameter (`&T`)
@@ -5577,6 +5651,28 @@ fn detect_raw_fn_trait_obj(
                 }
             }
         }
+    }
+    None
+}
+
+/// Extracts the argument and return types from a `Fn`/`FnMut` trait bound.
+fn fn_trait_bound_sig(
+    bounds: &syn::punctuated::Punctuated<syn::TypeParamBound, syn::token::Plus>,
+) -> Option<(Vec<syn::Type>, syn::Type, bool)> {
+    for bound in bounds {
+        let syn::TypeParamBound::Trait(tb) = bound else {
+            continue;
+        };
+        let segment = tb.path.segments.last()?;
+        let syn::PathArguments::Parenthesized(args) = &segment.arguments else {
+            continue;
+        };
+        let inputs = args.inputs.iter().map(|arg| arg.ty.clone()).collect();
+        let ret = match &args.output {
+            syn::ReturnType::Type(_, ty) => (**ty).clone(),
+            syn::ReturnType::Default => parse_quote!(()),
+        };
+        return Some((inputs, ret, tb.lifetimes.is_some()));
     }
     None
 }

--- a/crates/macro/ui-tests/generic-per-mono-unsupported.rs
+++ b/crates/macro/ui-tests/generic-per-mono-unsupported.rs
@@ -197,4 +197,19 @@ extern "C" {
     fn erased_slice_to_array_generic_elem<T>(xs: &[T]);
 }
 
+#[wasm_bindgen]
+extern "C" {
+    // Generic callback inputs cannot be borrowed by per-mono codegen.
+    #[wasm_bindgen(experimental_generic_mono)]
+    fn callback_borrowed_arg<T>(f: &mut dyn FnMut(&T));
+
+    // Higher-ranked generic callback signatures are likewise unsupported.
+    #[wasm_bindgen(experimental_generic_mono)]
+    fn callback_higher_ranked_arg<T>(f: &mut dyn for<'a> FnMut(&'a T));
+
+    // Nor can a generic callback return a borrowed value.
+    #[wasm_bindgen(experimental_generic_mono)]
+    fn callback_borrowed_return<'a, T>(f: &mut dyn FnMut() -> &'a T);
+}
+
 fn main() {}

--- a/crates/macro/ui-tests/generic-per-mono-unsupported.stderr
+++ b/crates/macro/ui-tests/generic-per-mono-unsupported.stderr
@@ -171,3 +171,21 @@ error: `slice_to_array` requires a concrete slice element type (e.g. `&[u16]`); 
     |
 197 |     fn erased_slice_to_array_generic_elem<T>(xs: &[T]);
     |                                                  ^^^^
+
+error: experimental_generic_mono does not support borrowed generic callback arguments
+   --> ui-tests/generic-per-mono-unsupported.rs:204:51
+    |
+204 |     fn callback_borrowed_arg<T>(f: &mut dyn FnMut(&T));
+    |                                                   ^^
+
+error: experimental_generic_mono does not support higher-ranked generic callback signatures
+   --> ui-tests/generic-per-mono-unsupported.rs:208:41
+    |
+208 |     fn callback_higher_ranked_arg<T>(f: &mut dyn for<'a> FnMut(&'a T));
+    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: experimental_generic_mono does not support borrowed generic callback returns
+   --> ui-tests/generic-per-mono-unsupported.rs:212:63
+    |
+212 |     fn callback_borrowed_return<'a, T>(f: &mut dyn FnMut() -> &'a T);
+    |                                                               ^^^^^

--- a/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
+++ b/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
@@ -265,6 +265,34 @@ A constructor or inferred self-returning static method whose return is
 so the method remains on the imported class's default specialization instead
 of being hoisted.
 
+## Callback arguments
+
+A top-level raw `&dyn Fn(...)` or `&mut dyn FnMut(...)` callback may use type
+parameters in its own inputs and return type. This is the shape used by typed
+`js-sys` APIs such as `Array::map`:
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    type Array<T>;
+
+    #[wasm_bindgen(method, experimental_generic_mono)]
+    fn map<T, U>(
+        this: &Array<T>,
+        callback: &mut dyn FnMut(T, u32, Array<T>) -> U,
+    ) -> Array<U>;
+}
+```
+
+The public wrapper accepts an ordinary Rust closure through `impl Fn` or
+`impl FnMut`, as on the non-generic import path. Each monomorphization describes
+the callback's concrete ABI argument and return types.
+
+Generic callback inputs and returns must be owned types. Borrowed forms such as
+`FnMut(&T)` and higher-ranked forms such as `for<'a> FnMut(&'a T)` are rejected.
+The callback must also be the top-level argument shape shown above; callback
+trait objects nested in another type do not receive this lowering.
+
 ## Other attributes
 
 `experimental_generic_mono` composes with the usual import attributes — `method`,
@@ -326,7 +354,10 @@ usually to drop `experimental_generic_mono`:
   `&T` *is* supported, and mutable references to *concrete* types (e.g.
   `&mut [u16]`, `&mut dyn FnMut(u32)`) bind exactly as they do on the
   non-generic import path — the restriction is only about references to type
-  parameters.
+  parameters. Top-level callbacks whose owned input or return types are generic
+  are supported separately as described in [Callback arguments](#callback-arguments).
+* **Borrowed or higher-ranked generic callback inputs and returns**
+  (`FnMut(&T)`, `for<'a> FnMut(&'a T)`).
 * **Returning a reference.**
 * **A bare type parameter, or a reference to one (`&T`), as the `variadic`
   argument**, since it may monomorphise to a scalar, which is not spreadable.

--- a/tests/wasm/generic_import_args.js
+++ b/tests/wasm/generic_import_args.js
@@ -13,6 +13,10 @@ exports.withCallback = function (f, times) {
   }
 };
 
+exports.transform = function (value, f) {
+  return f(value);
+};
+
 exports.tryGet = function (key) {
   if (key === 0) {
     throw new Error("boom");

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -5,7 +5,8 @@
 //! - `&mut [u16]`: must be a live view into wasm memory, so JS's writes reach
 //!   the caller. A copy would produce identical-looking glue.
 //! - `&mut dyn FnMut`: must be invoked the expected number of times, with the
-//!   reentrancy guard released afterwards.
+//!   reentrancy guard released afterwards, including when its own signature is
+//!   generic.
 //! - non-async `catch` with a *generic* `Ok`: the success value is marshalled at
 //!   each monomorphisation's concrete type while the error stays `JsValue`; the
 //!   throwing path is a different unwrap from the async one covered elsewhere.
@@ -29,6 +30,9 @@ extern "C" {
 
     #[wasm_bindgen(experimental_generic_mono, js_name = withCallback)]
     fn with_callback<T>(f: &mut dyn FnMut(u32), times: T);
+
+    #[wasm_bindgen(experimental_generic_mono)]
+    fn transform<T, U>(value: T, f: &mut dyn FnMut(T) -> U) -> U;
 
     #[wasm_bindgen(experimental_generic_mono, catch, js_name = tryGet)]
     fn try_get<T>(key: u32) -> Result<T, JsValue>;
@@ -89,6 +93,15 @@ fn experimental_generic_mono_mut_closure_is_invoked() {
         with_callback(&mut bump, 2.0f64);
     }
     assert_eq!(count, 2);
+}
+
+#[wasm_bindgen_test]
+fn experimental_generic_mono_callback_signature() {
+    let mut double = |value: u32| value * 2;
+    assert_eq!(transform(3u32, &mut double), 6);
+
+    let mut label = |value: f64| format!("value:{value}");
+    assert_eq!(transform(2.5f64, &mut label), "value:2.5");
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -83,7 +83,9 @@ fn experimental_generic_mono_mut_slice_is_written_back() {
 fn experimental_generic_mono_mut_closure_is_invoked() {
     let mut seen = Vec::new();
     {
-        let mut push = |v: u32| seen.push(v);
+        // Mutable captures require an explicit unwind-safety opt-in.
+        let mut seen = core::panic::AssertUnwindSafe(&mut seen);
+        let mut push = move |v: u32| seen.push(v);
         with_callback(&mut push, 3u32);
     }
     assert_eq!(seen, vec![0, 1, 2]);
@@ -92,7 +94,8 @@ fn experimental_generic_mono_mut_closure_is_invoked() {
     // used again with a different monomorphisation.
     let mut count = 0u32;
     {
-        let mut bump = |_: u32| count += 1;
+        let mut count = core::panic::AssertUnwindSafe(&mut count);
+        let mut bump = move |_: u32| **count += 1;
         with_callback(&mut bump, 2.0f64);
     }
     assert_eq!(count, 2);

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -34,6 +34,9 @@ extern "C" {
     #[wasm_bindgen(experimental_generic_mono)]
     fn transform<T, U>(value: T, f: &mut dyn FnMut(T) -> U) -> U;
 
+    #[wasm_bindgen(experimental_generic_mono, js_name = transform)]
+    fn transform_shared<T, U>(value: T, f: &dyn Fn(T) -> U) -> U;
+
     #[wasm_bindgen(experimental_generic_mono, catch, js_name = tryGet)]
     fn try_get<T>(key: u32) -> Result<T, JsValue>;
 
@@ -102,6 +105,12 @@ fn experimental_generic_mono_callback_signature() {
 
     let mut label = |value: f64| format!("value:{value}");
     assert_eq!(transform(2.5f64, &mut label), "value:2.5");
+
+    let increment = |value: u32| value + 1;
+    assert_eq!(transform_shared(3u32, &increment), 4);
+
+    let label = |value: f64| format!("shared:{value}");
+    assert_eq!(transform_shared(2.5f64, &label), "shared:2.5");
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
### Description
Adds support for trait object callbacks (`&dyn Fn(...)` and `&mut dyn FnMut(...)`) with type parameter arguments and return types. Currently arguments and return types cannot be references, or have higher ranked lifetime bounds. So these cases:
- FnMut(&T)
- for<'a> FnMut(&'a T)
- FnMut() -> &'a T

are rejected. These cases should most likely be handled by erasible generics instead (they are already supported in that path).

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
