### PR TITLE
Support JSPI on the emscripten target via its lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ### Added
 
+* Added JSPI support on the `wasm32-unknown-emscripten` target:
+  `#[wasm_bindgen(jspi)]`, `#[wasm_bindgen(suspending)]`,
+  `jspi_block_on_promise` and the JSPI context inheritance of `spawn_local`
+  now work when linking with `-sJSPI` and `-sJSPI_HOOKS` (or
+  `-sREENTRANT_JSPI`). The fibers belong to emscripten's JSPI runtime, which
+  wasm-bindgen integrates with through its lifecycle hook exports instead of
+  its own shadow stack management.
+  [#5330](https://github.com/wasm-bindgen/wasm-bindgen/pull/5330)
+
 ### Changed
 
 ### Fixed

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -2150,8 +2150,9 @@ impl Invocation {
                         Cow::Owned(format!("let {cache_var};"))
                     };
                     cx.intrinsic(Cow::Owned(cache_var.clone()), Some(&cache_var), decl, &[]);
+                    let raw = cx.raw_wasm_export_ref(&name);
                     Ok(format!(
-                        "({cache_var} ??= WebAssembly.promising({accessor}))({})",
+                        "({cache_var} ??= WebAssembly.promising({raw}))({})",
                         args.join(", ")
                     ))
                 } else {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -5585,13 +5585,15 @@ addToLibrary({
                 // evaluation time before `wasmImports` is assembled.
                 let import_def = if self.aux.imports_with_suspending.contains(&id) {
                     if matches!(self.config.mode, OutputMode::Emscripten) {
-                        let name = self.module.imports.get(core).name.clone();
+                        // The jsifier binds library functions under their
+                        // asmjs-mangled identifier.
+                        let name = emscripten_mangle(&self.module.imports.get(core).name);
                         self.emscripten_import_postsets.insert(
                             core,
                             format!(
-                                "var __wbg_inner_{name} = {name}; \
+                                "var __wbg_inner{name} = {name}; \
                                  {name} = new WebAssembly.Suspending(function(...args) {{ \
-                                     try {{ return __wbg_inner_{name}.apply(this, args); }} \
+                                     try {{ return __wbg_inner{name}.apply(this, args); }} \
                                      catch (e) {{ return Promise.reject(e); }} \
                                  }});"
                             ),
@@ -6619,7 +6621,8 @@ addToLibrary({
                     Cow::Owned(format!("let {cache};"))
                 };
                 self.intrinsic(Cow::Borrowed(cache), Some(cache), decl, &[]);
-                let trampoline = self.wasm_export_ref(crate::transforms::jspi::TASK_POLL_EXPORT);
+                let trampoline =
+                    self.raw_wasm_export_ref(crate::transforms::jspi::TASK_POLL_EXPORT);
                 // The promise is dropped, so a poll that unwinds (a panic, or
                 // a rethrown rejection of a non-`catch` suspending import)
                 // surfaces as an unhandled rejection. When the catch-wrapper
@@ -7068,6 +7071,18 @@ addToLibrary({
     fn wasm_export_ref(&self, name: &str) -> String {
         if matches!(self.config.mode, OutputMode::Emscripten) {
             emscripten_mangle(name)
+        } else {
+            format!("wasm.{name}")
+        }
+    }
+
+    /// JS expression for the raw exported wasm function, as
+    /// `WebAssembly.promising` requires. On emscripten the mangled binding may
+    /// be an assertion wrapper (`createExportWrapper`), so read `wasmExports`
+    /// directly; metadce roots name-keyed `wasmExports` accesses.
+    fn raw_wasm_export_ref(&self, name: &str) -> String {
+        if matches!(self.config.mode, OutputMode::Emscripten) {
+            format!("wasmExports[{name:?}]")
         } else {
             format!("wasm.{name}")
         }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -522,11 +522,11 @@ impl Bindgen {
         // suspending wrappers (via the repointed `implements` entries) so
         // that promise rejections are consumed innermost as data while
         // SuspendError misuse and rethrown exceptions still reach the
-        // abort/catch machinery over a restored shadow stack. The transform
-        // is target agnostic: on emscripten it operates against emscripten's
-        // `__stack_pointer` in exactly the same way, with no interaction
-        // with emscripten's own JSPI machinery.
-        run_jspi_transform(&mut module, self.externref)?;
+        // abort/catch machinery over a restored shadow stack. On emscripten
+        // the fibers belong to emscripten's JSPI runtime, so the wrappers
+        // call its lifecycle hooks instead and touch no stack state.
+        let emscripten = matches!(self.mode, OutputMode::Emscripten).then_some(eh_version);
+        run_jspi_transform(&mut module, self.externref, emscripten)?;
 
         // Generate Wasm catch wrappers for imports with #[wasm_bindgen(catch)].
         // This runs after externref processing so that we have access to the
@@ -947,8 +947,13 @@ fn split_debug_info(wasm: &[u8], url: &str) -> Result<Vec<u8>, Error> {
 }
 
 /// Instrument `#[wasm_bindgen(jspi)]` exports and `#[wasm_bindgen(suspending)]`
-/// imports with in-wasm shadow-stack management. See `transforms::jspi`.
-fn run_jspi_transform(module: &mut Module, externref: bool) -> Result<(), Error> {
+/// imports with in-wasm shadow-stack management, or with emscripten's JSPI
+/// lifecycle hooks when `emscripten` is set. See `transforms::jspi`.
+fn run_jspi_transform(
+    module: &mut Module,
+    externref: bool,
+    emscripten: Option<transforms::ExceptionHandlingVersion>,
+) -> Result<(), Error> {
     let mut aux = module
         .customs
         .delete_typed::<wit::WasmBindgenAux>()
@@ -958,7 +963,7 @@ fn run_jspi_transform(module: &mut Module, externref: bool) -> Result<(), Error>
         .delete_typed::<wit::NonstandardWitSection>()
         .expect("wit section should exist");
 
-    let result = transforms::jspi::run(module, &mut aux, &mut wit, externref)
+    let result = transforms::jspi::run(module, &mut aux, &mut wit, externref, emscripten)
         .context("failed to instrument module for JSPI");
 
     module.customs.add(*wit);

--- a/crates/cli-support/src/transforms/jspi.rs
+++ b/crates/cli-support/src/transforms/jspi.rs
@@ -59,6 +59,10 @@
 //! would permanently leak the region above it. A fiber that never suspends
 //! completes synchronously under its still-live callers and keeps the entry
 //! offset.
+//!
+//! On the emscripten target none of this runs: emscripten's own JSPI runtime
+//! owns the fibers and their stacks, and the exports and imports are instead
+//! wrapped with its lifecycle hooks (see `transforms::jspi_hooks`).
 
 use crate::wit::{AdapterKind, Instruction, NonstandardWitSection, WasmBindgenAux};
 use anyhow::{anyhow, bail, Error};
@@ -78,6 +82,7 @@ pub fn run(
     aux: &mut WasmBindgenAux,
     wit: &mut NonstandardWitSection,
     externref: bool,
+    emscripten: Option<super::ExceptionHandlingVersion>,
 ) -> Result<(), Error> {
     // The wasm-level export ids of `#[wasm_bindgen(jspi)]` exports.
     let mut jspi_exports = Vec::new();
@@ -191,6 +196,18 @@ pub fn run(
         );
     }
 
+    if let Some(eh_version) = emscripten {
+        let legacy_eh = eh_version == super::ExceptionHandlingVersion::Legacy;
+        return super::jspi_hooks::run(
+            module,
+            aux,
+            wit,
+            jspi_exports,
+            suspending_imports,
+            legacy_eh,
+        );
+    }
+
     // The single stack-top snapshot and the fiber globals are per-instance,
     // not per-thread, and JSPI itself is a single-threaded proposal.
     if module.memories.iter().any(|m| m.shared) {
@@ -282,10 +299,10 @@ pub fn run(
     // The rejection protocol for `catch`-marked suspending imports, if any.
     let has_catch = suspending_imports.iter().any(|(_, c)| *c);
     let rejection = if has_catch {
-        let addr = aux.jspi_rejected.ok_or_else(|| {
+        let set_rejected = aux.jspi_set_rejected.ok_or_else(|| {
             anyhow!(
-                "could not locate the `__wbindgen_jspi_rejected` flag static; \
-                 it is defined by the wasm-bindgen runtime"
+                "could not locate `__wbindgen_jspi_set_rejected`; it is defined by \
+                 the wasm-bindgen runtime"
             )
         })?;
         // The JS glue wires `WebAssembly.JSTag` up to any present tag import
@@ -293,7 +310,10 @@ pub fn run(
         // unset — it means "catch imports use wasm catch wrappers", which is
         // the catch-wrapper transform's decision, not ours.
         let js_tag = crate::transforms::catch_handler::get_or_import_js_tag(module);
-        Some(Rejection { js_tag, addr })
+        Some(Rejection {
+            js_tag,
+            set_rejected,
+        })
     } else {
         None
     };
@@ -352,10 +372,10 @@ struct JspiContext {
 
 /// The rejection-to-data protocol for the suspend intrinsic.
 #[derive(Clone, Copy)]
-struct Rejection {
-    js_tag: TagId,
-    /// Linear-memory address of the `__wbindgen_jspi_rejected` u32 flag.
-    addr: u64,
+pub(super) struct Rejection {
+    pub(super) js_tag: TagId,
+    /// The runtime's `__wbindgen_jspi_set_rejected(i32)`.
+    pub(super) set_rejected: FunctionId,
 }
 
 fn const_zero(ty: ValType) -> ConstExpr {
@@ -682,7 +702,7 @@ fn push_align(body: &mut InstrSeqBuilder, ty: ValType) {
 ///                 local.set <results>...
 ///                 local.get $base $len $buf
 ///                 call $__jspi_restore
-///                 (i32.store rejected_addr (i32.const 0))
+///                 (call $__wbindgen_jspi_set_rejected (i32.const 0))
 ///                 local.get <results>...
 ///                 br $done
 ///             end
@@ -690,7 +710,7 @@ fn push_align(body: &mut InstrSeqBuilder, ty: ValType) {
 ///             local.set <result>
 ///             local.get $base $len $buf
 ///             call $__jspi_restore
-///             (i32.store rejected_addr (i32.const 1))
+///             (call $__wbindgen_jspi_set_rejected (i32.const 1))
 ///             local.get <result>
 ///             br $done
 ///         end
@@ -753,19 +773,7 @@ fn wrap_suspending(
         }
     };
     let store_rejected = |seq: &mut InstrSeqBuilder, rejection: Rejection, value: i32| {
-        match ctx.ptr_ty {
-            ValType::I64 => seq.i64_const(rejection.addr as i64),
-            _ => seq.i32_const(rejection.addr as i32),
-        };
-        seq.i32_const(value);
-        seq.store(
-            ctx.memory,
-            ir::StoreKind::I32 { atomic: false },
-            MemArg {
-                align: 4,
-                offset: 0,
-            },
-        );
+        seq.i32_const(value).call(rejection.set_rejected);
     };
 
     // Pre-allocate the block sequences so labels can reference each other.
@@ -881,7 +889,7 @@ fn wrap_suspending(
 }
 
 /// Rewrite all calls to suspending imports to go through the wrappers.
-fn rewrite_calls(module: &mut Module, wrappers: &HashMap<FunctionId, FunctionId>) {
+pub(super) fn rewrite_calls(module: &mut Module, wrappers: &HashMap<FunctionId, FunctionId>) {
     let wrapper_ids: std::collections::HashSet<_> = wrappers.values().copied().collect();
     for (func_id, func) in module.funcs.iter_local_mut() {
         if wrapper_ids.contains(&func_id) {

--- a/crates/cli-support/src/transforms/jspi_hooks.rs
+++ b/crates/cli-support/src/transforms/jspi_hooks.rs
@@ -1,0 +1,599 @@
+//! JSPI instrumentation for the emscripten target: lifecycle hooks instead of
+//! shadow-stack management.
+//!
+//! Under emscripten the fiber runtime is emscripten's own (`-sJSPI_HOOKS`, or
+//! `-sREENTRANT_JSPI` which gives every fiber its own shadow stack), reached
+//! through the four hook exports its libjspi provides:
+//!
+//! ```text
+//! __jspi_enter:   [] -> [i64 token]
+//! __jspi_exit:    [i64 token, i32 error] -> []
+//! __jspi_suspend: [] -> [i64 token]
+//! __jspi_resume:  [i64 token, i32 error] -> []
+//! ```
+//!
+//! This pass is the wasm-bindgen counterpart of binaryen's `--jspi-hooks`,
+//! which emscripten runs on its own `JSPI_EXPORTS`/`JSPI_IMPORTS` after
+//! wasm-bindgen has finished: each `#[wasm_bindgen(jspi)]` export is wrapped
+//! with `enter`/`exit` and each `#[wasm_bindgen(suspending)]` import with
+//! `suspend`/`resume`. The token returned by the "before" hook is kept in a
+//! local (which JSPI preserves across the suspension) and handed to the
+//! "after" hook, never interpreted. An exceptional completion delivers the
+//! after hook with `error=1` and rethrows the exception unchanged.
+//!
+//! The `catch` rejection-to-data protocol of `transforms::jspi` is kept: a
+//! `catch`-marked suspending import catches the `WebAssembly.JSTag` exception
+//! JSPI throws at the resume point for a rejected promise, reports it through
+//! `__wbindgen_jspi_set_rejected` and returns the reason as its value. The
+//! resume hook sees `error=0` there, since the exception is consumed rather
+//! than rethrown.
+//!
+//! Emscripten defaults to the legacy exception-handling instructions and
+//! engines reject modules mixing the two dialects, so the wrappers are emitted
+//! in whichever form the module already uses.
+
+use super::jspi::Rejection;
+use crate::wit::{NonstandardWitSection, WasmBindgenAux};
+use anyhow::{anyhow, bail, Error};
+use std::collections::HashMap;
+use walrus::ir::{self, LegacyCatch};
+use walrus::{
+    ExportId, ExportItem, FunctionBuilder, FunctionId, InstrSeqBuilder, Module, RefType, ValType,
+};
+
+const HOOK_NAMES: [&str; 4] = [
+    "__jspi_enter",
+    "__jspi_exit",
+    "__jspi_suspend",
+    "__jspi_resume",
+];
+
+#[derive(Clone, Copy)]
+struct Hooks {
+    enter: FunctionId,
+    exit: FunctionId,
+    suspend: FunctionId,
+    resume: FunctionId,
+}
+
+impl Hooks {
+    fn locate(module: &Module) -> Result<Self, Error> {
+        let before = (&[][..], &[ValType::I64][..]);
+        let after = (&[ValType::I64, ValType::I32][..], &[][..]);
+        let mut ids = [None; 4];
+        for (i, (name, sig)) in HOOK_NAMES
+            .iter()
+            .zip([before, after, before, after])
+            .enumerate()
+        {
+            let func = module
+                .exports
+                .iter()
+                .find(|e| e.name == *name)
+                .and_then(|e| match e.item {
+                    ExportItem::Function(f) => Some(f),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    anyhow!(
+                        "JSPI on the emscripten target requires the `{name}` hook export \
+                         provided by emscripten's JSPI runtime; link with `-sJSPI_HOOKS` \
+                         (or `-sREENTRANT_JSPI`)"
+                    )
+                })?;
+            let ty = module.types.get(module.funcs.get(func).ty());
+            if ty.params() != sig.0 || ty.results() != sig.1 {
+                bail!(
+                    "emscripten JSPI hook export `{name}` has type {:?} -> {:?}, \
+                     expected {:?} -> {:?}",
+                    ty.params(),
+                    ty.results(),
+                    sig.0,
+                    sig.1
+                );
+            }
+            ids[i] = Some(func);
+        }
+        Ok(Hooks {
+            enter: ids[0].unwrap(),
+            exit: ids[1].unwrap(),
+            suspend: ids[2].unwrap(),
+            resume: ids[3].unwrap(),
+        })
+    }
+}
+
+pub(super) fn run(
+    module: &mut Module,
+    aux: &WasmBindgenAux,
+    wit: &mut NonstandardWitSection,
+    jspi_exports: Vec<ExportId>,
+    suspending_imports: Vec<(FunctionId, bool)>,
+    legacy_eh: bool,
+) -> Result<(), Error> {
+    let hooks = Hooks::locate(module)?;
+
+    for export_id in jspi_exports {
+        let inner = match module.exports.get(export_id).item {
+            ExportItem::Function(f) => f,
+            _ => bail!("jspi export is not a function"),
+        };
+        let wrapper = wrap(module, inner, hooks.enter, hooks.exit, None, legacy_eh);
+        let name = module.funcs.get(inner).name.clone();
+        module.funcs.get_mut(wrapper).name = name.map(|n| format!("{n} jspi wrapper"));
+        module.exports.get_mut(export_id).item = wrapper.into();
+    }
+
+    if suspending_imports.is_empty() {
+        return Ok(());
+    }
+
+    let rejection = if suspending_imports.iter().any(|(_, c)| *c) {
+        let set_rejected = aux.jspi_set_rejected.ok_or_else(|| {
+            anyhow!(
+                "could not locate `__wbindgen_jspi_set_rejected`; it is defined by \
+                 the wasm-bindgen runtime"
+            )
+        })?;
+        let js_tag = super::catch_handler::get_or_import_js_tag(module);
+        Some(Rejection {
+            js_tag,
+            set_rejected,
+        })
+    } else {
+        None
+    };
+
+    let mut wrappers = HashMap::new();
+    for (import, catch) in suspending_imports {
+        if wrappers.contains_key(&import) {
+            continue;
+        }
+        let rejection = if catch {
+            let ty = module.types.get(module.funcs.get(import).ty());
+            if ty.results() != [ValType::Ref(RefType::EXTERNREF)] {
+                bail!(
+                    "unexpected ABI for a `catch` suspending import: expected \
+                     an externref return, found {:?}",
+                    ty.results()
+                );
+            }
+            rejection
+        } else {
+            None
+        };
+        let wrapper = wrap(
+            module,
+            import,
+            hooks.suspend,
+            hooks.resume,
+            rejection,
+            legacy_eh,
+        );
+        let name = module.funcs.get(import).name.clone();
+        module.funcs.get_mut(wrapper).name = Some(match name {
+            Some(n) => format!("{n} suspending wrapper"),
+            None => "suspending wrapper".to_string(),
+        });
+        wrappers.insert(import, wrapper);
+    }
+    super::jspi::rewrite_calls(module, &wrappers);
+
+    for (_, func, adapter) in wit.implements.iter_mut() {
+        if aux.imports_with_suspending.contains(adapter) {
+            if let Some(wrapper) = wrappers.get(func) {
+                *func = *wrapper;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Wrap `target` with the `before`/`after` hook pair.
+///
+/// Standardized form (the optional `$rejected` arm only for `catch`
+/// suspending imports):
+///
+/// ```wat
+/// (func $wrapper (param ...) (result ...)
+///     (local $tok i64) (local $exn exnref)
+///     call $before
+///     local.set $tok
+///     block $done (result ...)
+///         block $catch_all (result exnref)
+///             block $rejected (result externref)
+///                 try_table (result ...) (catch $__wbindgen_jstag $rejected)
+///                                        (catch_all_ref $catch_all)
+///                     local.get <params>...
+///                     call $target
+///                 end
+///                 local.set <results>...
+///                 (call $after (local.get $tok) (i32.const 0))
+///                 (call $__wbindgen_jspi_set_rejected (i32.const 0))
+///                 local.get <results>...
+///                 br $done
+///             end
+///             local.set <result>
+///             (call $after (local.get $tok) (i32.const 0))
+///             (call $__wbindgen_jspi_set_rejected (i32.const 1))
+///             local.get <result>
+///             br $done
+///         end
+///         local.set $exn
+///         (call $after (local.get $tok) (i32.const 1))
+///         local.get $exn
+///         throw_ref
+///     end)
+/// ```
+///
+/// Legacy form:
+///
+/// ```wat
+/// (func $wrapper (param ...) (result ...)
+///     (local $tok i64)
+///     call $before
+///     local.set $tok
+///     block $done (result ...)
+///         try (result ...)
+///             local.get <params>...
+///             call $target
+///         catch $__wbindgen_jstag
+///             local.set <result>
+///             (call $after (local.get $tok) (i32.const 0))
+///             (call $__wbindgen_jspi_set_rejected (i32.const 1))
+///             local.get <result>
+///             br $done
+///         catch_all
+///             (call $after (local.get $tok) (i32.const 1))
+///             rethrow 0
+///         end
+///         local.set <results>...
+///         (call $after (local.get $tok) (i32.const 0))
+///         (call $__wbindgen_jspi_set_rejected (i32.const 0))
+///         local.get <results>...
+///     end)
+/// ```
+fn wrap(
+    module: &mut Module,
+    target: FunctionId,
+    before: FunctionId,
+    after: FunctionId,
+    rejection: Option<Rejection>,
+    legacy_eh: bool,
+) -> FunctionId {
+    let ty = module.types.get(module.funcs.get(target).ty());
+    let params = ty.params().to_vec();
+    let results = ty.results().to_vec();
+
+    let results_ty: ir::InstrSeqType = match results.len() {
+        0 => ir::InstrSeqType::Simple(None),
+        1 => ir::InstrSeqType::Simple(Some(results[0])),
+        _ => module.types.add(&[], &results).into(),
+    };
+
+    let mut builder = FunctionBuilder::new(&mut module.types, &params, &results);
+    let param_locals: Vec<_> = params.iter().map(|ty| module.locals.add(*ty)).collect();
+    let result_locals: Vec<_> = results.iter().map(|ty| module.locals.add(*ty)).collect();
+    let tok = module.locals.add(ValType::I64);
+
+    let call_after = |seq: &mut InstrSeqBuilder, error: i32| {
+        seq.local_get(tok).i32_const(error).call(after);
+    };
+    let stash_results = |seq: &mut InstrSeqBuilder| {
+        for local in result_locals.iter().rev() {
+            seq.local_set(*local);
+        }
+    };
+    let unstash_results = |seq: &mut InstrSeqBuilder| {
+        for local in &result_locals {
+            seq.local_get(*local);
+        }
+    };
+    let store_rejected = |seq: &mut InstrSeqBuilder, value: i32| {
+        if let Some(rejection) = rejection {
+            seq.i32_const(value).call(rejection.set_rejected);
+        }
+    };
+
+    let done_seq = builder.dangling_instr_seq(results_ty).id();
+    let try_seq = builder.dangling_instr_seq(results_ty).id();
+    {
+        let mut seq = builder.instr_seq(try_seq);
+        for local in &param_locals {
+            seq.local_get(*local);
+        }
+        seq.call(target);
+    }
+
+    if legacy_eh {
+        let mut catches = Vec::new();
+        if let Some(rejection) = rejection {
+            let handler = builder.dangling_instr_seq(results_ty).id();
+            let mut seq = builder.instr_seq(handler);
+            stash_results(&mut seq);
+            call_after(&mut seq, 0);
+            store_rejected(&mut seq, 1);
+            unstash_results(&mut seq);
+            seq.br(done_seq);
+            catches.push(LegacyCatch::Catch {
+                tag: rejection.js_tag,
+                handler,
+            });
+        }
+        let catch_all = builder.dangling_instr_seq(results_ty).id();
+        {
+            let mut seq = builder.instr_seq(catch_all);
+            call_after(&mut seq, 1);
+            seq.instr(ir::Rethrow { relative_depth: 0 });
+        }
+        catches.push(LegacyCatch::CatchAll { handler: catch_all });
+
+        let mut seq = builder.instr_seq(done_seq);
+        seq.instr(ir::Try {
+            seq: try_seq,
+            catches,
+        });
+        stash_results(&mut seq);
+        call_after(&mut seq, 0);
+        store_rejected(&mut seq, 0);
+        unstash_results(&mut seq);
+    } else {
+        let exnref_ty: ir::InstrSeqType = ValType::Ref(RefType::EXNREF).into();
+        let externref_ty: ir::InstrSeqType = ValType::Ref(RefType::EXTERNREF).into();
+        let exn = module.locals.add(ValType::Ref(RefType::EXNREF));
+
+        let catch_all_seq = builder.dangling_instr_seq(exnref_ty).id();
+        let rejected_seq = rejection.map(|_| builder.dangling_instr_seq(externref_ty).id());
+
+        let mut catches = Vec::new();
+        if let (Some(rejection), Some(rejected_seq)) = (rejection, rejected_seq) {
+            catches.push(ir::TryTableCatch::Catch {
+                tag: rejection.js_tag,
+                label: rejected_seq,
+            });
+        }
+        catches.push(ir::TryTableCatch::CatchAllRef {
+            label: catch_all_seq,
+        });
+        {
+            let mut seq = builder.instr_seq(rejected_seq.unwrap_or(catch_all_seq));
+            seq.instr(ir::TryTable {
+                seq: try_seq,
+                catches,
+            });
+            stash_results(&mut seq);
+            call_after(&mut seq, 0);
+            store_rejected(&mut seq, 0);
+            unstash_results(&mut seq);
+            seq.br(done_seq);
+        }
+        if let Some(rejected_seq) = rejected_seq {
+            let mut seq = builder.instr_seq(catch_all_seq);
+            seq.instr(ir::Block { seq: rejected_seq });
+            stash_results(&mut seq);
+            call_after(&mut seq, 0);
+            store_rejected(&mut seq, 1);
+            unstash_results(&mut seq);
+            seq.br(done_seq);
+        }
+        {
+            let mut seq = builder.instr_seq(done_seq);
+            seq.instr(ir::Block { seq: catch_all_seq });
+            seq.local_set(exn);
+            call_after(&mut seq, 1);
+            seq.local_get(exn);
+            seq.instr(ir::ThrowRef {});
+        }
+    }
+
+    let mut body = builder.func_body();
+    body.call(before).local_set(tok);
+    body.instr(ir::Block { seq: done_seq });
+
+    builder.finish(param_locals, &mut module.funcs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transforms::parse_wat;
+    use walrus::ir::{Instr, InstrSeq, Visitor};
+    use walrus::FunctionKind;
+
+    const HOOKS_WAT: &str = r#"
+        (func $__jspi_enter (result i64) i64.const 0)
+        (func $__jspi_exit (param i64 i32))
+        (func $__jspi_suspend (result i64) i64.const 0)
+        (func $__jspi_resume (param i64 i32))
+        (export "__jspi_enter" (func $__jspi_enter))
+        (export "__jspi_exit" (func $__jspi_exit))
+        (export "__jspi_suspend" (func $__jspi_suspend))
+        (export "__jspi_resume" (func $__jspi_resume))
+        (func $__wbindgen_jspi_set_rejected (param i32))
+    "#;
+
+    fn module(catch: bool, legacy: bool) -> (Module, ExportId, FunctionId) {
+        let import = if catch {
+            r#"(import "env" "sleep" (func $sleep (param i32) (result externref)))"#
+        } else {
+            r#"(import "env" "sleep" (func $sleep (param i32) (result i32)))"#
+        };
+        let body = if legacy {
+            "try i32.const 1 drop catch_all end"
+        } else {
+            ""
+        };
+        let wat = format!(
+            r#"(module
+                {import}
+                (memory 1)
+                {HOOKS_WAT}
+                (func $work (param i32) (result i32)
+                    {body}
+                    local.get 0
+                    call $sleep
+                    drop
+                    local.get 0)
+                (export "work" (func $work)))"#
+        );
+        let module = parse_wat(&wat);
+        let export = module
+            .exports
+            .iter()
+            .find(|e| e.name == "work")
+            .unwrap()
+            .id();
+        let import = module.funcs.by_name("sleep").unwrap();
+        (module, export, import)
+    }
+
+    fn run(catch: bool, legacy: bool) -> Module {
+        let (mut module, export, import) = module(catch, legacy);
+        let aux = WasmBindgenAux {
+            jspi_set_rejected: module.funcs.by_name("__wbindgen_jspi_set_rejected"),
+            ..Default::default()
+        };
+        let mut wit = NonstandardWitSection::default();
+        super::run(
+            &mut module,
+            &aux,
+            &mut wit,
+            vec![export],
+            vec![(import, catch)],
+            legacy,
+        )
+        .unwrap();
+        let features =
+            wasmparser::WasmFeatures::default() | wasmparser::WasmFeatures::LEGACY_EXCEPTIONS;
+        wasmparser::Validator::new_with_features(features)
+            .validate_all(&module.emit_wasm())
+            .expect("transformed module should validate");
+        module
+    }
+
+    /// The hook calls on every path of `func`, in order of appearance.
+    fn hook_calls(module: &Module, func: FunctionId) -> Vec<String> {
+        struct Scan<'a> {
+            module: &'a Module,
+            calls: Vec<String>,
+            legacy_try: usize,
+            try_table: usize,
+        }
+        impl<'instr> Visitor<'instr> for Scan<'_> {
+            fn start_instr_seq(&mut self, seq: &'instr InstrSeq) {
+                for (instr, _) in &seq.instrs {
+                    match instr {
+                        Instr::Call(c) => {
+                            if let Some(name) = &self.module.funcs.get(c.func).name {
+                                if name.starts_with("__jspi_") {
+                                    self.calls.push(name.clone());
+                                }
+                            }
+                        }
+                        Instr::Try(_) => self.legacy_try += 1,
+                        Instr::TryTable(_) => self.try_table += 1,
+                        _ => {}
+                    }
+                }
+            }
+        }
+        let FunctionKind::Local(local) = &module.funcs.get(func).kind else {
+            panic!("wrapper should be local");
+        };
+        let mut scan = Scan {
+            module,
+            calls: Vec::new(),
+            legacy_try: 0,
+            try_table: 0,
+        };
+        ir::dfs_in_order(&mut scan, local, local.entry_block());
+        scan.calls.push(format!(
+            "try={} try_table={}",
+            scan.legacy_try, scan.try_table
+        ));
+        scan.calls
+    }
+
+    fn wrapper_of_export(module: &Module, name: &str) -> FunctionId {
+        match module.exports.iter().find(|e| e.name == name).unwrap().item {
+            ExportItem::Function(f) => f,
+            _ => unreachable!(),
+        }
+    }
+
+    fn check(catch: bool, legacy: bool) {
+        let module = run(catch, legacy);
+        let eh = if legacy {
+            "try=1 try_table=0"
+        } else {
+            "try=0 try_table=1"
+        };
+
+        let export_wrapper = wrapper_of_export(&module, "work");
+        assert_ne!(export_wrapper, module.funcs.by_name("work").unwrap());
+        assert_eq!(
+            hook_calls(&module, export_wrapper),
+            ["__jspi_enter", "__jspi_exit", "__jspi_exit", eh]
+        );
+
+        // `work` now calls the suspending wrapper, not the import.
+        let import = module.funcs.by_name("sleep").unwrap();
+        let work = module.funcs.by_name("work").unwrap();
+        let FunctionKind::Local(local) = &module.funcs.get(work).kind else {
+            unreachable!()
+        };
+        let mut callee = None;
+        ir::dfs_in_order(&mut CalleeScan(&mut callee), local, local.entry_block());
+        let import_wrapper = callee.expect("work should call something");
+        assert_ne!(import_wrapper, import);
+        let resumes = if catch { 3 } else { 2 };
+        let mut expected = vec!["__jspi_suspend".to_string()];
+        expected.extend(std::iter::repeat_n("__jspi_resume".to_string(), resumes));
+        expected.push(eh.to_string());
+        assert_eq!(hook_calls(&module, import_wrapper), expected);
+    }
+
+    struct CalleeScan<'a>(&'a mut Option<FunctionId>);
+    impl<'instr> Visitor<'instr> for CalleeScan<'_> {
+        fn visit_call(&mut self, call: &ir::Call) {
+            *self.0 = Some(call.func);
+        }
+    }
+
+    #[test]
+    fn modern() {
+        check(false, false);
+    }
+
+    #[test]
+    fn modern_catch() {
+        check(true, false);
+    }
+
+    #[test]
+    fn legacy() {
+        check(false, true);
+    }
+
+    #[test]
+    fn legacy_catch() {
+        check(true, true);
+    }
+
+    #[test]
+    fn missing_hooks() {
+        let mut module = parse_wat(r#"(module (func $work) (export "work" (func $work)))"#);
+        let export = module.exports.iter().next().unwrap().id();
+        let err = super::run(
+            &mut module,
+            &WasmBindgenAux::default(),
+            &mut NonstandardWitSection::default(),
+            vec![export],
+            vec![],
+            false,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("-sJSPI_HOOKS"), "{err}");
+    }
+}

--- a/crates/cli-support/src/transforms/mod.rs
+++ b/crates/cli-support/src/transforms/mod.rs
@@ -2,6 +2,7 @@ pub mod catch_handler;
 pub mod export_sp_restore;
 pub mod externref;
 pub mod jspi;
+pub mod jspi_hooks;
 pub mod multi_value;
 pub mod threads;
 

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -190,29 +190,15 @@ pub fn process(
 
     // The JSPI transform (`transforms::jspi`) needs `__wbindgen_malloc`/
     // `__wbindgen_free` to evacuate fiber shadow stacks around suspensions,
-    // and the address of the `__wbindgen_jspi_rejected` flag static to report
-    // promise rejections. Record them before `unexport_intrinsics` removes
-    // their exports.
+    // and `__wbindgen_jspi_set_rejected` to report promise rejections. Record
+    // them before `unexport_intrinsics` removes their exports.
     if !cx.aux.imports_with_suspending.is_empty() || cx.aux.export_map.values().any(|e| e.jspi) {
         cx.aux.jspi_malloc = Some(cx.malloc()?);
         cx.aux.jspi_free = Some(cx.free()?);
-        cx.aux.jspi_rejected = cx
-            .module
-            .exports
-            .iter()
-            .find(|e| e.name == "__wbindgen_jspi_rejected")
-            .and_then(|e| match e.item {
-                walrus::ExportItem::Global(g) => Some(g),
-                _ => None,
-            })
-            .and_then(|g| match &cx.module.globals.get(g).kind {
-                walrus::GlobalKind::Local(walrus::ConstExpr::Value(v)) => match *v {
-                    walrus::ir::Value::I32(v) => Some(v as u32 as u64),
-                    walrus::ir::Value::I64(v) => Some(v as u64),
-                    _ => None,
-                },
-                _ => None,
-            });
+        cx.aux.jspi_set_rejected = cx
+            .function_exports
+            .get("__wbindgen_jspi_set_rejected")
+            .map(|p| p.1);
     }
 
     cx.verify()?;

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -88,11 +88,10 @@ pub struct WasmBindgenAux {
     pub jspi_malloc: Option<walrus::FunctionId>,
     pub jspi_free: Option<walrus::FunctionId>,
 
-    /// Linear-memory address of `js_sys::futures::jspi::__wbindgen_jspi_rejected`,
-    /// the flag the JSPI suspend wrapper writes in-fiber at every resume to
-    /// report whether the awaited promise rejected. Recorded from the exported
-    /// address global before `unexport_intrinsics` removes it.
-    pub jspi_rejected: Option<u64>,
+    /// The runtime's `__wbindgen_jspi_set_rejected`, which the JSPI suspend
+    /// wrapper calls in-fiber at every resume to report whether the awaited
+    /// promise rejected. Recorded before `unexport_intrinsics` removes it.
+    pub jspi_set_rejected: Option<walrus::FunctionId>,
 
     /// The imported JSTag for catching JavaScript exceptions in Wasm.
     /// When this is `Some`, all imports with `catch` use Wasm catch wrappers
@@ -603,6 +602,9 @@ impl walrus::CustomSection for WasmBindgenAux {
             roots.push_func(id);
         }
         if let Some(id) = self.jspi_free {
+            roots.push_func(id);
+        }
+        if let Some(id) = self.jspi_set_rejected {
             roots.push_func(id);
         }
         if let Some(id) = self.js_tag {

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -2997,14 +2997,16 @@ fn emscripten_exports_hoisted_to_library_symbols() {
 
 #[test]
 fn emscripten_jspi_codegen() {
-    // JSPI on the emscripten target uses exactly the same path as the other
-    // targets: the in-wasm shadow-stack instrumentation plus
-    // `WebAssembly.promising`/`WebAssembly.Suspending` in the JS glue — with
-    // no interaction with emscripten's own JSPI machinery. The emscripten
-    // specifics are purely about the JS library format: exports hoist as
-    // `async function` symbols, the promising cache is a library symbol, and
-    // the suspending import is rewrapped via `__postset` (a Suspending
-    // instance can't be stringified through the compile-time jsifier).
+    // On the emscripten target the fibers belong to emscripten's JSPI runtime
+    // (`-sJSPI_HOOKS` / `-sREENTRANT_JSPI`): wasm-bindgen emits no shadow-stack
+    // instrumentation of its own and instead wraps the jspi exports and
+    // suspending imports with the `__jspi_*` lifecycle hook exports that
+    // runtime provides. The JS glue is the same `WebAssembly.promising` /
+    // `WebAssembly.Suspending` as on other targets, in JS library form:
+    // exports hoist as `async function` symbols, the promising cache is a
+    // library symbol, and the suspending import is rewrapped via `__postset`
+    // (a Suspending instance can't be stringified through the compile-time
+    // jsifier).
     let mut project = Project::new("emscripten_jspi_codegen");
     project.file(
         "src/lib.rs",
@@ -3031,11 +3033,60 @@ fn emscripten_jspi_codegen() {
     );
 
     let built = project.build();
-    let mut module = ModuleConfig::new().parse_file(&built).unwrap();
-    module.customs.add(RawCustomSection {
-        name: "__wasm_bindgen_emscripten_marker".into(),
-        data: vec![1],
-    });
+    // `emit_wasm` consumes the custom sections, so parse afresh per emit.
+    let emscripten_module = || {
+        let mut module = ModuleConfig::new().parse_file(&built).unwrap();
+        module.customs.add(RawCustomSection {
+            name: "__wasm_bindgen_emscripten_marker".into(),
+            data: vec![1],
+        });
+        module
+    };
+
+    // Without emscripten's hook runtime linked in, JSPI is refused with a
+    // pointer at the link flag.
+    let no_hooks_wasm = project.root.join("emscripten_no_hooks.wasm");
+    emscripten_module().emit_wasm_file(&no_hooks_wasm).unwrap();
+    let no_hooks_dir = project.root.join("pkg-emscripten-no-hooks");
+    fs::create_dir_all(&no_hooks_dir).unwrap();
+    let err = wasm_bindgen_cli::wasm_bindgen::run_cli_with_args([
+        "wasm-bindgen".as_ref(),
+        "--out-dir".as_ref(),
+        no_hooks_dir.as_os_str(),
+        no_hooks_wasm.as_os_str(),
+    ])
+    .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("-sJSPI_HOOKS"),
+        "missing hooks should be reported:\n{err:?}"
+    );
+
+    // Stand in for libjspi: the four hook exports emscripten's
+    // `REQUIRED_EXPORTS` puts in the linked module.
+    let mut module = emscripten_module();
+    let before = module.types.add(&[], &[walrus::ValType::I64]);
+    let after = module
+        .types
+        .add(&[walrus::ValType::I64, walrus::ValType::I32], &[]);
+    for (name, ty) in [
+        ("__jspi_enter", before),
+        ("__jspi_exit", after),
+        ("__jspi_suspend", before),
+        ("__jspi_resume", after),
+    ] {
+        let (params, results) = {
+            let ty = module.types.get(ty);
+            (ty.params().to_vec(), ty.results().to_vec())
+        };
+        let mut builder = walrus::FunctionBuilder::new(&mut module.types, &params, &results);
+        let locals: Vec<_> = params.iter().map(|p| module.locals.add(*p)).collect();
+        if !results.is_empty() {
+            builder.func_body().i64_const(0);
+        }
+        let func = builder.finish(locals, &mut module.funcs);
+        module.funcs.get_mut(func).name = Some(name.to_string());
+        module.exports.add(name, func);
+    }
     let emscripten_wasm = project.root.join("emscripten_input.wasm");
     module.emit_wasm_file(&emscripten_wasm).unwrap();
 
@@ -3061,8 +3112,10 @@ fn emscripten_jspi_codegen() {
         lib.contains("$compute: async function compute("),
         "compute should hoist as an async library function:\n{lib}"
     );
+    // The promising target is the raw export: the mangled `_do_work` binding
+    // may be an assertion wrapper under emcc's `-sASSERTIONS`.
     assert!(
-        lib.contains("WebAssembly.promising(_do_work)"),
+        lib.contains("WebAssembly.promising(wasmExports[\"do_work\"])"),
         "do_work should call through WebAssembly.promising:\n{lib}"
     );
     assert!(
@@ -3081,17 +3134,49 @@ fn emscripten_jspi_codegen() {
         "the Suspending postset should target the sleep import:\n{lib}"
     );
 
-    // The in-wasm instrumentation ran: the fiber base global exists and the
-    // jspi exports are wired to their wrappers.
+    // The wasm carries the hook wrappers and none of the shadow-stack
+    // machinery of the non-emscripten transform.
     let out_module = ModuleConfig::new()
         .parse_file(out_dir.join("emscripten_input_bg.wasm"))
         .unwrap();
     assert!(
-        out_module
+        !out_module
             .globals
             .iter()
             .any(|g| g.name.as_deref() == Some("__jspi_stack_base")),
-        "output wasm should contain the __jspi_stack_base global"
+        "emscripten output must not carry wasm-bindgen's fiber stack globals"
+    );
+    let calls_hook = |export: &str, hook: &str| {
+        let walrus::ExportItem::Function(f) = out_module
+            .exports
+            .iter()
+            .find(|e| e.name == export)
+            .unwrap()
+            .item
+        else {
+            panic!("`{export}` is not a function export")
+        };
+        let hook = out_module.funcs.by_name(hook).unwrap();
+        let walrus::FunctionKind::Local(local) = &out_module.funcs.get(f).kind else {
+            panic!("`{export}` should be a local function")
+        };
+        struct Scan(walrus::FunctionId, bool);
+        impl<'a> walrus::ir::Visitor<'a> for Scan {
+            fn visit_call(&mut self, call: &walrus::ir::Call) {
+                self.1 |= call.func == self.0;
+            }
+        }
+        let mut scan = Scan(hook, false);
+        walrus::ir::dfs_in_order(&mut scan, local, local.entry_block());
+        scan.1
+    };
+    assert!(
+        calls_hook("do_work", "__jspi_enter") && calls_hook("do_work", "__jspi_exit"),
+        "do_work export should be wrapped with the enter/exit hooks"
+    );
+    assert!(
+        calls_hook("compute", "__jspi_enter"),
+        "compute export should be wrapped with the enter hook"
     );
 }
 

--- a/crates/js-sys/src/futures/jspi.rs
+++ b/crates/js-sys/src/futures/jspi.rs
@@ -21,6 +21,11 @@
 //! the `__jspi_stack_base` global when JSPI instrumentation is active and is
 //! a constant `0` otherwise, so modules that never use JSPI attributes carry
 //! no JSPI machinery and keep running on engines without exnref/JSPI.
+//!
+//! On the emscripten target the fibers belong to emscripten's JSPI runtime
+//! (`-sJSPI_HOOKS` / `-sREENTRANT_JSPI`): the CLI wraps the boundaries with
+//! its lifecycle hooks instead, and the context probe is a hook registered
+//! through `<emscripten/jspi.h>` that tracks whether a fiber is current.
 
 // The `suspending` attribute on the internal bridge import generates an
 // experimental-status deprecation warning; this module is itself part of the
@@ -46,6 +51,7 @@ extern "C" {
     /// export or a promising-entered poll. Rewritten in-wasm by the CLI to
     /// read the `__jspi_stack_base` global (constant `0` in modules without
     /// JSPI instrumentation); no JS shim is ever emitted.
+    #[cfg(not(target_os = "emscripten"))]
     fn __wbindgen_jspi_in_context() -> u32;
 
     /// Schedules a task poll on the microtask queue, entered through the
@@ -61,8 +67,63 @@ extern "C" {
 
 /// Whether the caller is executing within a JSPI context, i.e. whether a
 /// spawned task's polls should be promising-entered.
+#[cfg(not(target_os = "emscripten"))]
 pub(crate) fn in_context() -> bool {
     __wbindgen_jspi_in_context() != 0
+}
+
+#[cfg(target_os = "emscripten")]
+pub(crate) use emscripten::in_context;
+
+/// The context probe under emscripten: a lifecycle hook registered with
+/// emscripten's JSPI runtime, which reports every fiber's enter, exit,
+/// suspend and resume (for wasm-bindgen's and emscripten's own promising
+/// exports alike). The per-fiber token carries whether the fiber's host was
+/// itself in a fiber, so leaving the fiber restores the host's answer.
+#[cfg(target_os = "emscripten")]
+mod emscripten {
+    use core::ffi::c_void;
+    use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
+
+    const JSPI_ENTER: u32 = 1;
+    const JSPI_EXIT: u32 = 2;
+    const JSPI_SUSPEND: u32 = 4;
+    const JSPI_RESUME: u32 = 8;
+
+    type Hook = unsafe extern "C" fn(u32, *mut c_void, i32) -> *mut c_void;
+
+    extern "C" {
+        fn jspi_register(hook: Hook, mask: u32) -> i32;
+    }
+
+    // Per instance, not per thread: JSPI is rejected under `atomics`.
+    static IN_FIBER: AtomicBool = AtomicBool::new(false);
+
+    pub(crate) fn in_context() -> bool {
+        IN_FIBER.load(Relaxed)
+    }
+
+    unsafe extern "C" fn hook(event: u32, token: *mut c_void, _error: i32) -> *mut c_void {
+        match event {
+            JSPI_ENTER | JSPI_RESUME => IN_FIBER.swap(true, Relaxed) as usize as *mut c_void,
+            JSPI_SUSPEND | JSPI_EXIT => {
+                IN_FIBER.store(!token.is_null(), Relaxed);
+                token
+            }
+            _ => token,
+        }
+    }
+
+    extern "C" fn register() {
+        // -1 without `-sJSPI_HOOKS`: no events, so no fiber is ever current.
+        unsafe {
+            jspi_register(hook, JSPI_ENTER | JSPI_EXIT | JSPI_SUSPEND | JSPI_RESUME);
+        }
+    }
+
+    #[used]
+    #[link_section = ".init_array"]
+    static REGISTER: extern "C" fn() = register;
 }
 
 /// Suspend the current promising execution until `promise` settles.

--- a/guide/src/reference/jspi.md
+++ b/guide/src/reference/jspi.md
@@ -181,6 +181,27 @@ JSPI is not supported together with **threads/atomics** (shared memories):
 JSPI itself is a single-threaded proposal. Building with both enabled is
 rejected by the CLI.
 
+## Emscripten
+
+On the `wasm32-unknown-emscripten` target the fibers belong to emscripten's
+JSPI runtime, so link with `-sJSPI` and its lifecycle hooks:
+`-sJSPI_HOOKS`, or `-sREENTRANT_JSPI`, which additionally runs every
+promising activation on its own shadow stack so any number of fibers may be
+suspended at once (the rustc-driven flow is `-Clink-arg=-sWASM_BINDGEN
+-Clink-arg=-sJSPI -Clink-arg=-sREENTRANT_JSPI`). The `#[wasm_bindgen(jspi)]`
+and `#[wasm_bindgen(suspending)]` attributes, `jspi_block_on_promise` and the
+JSPI context inheritance of `spawn_local` then work as on the other targets.
+
+Instead of the shadow stack management described below, wasm-bindgen wraps
+each `jspi` export and `suspending` import with emscripten's `__jspi_enter`
+/ `__jspi_exit` and `__jspi_suspend` / `__jspi_resume` hook exports (the
+same instrumentation binaryen's `--jspi-hooks` pass applies to emscripten's
+own `JSPI_EXPORTS` and `JSPI_IMPORTS`), and the runtime registers a
+lifecycle hook through `<emscripten/jspi.h>` to track the ambient JSPI
+context. Emscripten's own promising exports and suspending imports (such as
+`main` and `emscripten_sleep`) participate in the same fiber system, so the
+two may be mixed freely.
+
 ## Full example — OPFS file system
 
 The `jspi-opfs` example demonstrates all four patterns: `#[wasm_bindgen(jspi)]`
@@ -240,6 +261,9 @@ one. If you see a `SuspendError`, check that every path reaching the
 suspending import originates in a `jspi` export.
 
 ## Shadow Stack Management
+
+This section describes the non-emscripten targets; see [Emscripten](#emscripten)
+above for how the emscripten runtime takes this over.
 
 On suspension the shadow stack is saved into the heap, and restored back
 onto the stack on resume. Each `#[wasm_bindgen(jspi)]` export records the

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -814,21 +814,26 @@ static GLOBAL_EXNDATA: ThreadLocalWrapper<Cell<[u32; 2]>> = ThreadLocalWrapper(C
 #[no_mangle]
 pub static mut __instance_terminated: u32 = 0;
 
-/// Written in-fiber at every resume by the CLI-generated wrapper around a
+/// Set in-fiber at every resume by the CLI-generated wrapper around a
 /// `#[wasm_bindgen(catch, suspending)]` import (see
-/// `cli-support/src/transforms/jspi.rs`): 0 when the awaited `Promise`
-/// fulfilled, 1 when it rejected — in which case the rejection reason is the
-/// import's return value. The store happens immediately before the suspend
-/// call returns, so reading it right after is race-free even with arbitrary
-/// fiber interleaving.
+/// `cli-support/src/transforms/jspi.rs`), through
+/// `__wbindgen_jspi_set_rejected`: 0 when the awaited `Promise` fulfilled, 1
+/// when it rejected — in which case the rejection reason is the import's
+/// return value. The store happens immediately before the suspend call
+/// returns, so reading it right after is race-free even with arbitrary fiber
+/// interleaving.
+static mut JSPI_REJECTED: u32 = 0;
+
 #[no_mangle]
-pub static mut __wbindgen_jspi_rejected: u32 = 0;
+pub extern "C" fn __wbindgen_jspi_set_rejected(rejected: u32) {
+    unsafe { JSPI_REJECTED = rejected }
+}
 
 /// Whether the just-returned `#[wasm_bindgen(catch, suspending)]` import
 /// call's awaited promise rejected. Used by macro-generated glue.
 #[inline]
 pub fn jspi_rejected() -> bool {
-    unsafe { __wbindgen_jspi_rejected != 0 }
+    unsafe { JSPI_REJECTED != 0 }
 }
 
 fn no_op() {}


### PR DESCRIPTION
This adds JSPI support on `wasm32-unknown-emscripten`: `#[wasm_bindgen(jspi)]`, `#[wasm_bindgen(suspending)]`, `jspi_block_on_promise` and the JSPI context inheritance of `spawn_local` now work when linking with `-sJSPI` and `-sJSPI_HOOKS` (or `-sREENTRANT_JSPI`).

On emscripten the fibers belong to emscripten's JSPI runtime, so wasm-bindgen's shadow-stack save/restore instrumentation cannot run there (the two stack conventions don't compose). Instead the module is instrumented with emscripten's JSPI lifecycle hooks, the same contract binaryen's `--jspi-hooks` pass applies to emscripten's own `JSPI_EXPORTS`/`JSPI_IMPORTS` (emscripten-core/emscripten#27698).

* `transforms/jspi_hooks`: each `jspi` export is wrapped with `__jspi_enter`/`__jspi_exit` and each `suspending` import with `__jspi_suspend`/`__jspi_resume`, passing the opaque token through a local and `error=1` on the rethrow path, in whichever exception-handling dialect the module already uses (legacy `try` or `try_table`). The `catch` rejection-to-data protocol is kept. A module without the hook exports gets an error pointing at the link flag.
* The rejection flag is reported through a runtime function `__wbindgen_jspi_set_rejected` rather than an exported data address: rustc's emscripten linker only exports functions.
* `js-sys`: on emscripten the `spawn_local` context probe is a hook registered through `<emscripten/jspi.h>`, tracking whether a fiber is current via the per-fiber token.
* Emscripten JS glue: the Suspending `__postset` now uses the asmjs-mangled library symbol, and `WebAssembly.promising` targets the raw `wasmExports` entry (the mangled binding is an assertion wrapper under `-sASSERTIONS`).

Tests: transform unit tests for both EH dialects with and without `catch`, the missing-hooks error, and the updated `emscripten_jspi_codegen` integration test. Verified end to end with `-sREENTRANT_JSPI`: interleaved fibers keep their frames, rejections and synchronous throws surface as `Err`, uncaught rejections reject the promising call, and tasks spawned inside a fiber may suspend.

Requires an emscripten with the JSPI lifecycle hooks (`jspi_register`) for programs linking `wasm-bindgen-futures` on the emscripten target.