### PR TITLE
Add JsStringLike marker trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,10 @@
   [#5230](https://github.com/wasm-bindgen/wasm-bindgen/pull/5230)
   [#5272](https://github.com/wasm-bindgen/wasm-bindgen/pull/5272)
 
-* Added `JsStringLike` and `JsStringLikeOwn` marker traits — implemented for
-  `String`/`&str` (and `js_sys::JsString`/`&js_sys::JsString` in `js-sys`),
-  with `JsStringLikeOwn` as the owned subset — as bounds for
-  `experimental_generic_mono` imports that accept or return any string shape
-  at its native wire format.
+* Added the experimental `JsStringLike` marker trait — implemented for
+  `String`/`&str` (and `js_sys::JsString`/`&js_sys::JsString` in `js-sys`) —
+  as a bound for `experimental_generic_mono` imports that accept any string
+  shape at its native wire format.
 
 * Added an experimental `--experimental-memory-discard` flag which replaces an
   `env.__wbindgen_memory_discard` function import with a local trampoline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@
   [#5230](https://github.com/wasm-bindgen/wasm-bindgen/pull/5230)
   [#5272](https://github.com/wasm-bindgen/wasm-bindgen/pull/5272)
 
+* Added `JsStringLike` and `JsStringLikeOwn` marker traits — implemented for
+  `String`/`&str` (and `js_sys::JsString`/`&js_sys::JsString` in `js-sys`),
+  with `JsStringLikeOwn` as the owned subset — as bounds for
+  `experimental_generic_mono` imports that accept or return any string shape
+  at its native wire format.
+
 * Added an experimental `--experimental-memory-discard` flag which replaces an
   `env.__wbindgen_memory_discard` function import with a local trampoline
   containing the `memory.discard` instruction from the memory-control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
   [#5230](https://github.com/wasm-bindgen/wasm-bindgen/pull/5230)
   [#5272](https://github.com/wasm-bindgen/wasm-bindgen/pull/5272)
 
-* Added the experimental `JsStringLike` marker trait — implemented for
+* Added the experimental, sealed `JsStringLike` marker trait — implemented for
   `String`/`&str` (and `js_sys::JsString`/`&js_sys::JsString` in `js-sys`) —
   as a bound for `experimental_generic_mono` imports that accept any string
   shape at its native wire format.

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -9875,7 +9875,6 @@ impl UpcastFrom<JsString> for char {}
 
 impl wasm_bindgen::JsStringLike for JsString {}
 impl wasm_bindgen::JsStringLike for &JsString {}
-impl wasm_bindgen::JsStringLikeOwn for JsString {}
 
 impl JsString {
     /// Returns the `JsString` value of this JS value if it's an instance of a

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -9873,6 +9873,8 @@ impl UpcastFrom<JsString> for &str {}
 impl UpcastFrom<char> for JsString {}
 impl UpcastFrom<JsString> for char {}
 
+impl wasm_bindgen::__rt::marker::JsStringLikeSealed for JsString {}
+impl wasm_bindgen::__rt::marker::JsStringLikeSealed for &JsString {}
 impl wasm_bindgen::JsStringLike for JsString {}
 impl wasm_bindgen::JsStringLike for &JsString {}
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -9873,6 +9873,10 @@ impl UpcastFrom<JsString> for &str {}
 impl UpcastFrom<char> for JsString {}
 impl UpcastFrom<JsString> for char {}
 
+impl wasm_bindgen::JsStringLike for JsString {}
+impl wasm_bindgen::JsStringLike for &JsString {}
+impl wasm_bindgen::JsStringLikeOwn for JsString {}
+
 impl JsString {
     /// Returns the `JsString` value of this JS value if it's an instance of a
     /// string.

--- a/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
+++ b/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
@@ -90,6 +90,37 @@ Relaxed bounds are the exception: `T: ?Sized` is not supported on any
 `wasm-bindgen` generic — erased or per-monomorphisation — and is reported as
 `unsupported in wasm-bindgen generics`.
 
+### String bounds
+
+For imports that take or return a JS string, the `wasm_bindgen::JsStringLike`
+and `wasm_bindgen::JsStringLikeOwn` marker traits name the set of string shapes
+directly:
+
+```rust
+use wasm_bindgen::{JsStringLike, JsStringLikeOwn};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(experimental_generic_mono)]
+    fn set_title<T: JsStringLike>(title: T);
+
+    #[wasm_bindgen(experimental_generic_mono)]
+    fn get_title<T: JsStringLikeOwn>() -> T;
+}
+```
+
+`JsStringLike` is implemented for `String`, `&str`, `js_sys::JsString` and
+`&js_sys::JsString`, so a caller can pass whichever it already holds and each
+monomorphisation crosses at that shape's native wire format — UTF-8 buffers
+for the Rust strings, a handle for `JsString` — all arriving in JS as a
+string value. `JsStringLikeOwn` is the owned subset — `String` (copied out of
+the JS string) and `js_sys::JsString` (a handle, no copy) — which is what can
+travel in every direction, so it is the bound for return positions and for
+sequence elements. Nullable positions work under both bounds (`Option<T>` in
+either direction), since the traits carry the `Option` ABI traits as
+supertraits. Both traits are open: implementing one for your own
+`#[wasm_bindgen]`-imported type is a promise that it marshals as a JS string.
+
 ## `impl Trait` arguments
 
 Argument-position `impl Trait` is supported. It is desugared into a synthesized

--- a/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
+++ b/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
@@ -112,8 +112,7 @@ monomorphisation crosses at that shape's native wire format — UTF-8 buffers
 for the Rust strings, a handle for `JsString` — all arriving in JS as a
 string value. Nullable positions work under the same bound (`Option<T>`),
 since the trait carries `OptionIntoWasmAbi` as a supertrait. The trait is
-open: implementing it for your own `#[wasm_bindgen]`-imported type is a
-promise that it marshals as a JS string. Like `experimental_generic_mono`
+sealed to exactly these string shapes. Like `experimental_generic_mono`
 itself, the trait is experimental and may change as the feature stabilizes.
 
 ## `impl Trait` arguments

--- a/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
+++ b/guide/src/reference/attributes/on-js-imports/experimental_generic_mono.md
@@ -92,20 +92,17 @@ Relaxed bounds are the exception: `T: ?Sized` is not supported on any
 
 ### String bounds
 
-For imports that take or return a JS string, the `wasm_bindgen::JsStringLike`
-and `wasm_bindgen::JsStringLikeOwn` marker traits name the set of string shapes
+For imports that take a JS string, the experimental
+`wasm_bindgen::JsStringLike` marker trait names the set of string shapes
 directly:
 
 ```rust
-use wasm_bindgen::{JsStringLike, JsStringLikeOwn};
+use wasm_bindgen::JsStringLike;
 
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(experimental_generic_mono)]
     fn set_title<T: JsStringLike>(title: T);
-
-    #[wasm_bindgen(experimental_generic_mono)]
-    fn get_title<T: JsStringLikeOwn>() -> T;
 }
 ```
 
@@ -113,13 +110,11 @@ extern "C" {
 `&js_sys::JsString`, so a caller can pass whichever it already holds and each
 monomorphisation crosses at that shape's native wire format — UTF-8 buffers
 for the Rust strings, a handle for `JsString` — all arriving in JS as a
-string value. `JsStringLikeOwn` is the owned subset — `String` (copied out of
-the JS string) and `js_sys::JsString` (a handle, no copy) — which is what can
-travel in every direction, so it is the bound for return positions and for
-sequence elements. Nullable positions work under both bounds (`Option<T>` in
-either direction), since the traits carry the `Option` ABI traits as
-supertraits. Both traits are open: implementing one for your own
-`#[wasm_bindgen]`-imported type is a promise that it marshals as a JS string.
+string value. Nullable positions work under the same bound (`Option<T>`),
+since the trait carries `OptionIntoWasmAbi` as a supertrait. The trait is
+open: implementing it for your own `#[wasm_bindgen]`-imported type is a
+promise that it marshals as a JS string. Like `experimental_generic_mono`
+itself, the trait is experimental and may change as the feature stabilizes.
 
 ## `impl Trait` arguments
 

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -652,16 +652,20 @@ impl<T: IntoJsGeneric + Clone> IntoJsGeneric for &T {
 /// `String` and `&str` cross as UTF-8 buffers, `js_sys::JsString` and
 /// `&js_sys::JsString` as handles — all arriving in JS as a string value.
 ///
-/// Implementing this trait for a type is a promise that its `IntoWasmAbi`
-/// conversion produces a JS string on the other side, as is the case for
-/// `#[wasm_bindgen]`-imported extern types of JS strings.
+/// This trait is sealed: it is implemented only for the string shapes above,
+/// each of which is guaranteed to produce a JS string on the other side.
 ///
 /// `OptionIntoWasmAbi` is a supertrait so that nullable string positions
 /// (`Option<T>`) work under the same bound.
 ///
 /// This trait is experimental, like `experimental_generic_mono` itself, and
 /// may change or be removed as that feature stabilizes.
-pub trait JsStringLike: IntoWasmAbi + OptionIntoWasmAbi {}
+pub trait JsStringLike:
+    IntoWasmAbi + OptionIntoWasmAbi + crate::__rt::marker::JsStringLikeSealed
+{
+}
 
+impl crate::__rt::marker::JsStringLikeSealed for alloc::string::String {}
+impl crate::__rt::marker::JsStringLikeSealed for &str {}
 impl JsStringLike for alloc::string::String {}
 impl JsStringLike for &str {}

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -644,3 +644,37 @@ impl<T: IntoJsGeneric + Clone> IntoJsGeneric for &T {
 // and prevent wrapper types from canonicalising to a different target.
 // Instead, implementations are provided explicitly by each owning crate
 // (macro-generated for user types; hand-written for `js_sys` containers).
+
+/// Marker for types that cross the ABI as a JavaScript string.
+///
+/// Use as a bound on an `experimental_generic_mono` import's type parameter to
+/// accept any Rust or JS string shape, each at its native wire format:
+/// `String` and `&str` cross as UTF-8 buffers, `js_sys::JsString` and
+/// `&js_sys::JsString` as handles — all arriving in JS as a string value.
+///
+/// Implementing this trait for a type is a promise that its `IntoWasmAbi`
+/// conversion produces a JS string on the other side, as is the case for
+/// `#[wasm_bindgen]`-imported extern types of JS strings.
+///
+/// `OptionIntoWasmAbi` is a supertrait so that nullable string positions
+/// (`Option<T>`) work under the same bound.
+pub trait JsStringLike: IntoWasmAbi + OptionIntoWasmAbi {}
+
+impl JsStringLike for alloc::string::String {}
+impl JsStringLike for &str {}
+
+/// Marker for the owned [`JsStringLike`] shapes: `String` and
+/// `js_sys::JsString`.
+///
+/// The owned subset is what can travel in every direction: received back from
+/// JS (a return the caller chooses to take as an owned Rust `String` copy or
+/// a `js_sys::JsString` handle), and carried as sequence elements through the
+/// vector ABI. Borrowed shapes (`&str`, `&js_sys::JsString`) have no place
+/// here, so the `FromWasmAbi`, `OptionFromWasmAbi` and `Vector*WasmAbi`
+/// supertraits are all satisfiable.
+pub trait JsStringLikeOwn:
+    JsStringLike + FromWasmAbi + OptionFromWasmAbi + VectorIntoWasmAbi + VectorFromWasmAbi
+{
+}
+
+impl JsStringLikeOwn for alloc::string::String {}

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -658,23 +658,10 @@ impl<T: IntoJsGeneric + Clone> IntoJsGeneric for &T {
 ///
 /// `OptionIntoWasmAbi` is a supertrait so that nullable string positions
 /// (`Option<T>`) work under the same bound.
+///
+/// This trait is experimental, like `experimental_generic_mono` itself, and
+/// may change or be removed as that feature stabilizes.
 pub trait JsStringLike: IntoWasmAbi + OptionIntoWasmAbi {}
 
 impl JsStringLike for alloc::string::String {}
 impl JsStringLike for &str {}
-
-/// Marker for the owned [`JsStringLike`] shapes: `String` and
-/// `js_sys::JsString`.
-///
-/// The owned subset is what can travel in every direction: received back from
-/// JS (a return the caller chooses to take as an owned Rust `String` copy or
-/// a `js_sys::JsString` handle), and carried as sequence elements through the
-/// vector ABI. Borrowed shapes (`&str`, `&js_sys::JsString`) have no place
-/// here, so the `FromWasmAbi`, `OptionFromWasmAbi` and `Vector*WasmAbi`
-/// supertraits are all satisfiable.
-pub trait JsStringLikeOwn:
-    JsStringLike + FromWasmAbi + OptionFromWasmAbi + VectorIntoWasmAbi + VectorFromWasmAbi
-{
-}
-
-impl JsStringLikeOwn for alloc::string::String {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ mod externref;
 use externref::__wbindgen_externref_heap_live_count;
 
 pub use crate::__rt::marker::ErasableGeneric;
-pub use crate::convert::{IntoJsGeneric, JsGeneric, JsStringLike, JsStringLikeOwn};
+pub use crate::convert::{IntoJsGeneric, JsGeneric, JsStringLike};
 
 #[doc(hidden)]
 pub mod handler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ mod externref;
 use externref::__wbindgen_externref_heap_live_count;
 
 pub use crate::__rt::marker::ErasableGeneric;
-pub use crate::convert::{IntoJsGeneric, JsGeneric};
+pub use crate::convert::{IntoJsGeneric, JsGeneric, JsStringLike, JsStringLikeOwn};
 
 #[doc(hidden)]
 pub mod handler;

--- a/src/rt/marker.rs
+++ b/src/rt/marker.rs
@@ -44,6 +44,10 @@ pub struct CheckSupportsStaticProperty<T: SupportsStaticProperty>(T);
 ))]
 use core::panic::UnwindSafe;
 
+/// Seal for `wasm_bindgen::JsStringLike`: only string shapes provided by
+/// `wasm-bindgen` and `js-sys` may implement it.
+pub trait JsStringLikeSealed {}
+
 /// Marker trait for types that are UnwindSafe only when building with panic unwind
 pub trait MaybeUnwindSafe {}
 

--- a/tests/wasm/generic_import_args.js
+++ b/tests/wasm/generic_import_args.js
@@ -49,6 +49,14 @@ exports.describeAny = function (x) {
   return typeof x + ":" + x;
 };
 
+exports.describeStr = function (s) {
+  return typeof s + ":" + s;
+};
+
+exports.makeStr = function () {
+  return "made";
+};
+
 exports.sumSlice = function (xs) {
   let total = 0;
   for (const v of xs) {

--- a/tests/wasm/generic_import_args.js
+++ b/tests/wasm/generic_import_args.js
@@ -53,10 +53,6 @@ exports.describeStr = function (s) {
   return typeof s + ":" + s;
 };
 
-exports.makeStr = function () {
-  return "made";
-};
-
 exports.sumSlice = function (xs) {
   let total = 0;
   for (const v of xs) {

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -18,7 +18,9 @@
 //! - `&[T]` with a generic element type: takes the `&T` HRTB route rather
 //!   than the concrete-slice route, both as a plain and a `variadic` argument.
 
+use js_sys::JsString;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsStringLike, JsStringLikeOwn};
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/generic_import_args.js")]
@@ -62,6 +64,16 @@ extern "C" {
     // view.
     #[wasm_bindgen(experimental_generic_mono, js_name = sumSlice)]
     fn sum_slice<T>(xs: &[T]) -> f64;
+
+    // `JsStringLike`/`JsStringLikeOwn` bounds: every string shape crosses at its
+    // native wire format (UTF-8 buffer vs handle) but must arrive in JS as a
+    // string *value*, and a JS string return must be receivable as either an
+    // owned copy or a handle.
+    #[wasm_bindgen(experimental_generic_mono, js_name = describeStr)]
+    fn describe_str<T: JsStringLike>(s: T) -> String;
+
+    #[wasm_bindgen(experimental_generic_mono, js_name = makeStr)]
+    fn make_str<T: JsStringLikeOwn>() -> T;
 }
 
 #[wasm_bindgen_test]
@@ -114,6 +126,24 @@ fn experimental_generic_mono_callback_signature() {
 
     let label = |value: f64| format!("shared:{value}");
     assert_eq!(transform_shared(2.5f64, &label), "shared:2.5");
+}
+
+#[wasm_bindgen_test]
+fn experimental_generic_mono_string_arg_bound() {
+    // JS reports `typeof` plus the value, so a shape that crossed as anything
+    // other than a string value surfaces as a mismatch.
+    assert_eq!(describe_str("borrowed"), "string:borrowed");
+    assert_eq!(describe_str(String::from("owned")), "string:owned");
+
+    let js = JsString::from("handle");
+    assert_eq!(describe_str(&js), "string:handle");
+    assert_eq!(describe_str(js), "string:handle");
+}
+
+#[wasm_bindgen_test]
+fn experimental_generic_mono_string_ret_bound() {
+    assert_eq!(make_str::<String>(), "made");
+    assert_eq!(make_str::<JsString>().to_string(), "made");
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -20,7 +20,7 @@
 
 use js_sys::JsString;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::{JsStringLike, JsStringLikeOwn};
+use wasm_bindgen::JsStringLike;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/generic_import_args.js")]
@@ -65,15 +65,10 @@ extern "C" {
     #[wasm_bindgen(experimental_generic_mono, js_name = sumSlice)]
     fn sum_slice<T>(xs: &[T]) -> f64;
 
-    // `JsStringLike`/`JsStringLikeOwn` bounds: every string shape crosses at its
-    // native wire format (UTF-8 buffer vs handle) but must arrive in JS as a
-    // string *value*, and a JS string return must be receivable as either an
-    // owned copy or a handle.
+    // `JsStringLike` bound: every string shape crosses at its native wire
+    // format (UTF-8 buffer vs handle) but must arrive in JS as a string *value*.
     #[wasm_bindgen(experimental_generic_mono, js_name = describeStr)]
     fn describe_str<T: JsStringLike>(s: T) -> String;
-
-    #[wasm_bindgen(experimental_generic_mono, js_name = makeStr)]
-    fn make_str<T: JsStringLikeOwn>() -> T;
 }
 
 #[wasm_bindgen_test]
@@ -138,12 +133,6 @@ fn experimental_generic_mono_string_arg_bound() {
     let js = JsString::from("handle");
     assert_eq!(describe_str(&js), "string:handle");
     assert_eq!(describe_str(js), "string:handle");
-}
-
-#[wasm_bindgen_test]
-fn experimental_generic_mono_string_ret_bound() {
-    assert_eq!(make_str::<String>(), "made");
-    assert_eq!(make_str::<JsString>().to_string(), "made");
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/generic_import_args.rs
+++ b/tests/wasm/generic_import_args.rs
@@ -69,6 +69,9 @@ extern "C" {
     // format (UTF-8 buffer vs handle) but must arrive in JS as a string *value*.
     #[wasm_bindgen(experimental_generic_mono, js_name = describeStr)]
     fn describe_str<T: JsStringLike>(s: T) -> String;
+
+    #[wasm_bindgen(experimental_generic_mono, js_name = describeStr)]
+    fn describe_str_impl(s: impl JsStringLike) -> String;
 }
 
 #[wasm_bindgen_test]
@@ -133,6 +136,16 @@ fn experimental_generic_mono_string_arg_bound() {
     let js = JsString::from("handle");
     assert_eq!(describe_str(&js), "string:handle");
     assert_eq!(describe_str(js), "string:handle");
+}
+
+#[wasm_bindgen_test]
+fn experimental_generic_mono_string_arg_impl_trait() {
+    assert_eq!(describe_str_impl("borrowed"), "string:borrowed");
+    assert_eq!(describe_str_impl(String::from("owned")), "string:owned");
+
+    let js = JsString::from("handle");
+    assert_eq!(describe_str_impl(&js), "string:handle");
+    assert_eq!(describe_str_impl(js), "string:handle");
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
This adds an experimental `JsStringLike` marker trait naming the string shapes that cross the wasm ABI as JavaScript string values.

Generic imports bound with `experimental_generic_mono` can already accept any concrete type satisfying the ABI traits, but there has been no way to name "any string" as a bound. This trait provides that vocabulary, so an import can accept whichever string shape the caller already holds — each crossing at its native wire format (UTF-8 buffers for the Rust strings, a handle for `JsString`, no re-encode) — rather than forcing every caller through one concrete shape.

* `JsStringLike` — implemented for `String`, `&str`, `js_sys::JsString` and `&js_sys::JsString`, with `IntoWasmAbi + OptionIntoWasmAbi` supertraits so both plain and nullable argument positions work under the single bound
* the trait is open: implementing it for a `#[wasm_bindgen]`-imported type is a promise that it marshals as a JS string
* like `experimental_generic_mono` itself, the trait is marked experimental and may change as that feature stabilizes

```rust
#[wasm_bindgen]
extern "C" {
    #[wasm_bindgen(experimental_generic_mono)]
    fn set_title<T: JsStringLike>(title: T);
}
```

Runtime tests cover all four argument shapes through a single generic import, and the guide documents the trait under the `experimental_generic_mono` reference.
