### PR TITLE
Skip the thread-bootstrap transform in Emscripten mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,9 +222,12 @@ jobs:
       - name: Setup Emscripten SDK
         uses: mymindstorm/setup-emsdk@v16
         with:
-          # Pinned: 6.0.6 drops the legacy JS-exceptions ABI (`__cpp_exception`)
-          # that rustc's prebuilt wasm32-unknown-emscripten std still links.
-          version: 6.0.5
+          # Minimum for the `-sWASM_BINDGEN` integration: the `__force`/
+          # `__export` JS library decorators the generated `library_bindgen.js`
+          # relies on landed in 6.0.7, which also restored linking rustc's
+          # prebuilt wasm32-unknown-emscripten std after 6.0.6 dropped the
+          # legacy JS-exceptions ABI (`__cpp_exception`).
+          version: 6.0.7
       - uses: actions/setup-node@v7
         with:
           node-version: '22'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
   module with shared memory and aborted the build (`failed to find
   __wasm_init_tls`), since Emscripten's linker had already consumed the
   synthetic symbols it looks for.
-  [#5314](https://github.com/wasm-bindgen/wasm-bindgen/pull/5314)
+  [#5315](https://github.com/wasm-bindgen/wasm-bindgen/pull/5315)
 
 * Fixed conflicting deprecation messages on `web-sys` dictionary fields that
   are themselves deprecated: the deprecated builder-style method no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,13 @@
 
 ### Fixed
 
+* The thread-bootstrap transform is now skipped in Emscripten mode, where the
+  Emscripten runtime owns pthread startup and TLS. It previously ran on any
+  module with shared memory and aborted the build (`failed to find
+  __wasm_init_tls`), since Emscripten's linker had already consumed the
+  synthetic symbols it looks for.
+  [#5314](https://github.com/wasm-bindgen/wasm-bindgen/pull/5314)
+
 * Fixed conflicting deprecation messages on `web-sys` dictionary fields that
   are themselves deprecated: the deprecated builder-style method no longer
   points at an equally-deprecated setter, and the WebAuthn fields removed from

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -419,8 +419,13 @@ impl Bindgen {
             bail!("--experimental-reset-state-function is only supported for --target module, --target web, or --target nodejs")
         }
 
-        let thread_count = transforms::threads::run(&mut module)
-            .with_context(|| "failed to prepare module for threading")?;
+        let thread_count = if self.mode.emscripten() {
+            // Emscripten owns multithreading bootstrap logic.
+            None
+        } else {
+            transforms::threads::run(&mut module)
+                .with_context(|| "failed to prepare module for threading")?
+        };
 
         transforms::memory_discard::run(&mut module, self.memory_discard)
             .with_context(|| "failed to generate `memory.discard` trampoline")?;

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2533,6 +2533,39 @@ fn private_namespaced_classes_export_actual_ts_identifier() {
 }
 
 #[test]
+fn emscripten_shared_memory_skips_thread_transform() {
+    // In an emcc `--shared-memory` link the Emscripten runtime owns pthread
+    // bootstrap and TLS, and the synthetic `__wasm_init_tls`/`__tls_size`
+    // exports the thread transform consumes don't survive the link, so the
+    // transform must be skipped rather than failing with
+    // `failed to find __wasm_init_tls`.
+    let root = TARGET_DIR
+        .join("cli-tests")
+        .join("emscripten_shared_memory_skips_thread_transform");
+    drop(fs::remove_dir_all(&root));
+    fs::create_dir_all(&root).unwrap();
+
+    let mut module = walrus::Module::default();
+    module.add_import_memory("env", "memory", true, false, 17, Some(16384), None);
+    module.customs.add(RawCustomSection {
+        name: "__wasm_bindgen_emscripten_marker".into(),
+        data: vec![1],
+    });
+    let wasm_path = root.join("input.wasm");
+    module.emit_wasm_file(&wasm_path).unwrap();
+
+    let out_dir = root.join("pkg");
+    fs::create_dir_all(&out_dir).unwrap();
+    wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir.as_os_str(),
+        wasm_path.as_os_str(),
+    ])
+    .unwrap();
+}
+
+#[test]
 fn emscripten_namespaced_exports_valid_ts() {
     // Covers all three TS-emission bugs for namespaced (`js_namespace`)
     // exports in emscripten output:


### PR DESCRIPTION
### Description

I am trying to use `wasm-bindgen` with the [experimental Emscripten integration](https://github.com/wasm-bindgen/wasm-bindgen/issues/5237) in a multithreaded environment. Unfortunately, I encounter this error with I try to link a Rust `.a` file into my Emscripten build with `-sWASM_BINDGEN`:

```
failed to prepare module for threading
Caused by: failed to find `__wasm_init_tls`
```

This happens because Emscripten already injects a TLS-init `start` function and consumes the `__wasm_init_tls`/`__tls_size` symbols during a `--shared-memory` link.

As a fix, this PR disables the multithreading transform performed by `wasm-bindgen-cli` when compiling for Emscripten targets.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
