### PR TITLE
cli-support: support Emscripten shared memory / pthreads mode

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -772,8 +772,15 @@ impl<'a> Context<'a> {
             String::new()
         };
 
-        if let Some(mem) = self.module.memories.iter().next() {
-            if let Some(id) = mem.import {
+        // Emscripten pthreads import shared memory as `env.memory` rather than placeholder.
+        if !matches!(self.config.mode, OutputMode::Emscripten) {
+            if let Some((mem, id)) = self
+                .module
+                .memories
+                .iter()
+                .next()
+                .and_then(|mem| mem.import.map(|id| (mem, id)))
+            {
                 self.module.imports.get_mut(id).module = PLACEHOLDER_MODULE.to_owned();
                 let mut init_memory = "new WebAssembly.Memory({".to_string();
                 init_memory.push_str(&format!("initial:{}", mem.initial));

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -380,8 +380,13 @@ impl Bindgen {
             bail!("--experimental-reset-state-function is only supported for --target module, --target web, or --target nodejs")
         }
 
-        let thread_count = transforms::threads::run(&mut module)
-            .with_context(|| "failed to prepare module for threading")?;
+        // Emscripten's pthread runtime manages `__wasm_init_tls` and TLS stacks itself.
+        let thread_count = if self.mode.emscripten() {
+            None
+        } else {
+            transforms::threads::run(&mut module)
+                .with_context(|| "failed to prepare module for threading")?
+        };
 
         // If requested, turn all mangled symbols into prettier unmangled
         // symbols with the help of `rustc-demangle`.


### PR DESCRIPTION
Hello! I am your friendly neighbourhood spaghetti toaster AI.

Emscripten pthreads (`-pthread` / `--shared-memory`) imports `env.memory` (`shared = true`) and emits its own TLS init (`__wasm_init_tls`). Without this change:
1. `transforms::threads::run` sees `shared = true` and deletes `__wasm_init_tls` / overwrites `__tls_base`.
2. `js::Context` sees `mem.import.is_some()` and rewrites `env.memory` to `__wbindgen_placeholder__.memory`, causing a `LinkError` on instantiation.

Skipping both when `OutputMode::Emscripten` is active preserves Emscripten's TLS and `env.memory` import.