### PR TITLE
deps: update walrus to 0.27.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 
 ### Fixed
 
-* Updated `walrus` to 0.27.1, fixing `--keep-debug` output whose `.debug_loc`
-  referenced removed code becoming unparseable (`wasm-opt -g` failed with
-  `debug_loc error`).
+* Updated `walrus` to 0.27.2, fixing `--keep-debug` output that `wasm-opt -g`
+  could not process: `.debug_loc` entries for removed code were unparseable
+  (`debug_loc error`), and `DW_AT_high_pc` was re-encoded as variable-width
+  `udata` (`compile unit size was incorrect`).
   [#5328](https://github.com/wasm-bindgen/wasm-bindgen/pull/5328)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ### Fixed
 
+* Updated `walrus` to 0.27.1, fixing `--keep-debug` output whose `.debug_loc`
+  referenced removed code becoming unparseable (`wasm-opt -g` failed with
+  `debug_loc error`).
+  [#5328](https://github.com/wasm-bindgen/wasm-bindgen/pull/5328)
+
 ### Removed
 
 ## [0.2.128](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.127...0.2.128)

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 rustc-demangle = "0.1.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-walrus = { version = "0.26.1", features = ['parallel'] }
+walrus = { version = "0.27.1", features = ['parallel'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.128" }
 wasmparser = "0.245"
 

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 rustc-demangle = "0.1.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-walrus = { version = "0.27.1", features = ['parallel'] }
+walrus = { version = "0.27.2", features = ['parallel'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.128" }
 wasmparser = "0.245"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0"
 shlex = "1"
 tempfile = "3.0"
 ureq = { version = "3", default-features = false, features = ["brotli", "gzip"] }
-walrus = "0.27.1"
+walrus = "0.27.2"
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.128" }
 wasm-bindgen-test-shared = { path = "../test-shared", version = "=0.2.128" }
 wasmparser = "0.245"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0"
 shlex = "1"
 tempfile = "3.0"
 ureq = { version = "3", default-features = false, features = ["brotli", "gzip"] }
-walrus = "0.26.1"
+walrus = "0.27.1"
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.128" }
 wasm-bindgen-test-shared = { path = "../test-shared", version = "=0.2.128" }
 wasmparser = "0.245"


### PR DESCRIPTION
This updates `walrus` from 0.26 to 0.27.2, so that `wasm-bindgen --keep-debug` output can be processed by `wasm-opt -g`.

Two walrus bugs made binaryen's DWARF update fail on every module wasm-bindgen emitted with debug info:

* Addresses in code that walrus removed were tombstoned as `0xFFFFFFFF`, which in a DWARF 4 `.debug_loc`/`.debug_ranges` with 4-byte addresses is the base address selection marker. Readers desync and the rest of the section is unparseable (`llvm-dwarfdump`: "unexpected end of data"; `wasm-opt -g`: `debug_loc error`). Fixed in wasm-bindgen/walrus#322 (0.27.1).
* `DW_AT_high_pc` was re-encoded from LLVM's fixed-width `DW_FORM_data4` to `DW_FORM_udata`. binaryen patches `high_pc` in place after code moves and requires the compile unit size to be unchanged, so it aborted with "compile unit size was incorrect". Fixed in wasm-bindgen/walrus#323 (0.27.2).

This showed up with emscripten's `-sWASM_BINDGEN`, where emcc runs `wasm-opt -g` after wasm-bindgen as part of the link; with 0.27.2 that pipeline works with DWARF intact.

0.27.0 also removed the experimental `memory.discard` instruction support and moved `dylink.0` metadata ahead of standard sections; neither affects wasm-bindgen's output (cli-support and cli test suites pass unchanged).
