### PR TITLE
js-sys: fix compilation failure with `no_std` and `futures-core-03-stream`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - run: >
         cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown
         -p wasm-bindgen
-        -p js-sys
+        -p js-sys --features js-sys/futures-core-03-stream
         -p web-sys
         -p wasm-bindgen-futures
         -p wasm-bindgen-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@
 
 ### Fixed
 
+* Fixed `js-sys` failing to compile with `no_std` and the
+  `futures-core-03-stream` feature enabled, since the feature unconditionally
+  pulled in `futures-util/std`. The `std` feature of `futures-util` is now only
+  enabled by the `js-sys` `std` feature.
+  [#5322](https://github.com/wasm-bindgen/wasm-bindgen/pull/5322)
+
 * The thread-bootstrap transform is now skipped in Emscripten mode, where the
   Emscripten runtime owns pthread startup and TLS. It previously ran on any
   module with shared memory and aborted the build (`failed to find

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -23,7 +23,7 @@ test = false
 [features]
 # TODO: remove unsafe-eval for 1.0 release
 default = ["std", "unsafe-eval"]
-std = ["wasm-bindgen/std", "dep:futures-util"]
+std = ["wasm-bindgen/std", "futures-util/std"]
 # It has been agreed to gate functionnality requiring CSP unsafe-eval behind this feature
 # See https://github.com/wasm-bindgen/wasm-bindgen/issues/1647#issuecomment-3775469177
 unsafe-eval = []
@@ -35,7 +35,7 @@ futures-core-03-stream = ["dep:futures-util", "dep:futures-core"]
 [dependencies]
 cfg-if = "1.0.0"
 futures-core = { version = "0.3.8", default-features = false, optional = true }
-futures-util = { version = "0.3.31", default-features = false, features = ["std"], optional = true }
+futures-util = { version = "0.3.31", default-features = false, optional = true }
 wasm-bindgen = { path = "../..", version = "=0.2.127", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]


### PR DESCRIPTION
### Description

Fix compilation:

```console
$ RUSTC_BOOTSTRAP=1 cargo check -Zbuild-std=core,alloc -q -p js-sys --no-default-features --features futures-core-03-stream --target armv7a-none-eabihf
error[E0463]: can't find crate for `std`
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-core-0.3.34/src/lib.rs:16:1
   |
16 | extern crate std;
   | ^^^^^^^^^^^^^^^^^ can't find crate
   |
   = note: the `armv7a-none-eabihf` target may not support the standard library
   = help: consider building the standard library from source with `cargo build -Zbuild-std`

```

### Checklist

- [x] Verified changelog requirement
