### PR TITLE
Disable reinit machinery in Emscripten output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 
 ### Fixed
 
+* Emscripten output no longer emits the instance reinit machinery, which
+  Emscripten's JS compiler rejected (unescaped multi-line `__postset`, and
+  `var reinit_scheduled = let ...`): `schedule_reinit()` is a no-op there since
+  Emscripten owns instantiation. The closure finalization `__postset` is now
+  emitted as an escaped string literal.
+  [#5332](https://github.com/wasm-bindgen/wasm-bindgen/pull/5332)
+
 * Updated `walrus` to 0.27.2, fixing `--keep-debug` output that `wasm-opt -g`
   could not process: `.debug_loc` entries for removed code were unparseable
   (`debug_loc error`), and `DW_AT_high_pc` was re-encoded as variable-width

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -361,7 +361,10 @@ impl<'a> Context<'a> {
             config,
             threads_enabled: threads_xform::is_enabled(module),
             unwind_enabled: has_local_exception_tags(module),
-            generate_reinit: aux.uses_reinit || config.generate_reset_state,
+            // Emscripten owns instantiation, so the instance cannot be reset
+            // from the bindgen glue; reinit requests are no-ops there.
+            generate_reinit: !matches!(config.mode, OutputMode::Emscripten)
+                && (aux.uses_reinit || config.generate_reset_state),
             module,
             npm_dependencies: Default::default(),
             wit,
@@ -4355,10 +4358,13 @@ if (require('worker_threads').isMainThread) {{
             };
 
             if matches!(self.config.mode, OutputMode::Emscripten) {
+                let postset = format!(
+                    "CLOSURE_DTORS = (typeof FinalizationRegistry === 'undefined') ? {{ register: () => {{}}, unregister: () => {{}} }} : new FinalizationRegistry({prevent_stale});"
+                );
                 format!(
                     "addToLibrary({{
                         $CLOSURE_DTORS: {{}},
-                        $CLOSURE_DTORS__postset: \"CLOSURE_DTORS = (typeof FinalizationRegistry === 'undefined') ? {{ register: () => {{}}, unregister: () => {{}} }} : new FinalizationRegistry({prevent_stale});\"
+                        $CLOSURE_DTORS__postset: {postset:?}
                     }});\n"
                 )
             }             else {
@@ -6572,7 +6578,11 @@ addToLibrary({
             }
             Intrinsic::Reinit => {
                 assert_eq!(args.len(), 0);
-                "__wbg_reinit_scheduled = true".to_string()
+                if self.generate_reinit {
+                    "__wbg_reinit_scheduled = true".to_string()
+                } else {
+                    "undefined".to_string()
+                }
             }
 
             // Identity: the shim hands the pending Promise straight back to

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2566,6 +2566,63 @@ fn emscripten_shared_memory_skips_thread_transform() {
 }
 
 #[test]
+fn emscripten_reinit_is_noop_and_library_parses() {
+    // Emscripten owns instantiation, so the reinit machinery that
+    // `schedule_reinit()` turns on has nothing to reset there; it must not
+    // be emitted. The closure
+    // finalization registry (a multi-line `__postset`) must also come out as
+    // a valid JS string literal.
+    let mut project = Project::new("emscripten_reinit_is_noop_and_library_parses");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub fn make_closure() -> JsValue {
+                let cb = Closure::<dyn Fn()>::new(|| wasm_bindgen::handler::schedule_reinit());
+                cb.into_js_value()
+            }
+        "#,
+    );
+
+    let built = project.build();
+    let mut module = ModuleConfig::new().parse_file(&built).unwrap();
+    module.customs.add(RawCustomSection {
+        name: "__wasm_bindgen_emscripten_marker".into(),
+        data: vec![1],
+    });
+    let emscripten_wasm = project.root.join("emscripten_input.wasm");
+    module.emit_wasm_file(&emscripten_wasm).unwrap();
+
+    let out_dir = project.root.join("pkg-emscripten");
+    fs::create_dir_all(&out_dir).unwrap();
+    wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--out-dir".as_ref(),
+        out_dir.as_os_str(),
+        emscripten_wasm.as_os_str(),
+    ])
+    .unwrap();
+
+    let lib = fs::read_to_string(out_dir.join("library_bindgen.js")).unwrap();
+    assert!(
+        !lib.contains("__wbg_reinit_scheduled") && !lib.contains("__wbg_reset_state"),
+        "reinit machinery must not be emitted for emscripten:\n{lib}"
+    );
+    assert!(lib.contains("$CLOSURE_DTORS__postset"));
+
+    // The library is a script evaluated by emcc's JS compiler, where
+    // `addToLibrary` is provided.
+    Command::new("node")
+        .arg("-e")
+        .arg("globalThis.addToLibrary = () => {}; require(process.argv[1])")
+        .arg(out_dir.join("library_bindgen.js"))
+        .assert()
+        .success();
+}
+
+#[test]
 fn emscripten_namespaced_exports_valid_ts() {
     // Covers all three TS-emission bugs for namespaced (`js_namespace`)
     // exports in emscripten output:


### PR DESCRIPTION
This fixes Emscripten-mode output for crates using `schedule_reinit()` (e.g. the `worker` crate), where emcc's JS compiler rejected `library_bindgen.js`:

```
$CLOSURE_DTORS__postset: "CLOSURE_DTORS = (typeof FinalizationRegistry === 'undefined') ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry(state => {
                         ^^^^ SyntaxError: Invalid or unexpected token
```

and, once past that:

```
var reinit_scheduled = let __wbg_reinit_scheduled = false;;
```

Emscripten owns instantiation, so there is nothing for the reinit machinery to reset there.

* `generate_reinit` is forced off for `OutputMode::Emscripten`; the `Reinit` intrinsic lowers to `undefined` when disabled.
* The closure finalization `__postset` is emitted through `{:?}` so the multi-line body becomes an escaped string literal, matching the other postsets.

Test: `emscripten_reinit_is_noop_and_library_parses` builds a closure that calls `schedule_reinit()`, runs the CLI in emscripten mode, asserts no reinit symbols are emitted, and evaluates `library_bindgen.js` under node (fails on `main` with the `SyntaxError` above).