### PR TITLE
Fix non_wasm_test deadlock with a single test thread

### DIFF
--- a/tests/non_wasm_test.rs
+++ b/tests/non_wasm_test.rs
@@ -1,25 +1,6 @@
 #![cfg(not(target_family = "wasm"))]
 
-use std::sync::{Arc, Condvar, Mutex};
-
-use once_cell::sync::Lazy;
 use wasm_bindgen_test::wasm_bindgen_test;
 
-static TEST: Lazy<Arc<(Mutex<bool>, Condvar)>> =
-    Lazy::new(|| Arc::new((Mutex::new(false), Condvar::new())));
-
 #[wasm_bindgen_test(unsupported = test)]
-fn test_success() {
-    let mut success = TEST.0.lock().unwrap();
-    *success = true;
-    // We notify the condvar that the value has changed.
-    TEST.1.notify_one();
-}
-
-#[test]
-fn test() {
-    let mut success = TEST.0.lock().unwrap();
-    while !*success {
-        success = TEST.1.wait(success).unwrap();
-    }
-}
+fn test_success() {}


### PR DESCRIPTION
### Description

Fixes the `non_wasm_test` deadlock on single-CPU hosts, resolving #5202.

`tests/non_wasm_test.rs` used a condvar handshake between two tests: `test` waited for `test_success` to signal. That only works when cargo runs both at once. On a 1-CPU machine cargo defaults to `--test-threads=1`, so `test` runs first, waits, and never lets `test_success` start.

The condvar was not testing `unsupported = test`. Dropping it leaves a single `#[wasm_bindgen_test(unsupported = test)]` that compiles and runs on native.

Verified:

```
# before (hung after "test test ...")
cargo test --test non_wasm_test -- --test-threads=1

# after
cargo test --test non_wasm_test -- --test-threads=1
# test result: ok. 1 passed
```

### Checklist

- [x] Verified changelog requirement
